### PR TITLE
[Bugfix] Do not export `evals` on wildcard imports of line to prevent forced dependency on `google-genai`

### DIFF
--- a/line/__init__.py
+++ b/line/__init__.py
@@ -3,7 +3,6 @@
 from line.bridge import Bridge
 from line.bus import Bus, Message
 from line.call_request import CallRequest, PreCallResult
-from line.evals import AgentTurn, ConversationRunner, Turn, UserTurn
 from line.nodes.conversation_context import ConversationContext
 
 # Reasoning components
@@ -27,9 +26,4 @@ __all__ = [
     "VoiceAgentApp",
     "VoiceAgentSystem",
     "register_observability_event",
-    "AgentTurn",
-    "ConversationRunner",
-    "Turn",
-    "UserTurn",
-    "SimilarityUtils",
 ]


### PR DESCRIPTION
## What does this PR do?

Do not export `evals` on wildcard import to prevent required dependency on `google-genai`, even for non-Gemini uses. This currently breaks OpenAI text-to-agent deployments, which do not install the optional `gemini` dependency group. See `examples/text_to_agent/basic_chat/openai` for more context. Generally, it's also likely more principled not to expose the `evals` package on wildcard export anyway, since it is a dev dependency.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How did you test this?

Go to `examples/text_to_agent/basic_chat/openai`.

Before change:
```
❯ OPENAI_API_KEY='******' uv run main.py
Using CPython 3.13.7
Creating virtual environment at: .venv
      Built basic-chat-openai @ file:///Users/daksh/workspace/line/examples/text_to_agent/basic_chat/openai
Installed 37 packages in 87ms
Traceback (most recent call last):
  File "/Users/daksh/workspace/line/examples/text_to_agent/basic_chat/openai/main.py", line 1, in <module>
    from chat import ChatNode
  File "/Users/daksh/workspace/line/examples/text_to_agent/basic_chat/openai/chat.py", line 19, in <module>
    from line import ConversationContext, ReasoningNode
  File "/Users/daksh/workspace/line/examples/text_to_agent/basic_chat/openai/.venv/lib/python3.13/site-packages/line/__init__.py", line 6, in <module>
    from line.evals import AgentTurn, ConversationRunner, Turn, UserTurn
  File "/Users/daksh/workspace/line/examples/text_to_agent/basic_chat/openai/.venv/lib/python3.13/site-packages/line/evals/__init__.py", line 2, in <module>
    from line.evals.conversation_runner import ConversationRunner
  File "/Users/daksh/workspace/line/examples/text_to_agent/basic_chat/openai/.venv/lib/python3.13/site-packages/line/evals/conversation_runner.py", line 10, in <module>
    from line.evals.similarity_utils import is_similar_str
  File "/Users/daksh/workspace/line/examples/text_to_agent/basic_chat/openai/.venv/lib/python3.13/site-packages/line/evals/similarity_utils.py", line 11, in <module>
    from google.genai import Client
ModuleNotFoundError: No module named 'google'
```

After fix (using local changes):
```
INFO:     Started server process [73036]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
```

## Checklist
- [X] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have formatted my code with `make format`
