### PR TITLE
[DTMF] Adds serialization to library by default

### DIFF
--- a/examples/dtmf_storyteller/chat_node.py
+++ b/examples/dtmf_storyteller/chat_node.py
@@ -83,13 +83,7 @@ class ChatNode(ReasoningNode):
             logger.info("No messages to process")
             return
 
-        messages = convert_messages_to_gemini(
-            context.events,
-            {
-                DTMFInputEvent: serialize_dtmf_input_event,
-                DTMFOutputEvent: serialize_dtmf_output_event,
-            },
-        )
+        messages = convert_messages_to_gemini(context.events)
 
         user_message = context.get_latest_user_transcript_message()
         if user_message:

--- a/line/utils/gemini_utils.py
+++ b/line/utils/gemini_utils.py
@@ -11,6 +11,8 @@ from loguru import logger
 
 from line.events import (
     AgentResponse,
+    DTMFInputEvent,
+    DTMFOutputEvent,
     EventInstance,
     EventType,
     ToolResult,
@@ -65,6 +67,10 @@ def convert_messages_to_gemini(
             gemini_messages.append(types.ModelContent(parts=[types.Part.from_text(text=event.content)]))
         elif isinstance(event, UserTranscriptionReceived):
             gemini_messages.append(types.UserContent(parts=[types.Part.from_text(text=event.content)]))
+        elif isinstance(event, DTMFInputEvent):
+            gemini_messages.append(types.UserContent(parts=[types.Part.from_text(text=event.button)]))
+        elif isinstance(event, DTMFOutputEvent):
+            gemini_messages.append(types.ModelContent(parts=[types.Part.from_text(text=event.button)]))
         elif isinstance(event, ToolResult):
             # Gemini 400s if a ToolResult is the first message in the context, so don't add it:
             if not gemini_messages:


### PR DESCRIPTION
## What does this PR do?
Push the serialization of DTMF events down in to the utils so that other examples can use them

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
I used the CLI to test the dtmf story teller and then added a custom logline to verify that gemini events are being serialized properly
