### PR TITLE
Adding 3rd Party Integrations Folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Welcome to the Line Voice Agents SDK repository. This file contains guidelines f
 - **Tests:** `tests/` contains the unit tests with a guide to writing tests below.
 - **Examples:** `examples/` contains examples of how to use the SDK.
 - **Example Integrations:** `example_integrations/` contains examples of how 3rd party providers manage to integrate with our Line SDK.
-  
+
   > [!note]
   > These examples are developed and maintained by our partners.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Welcome to the Line Voice Agents SDK repository. This file contains guidelines f
 - **Source code:** `line/` contains the implementation
 - **Tests:** `tests/` contains the unit tests with a guide to writing tests below.
 - **Examples:** `examples/` contains examples of how to use the SDK.
+- **Example Integrations:** `example_integrations/` contains examples of how 3rd party providers manage to integrate with our Line SDK. 
+  - *Note: These examples are developed and maintained by our partners.*
 
 
 ## Python Version Support
@@ -70,3 +72,9 @@ Reviewers look for the following:
 - Clear PR description and title
 - Unittests covering the new code
 - Consistent style: Use `pre-commit` to run linters and formatters.
+
+## Contributing to Our Example Integrations
+Our `example_integrations/` folder contains agents developed by our partners that utilizes their services. If you're interested in adding your own example integration, your PR must satisfy the following requirements:
+- Must be deployable on the Line platform
+- Must have a README with clear documentation around the usecase with a link to your API docs
+- Must follow our repositories style guide

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Welcome to the Line Voice Agents SDK repository. This file contains guidelines f
 - **Examples:** `examples/` contains examples of how to use the SDK.
 - **Example Integrations:** `example_integrations/` contains examples of how 3rd party providers manage to integrate with our Line SDK.
 
-  > [!note]
+  > [!NOTE]
   > These examples are developed and maintained by our partners.
 
 
@@ -84,5 +84,5 @@ Our `example_integrations/` folder contains agents developed by our partners tha
   - See our [basic agent README](./examples/basic_chat/README.md) or [form filling README](./examples/form-filling/README.md) for examples
 - Must follow our repositories style guide
 
