### PR TITLE
[Bugfix] Fixes gemini DTMF system tool

### DIFF
--- a/line/tools/system_tools.py
+++ b/line/tools/system_tools.py
@@ -182,6 +182,8 @@ class DTMFToolCall(ToolDefinition):
                     },
                 },
                 "required": ["button"],
+                "additionalProperties": False,
+                "strict": True,
             },
         }
 


### PR DESCRIPTION
## What does this PR do?
Gemini doesn't actually take `additionalProperties` as a parameter, so this will error if you try to import the tool

## Testing
1. I run the DnD story teller
2. I see HTTP errors for additionaProperties being rejected
3. I remove it here
4. I rerun the story teller
5. It succeeds