-  > [!note]
+  > [!NOTE]
   > Partners are responsible for keeping their integration example up to date with Line changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ Our `example_integrations/` folder contains agents developed by our partners tha
 - Must be deployable on the Line platform
   - You can connect an existing Git repository with the agent code via our [Github Integration](https://docs.cartesia.ai/line/integrations/github) to test the agent
 - Must have a README with clear documentation around the usecase with a link to your API docs
+  - README should include Prerequisites, Environment Variables, File Overview, and any other information that might be relevant to modifying or using the example agent
+  - See our [basic agent README](./examples/basic_chat/README.md) or [form filling README](./examples/form-filling/README.md) for examples
 - Must follow our repositories style guide
 
   > [!note]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Welcome to the Line Voice Agents SDK repository. This file contains guidelines f
 - **Source code:** `line/` contains the implementation
 - **Tests:** `tests/` contains the unit tests with a guide to writing tests below.
 - **Examples:** `examples/` contains examples of how to use the SDK.
-- **Example Integrations:** `example_integrations/` contains examples of how 3rd party providers manage to integrate with our Line SDK. 
+- **Example Integrations:** `example_integrations/` contains examples of how 3rd party providers manage to integrate with our Line SDK.
   - *Note: These examples are developed and maintained by our partners.*
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Our `example_integrations/` folder contains agents developed by our partners tha
   - You can connect an existing Git repository with the agent code via our [Github Integration](https://docs.cartesia.ai/line/integrations/github) to test the agent
 - Must have a README with clear documentation around the usecase with a link to your API docs
   - README should include Prerequisites, Environment Variables, File Overview, and any other information that might be relevant to modifying or using the example agent
-  - See our [basic agent README](./examples/basic_chat/README.md) or [form filling README](./examples/form-filling/README.md) for examples
+  - See our [basic agent README](./examples/basic_chat/README.md) or [form filling README](./examples/form-filling/README.md) for reference on how to write the README
 - Must follow our repositories style guide
 
   > [!NOTE]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,9 @@ Welcome to the Line Voice Agents SDK repository. This file contains guidelines f
 - **Tests:** `tests/` contains the unit tests with a guide to writing tests below.
 - **Examples:** `examples/` contains examples of how to use the SDK.
 - **Example Integrations:** `example_integrations/` contains examples of how 3rd party providers manage to integrate with our Line SDK.
-  - *Note: These examples are developed and maintained by our partners.*
+  
+  > [!note]
+  > These examples are developed and maintained by our partners.
 
 
 ## Python Version Support

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,5 +78,9 @@ Reviewers look for the following:
 ## Contributing to Our Example Integrations
 Our `example_integrations/` folder contains agents developed by our partners that utilizes their services. If you're interested in adding your own example integration, your PR must satisfy the following requirements:
 - Must be deployable on the Line platform
+  - You can connect an existing Git repository with the agent code via our [Github Integration](https://docs.cartesia.ai/line/integrations/github) to test the agent
 - Must have a README with clear documentation around the usecase with a link to your API docs
 - Must follow our repositories style guide
+
+  > [!note]
+  > Partners are responsible for keeping their integration example up to date with Line changes

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install cartesia-line
 
 - **More examples**: [examples/](examples/) - See all available examples and patterns
 - **3rd party integrations**: [example_integrations/](example_integrations/) - See example integrations for external services
-  
+
   > [!note]
   > While Cartesia approves each example, they are implemented and maintained by our partners.
 - **Full API reference**: [docs.cartesia.ai/line](https://docs.cartesia.ai/line/)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install cartesia-line
 - **More examples**: [examples/](examples/) - See all available examples and patterns
 - **3rd party integrations**: [example_integrations/](example_integrations/) - See example integrations for external services
 
-  > [!note]
+  > [!NOTE]
   > While Cartesia approves each example, they are implemented and maintained by our partners.
 - **Full API reference**: [docs.cartesia.ai/line](https://docs.cartesia.ai/line/)
 - **Get help**: [Discord community](https://discord.gg/cartesia)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ pip install cartesia-line
 
 - **More examples**: [examples/](examples/) - See all available examples and patterns
 - **3rd party integrations**: [example_integrations/](example_integrations/) - See example integrations for external services
-  - *Note: While Cartesia approves each example, they are implemented and maintained by our partners.*
+  
+  > [!note]
+  > While Cartesia approves each example, they are implemented and maintained by our partners.
 - **Full API reference**: [docs.cartesia.ai/line](https://docs.cartesia.ai/line/)
 - **Get help**: [Discord community](https://discord.gg/cartesia)

--- a/README.md
+++ b/README.md
@@ -45,5 +45,7 @@ pip install cartesia-line
 ## Going Deeper
 
 - **More examples**: [examples/](examples/) - See all available examples and patterns
+- **3rd party integrations**: [example_integrations/](example_integrations/) - See example integrations for external services
+  - *Note: While Cartesia approves each example, they are implemented and maintained by our partners.*
 - **Full API reference**: [docs.cartesia.ai/line](https://docs.cartesia.ai/line/)
 - **Get help**: [Discord community](https://discord.gg/cartesia)

--- a/example_integrations/README.md
+++ b/example_integrations/README.md
@@ -1,0 +1,42 @@
+# Example Integrations
+
+This directory contains example integrations showing how third-party providers can integrate their services with the Cartesia Line SDK to build powerful voice agents.
+
+## About Example Integrations
+
+Example integrations demonstrate how to:
+- Connect external APIs and services to Line voice agents
+- Build specialized voice agents for specific use cases
+- Implement industry-specific workflows and integrations
+- Showcase partner services and capabilities
+
+*Note: While Cartesia approves of these each examples, they are implemented and maintained by our partners.*
+
+## Contributing an Integration
+
+Interested in adding your own example integration? See our [Contributing Guide](../CONTRIBUTING.md#contributing-to-our-example-integrations) for requirements.
+
+Your integration PR must:
+- Be deployable on the Line platform
+- Include a README with clear documentation and a link to your API docs
+- Follow the repository's style guide
+- Demonstrate a clear use case for your service
+
+## Getting Help
+
+- **Documentation**: [Line Docs](https://docs.cartesia.ai/line/introduction)
+- **Community**: [Discord community](https://discord.gg/cartesia)
+- **More Examples**: Check out [../examples/](../examples/) for core SDK examples
+
+## Structure
+
+Each integration should follow this structure:
+```
+your_integration_name/
+├── README.md          # Integration-specific documentation
+├── main.py           # Main agent implementation
+├── cartesia.toml     # Line platform configuration
+└── requirements.txt  # Dependencies (or pyproject.toml)
+```
+
+Additional files may be included as needed for your specific integration (additional modules, configuration files, etc.).

--- a/example_integrations/README.md
+++ b/example_integrations/README.md
@@ -10,17 +10,12 @@ Example integrations demonstrate how to:
 - Implement industry-specific workflows and integrations
 - Showcase partner services and capabilities
 
-*Note: While Cartesia approves of these each examples, they are implemented and maintained by our partners.*
+> [!note]
+> While Cartesia approves of these each examples, they are implemented and maintained by our partners.
 
 ## Contributing an Integration
 
 Interested in adding your own example integration? See our [Contributing Guide](../CONTRIBUTING.md#contributing-to-our-example-integrations) for requirements.
-
-Your integration PR must:
-- Be deployable on the Line platform
-- Include a README with clear documentation and a link to your API docs
-- Follow the repository's style guide
-- Demonstrate a clear use case for your service
 
 ## Getting Help
 
@@ -33,10 +28,14 @@ Your integration PR must:
 Each integration should follow this structure:
 ```
 your_integration_name/
-├── README.md          # Integration-specific documentation
+├── README.md         # Integration-specific documentation
 ├── main.py           # Main agent implementation
 ├── cartesia.toml     # Line platform configuration
 └── requirements.txt  # Dependencies (or pyproject.toml)
 ```
 
 Additional files may be included as needed for your specific integration (additional modules, configuration files, etc.).
+
+## Disclaimer
+
+All example integrations are provided "as is" without warranty of any kind. Cartesia assumes no liability for the use of these examples. All examples are subject to the license of this repository.

--- a/example_integrations/README.md
+++ b/example_integrations/README.md
@@ -10,7 +10,7 @@ Example integrations demonstrate how to:
 - Implement industry-specific workflows and integrations
 - Showcase partner services and capabilities
 
-> [!note]
+> [!NOTE]
 > While Cartesia approves of these each examples, they are implemented and maintained by our partners.
 
 ## Contributing an Integration


### PR DESCRIPTION
## What does this PR do?

Adds the `example_integrations/` folder to house third party integration examples and updates the `README` and `CONTRIBUTING` to indicate what it is and how to add to it.

## Type of change
- [x] Documentation

## Testing
I looked at the rendered markdown.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`
