### PR TITLE
[VA-450] Track event_ids given by the harness for response matching

### DIFF
--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -119,12 +119,14 @@ class LogEventOutput(BaseModel):
     type: Literal["log_event"] = "log_event"
     event: str
     metadata: Optional[Dict[str, object]] = None
+    responding_to: Optional[str] = None
 
 
 class LogMetricOutput(BaseModel):
     type: Literal["log_metric"] = "log_metric"
     name: str
     value: object
+    responding_to: Optional[str] = None
 
 
 class TTSConfig(BaseModel):

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -43,6 +43,7 @@ class ValidationErrorInput(BaseModel):
     error_message: str
     error_type: str
     type: Literal["validation_error"] = "validation_error"
+    event_id: Optional[str] = None
 
 
 class AgentSpeechInput(BaseModel):

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -18,21 +18,29 @@ from pydantic import BaseModel
 class TranscriptionInput(BaseModel):
     content: str
     type: Literal["message"] = "message"
+    event_id: Union[int, str, None] = None
+    turn_id: Union[int, str, None] = None
 
 
 class DTMFInput(BaseModel):
     button: str
     type: Literal["dtmf"] = "dtmf"
+    event_id: Union[int, str, None] = None
+    turn_id: Union[int, str, None] = None
 
 
 class UserStateInput(BaseModel):
     value: str
     type: Literal["user_state"] = "user_state"
+    event_id: Union[int, str, None] = None
+    turn_id: Union[int, str, None] = None
 
 
 class AgentStateInput(BaseModel):
     value: str
     type: Literal["agent_state"] = "agent_state"
+    event_id: Union[int, str, None] = None
+    turn_id: Union[int, str, None] = None
 
 
 class ValidationErrorInput(BaseModel):
@@ -44,11 +52,15 @@ class ValidationErrorInput(BaseModel):
 class AgentSpeechInput(BaseModel):
     content: str
     type: Literal["agent_speech"] = "agent_speech"
+    event_id: Union[int, str, None] = None
+    turn_id: Union[int, str, None] = None
 
 
 class CustomInput(BaseModel):
     metadata: Dict[str, object]
     type: Literal["custom"] = "custom"
+    event_id: Union[int, str, None] = None
+    turn_id: Union[int, str, None] = None
 
 
 InputMessage = Union[
@@ -73,12 +85,14 @@ class ErrorOutput(BaseModel):
 class DTMFOutput(BaseModel):
     type: Literal["dtmf"] = "dtmf"
     button: str
+    responding_to: Optional[str] = None
 
 
 class MessageOutput(BaseModel):
     type: Literal["message"] = "message"
     content: str
     interruptible: bool = True
+    responding_to: Optional[str] = None
 
 
 class ToolCallOutput(BaseModel):
@@ -87,15 +101,18 @@ class ToolCallOutput(BaseModel):
     arguments: Dict[str, object]
     result: Optional[str] = None
     id: Optional[str] = None
+    responding_to: Optional[str] = None
 
 
 class TransferOutput(BaseModel):
     type: Literal["transfer"] = "transfer"
     target_phone_number: str
+    responding_to: Optional[str] = None
 
 
 class EndCallOutput(BaseModel):
     type: Literal["end_call"] = "end_call"
+    responding_to: Optional[str] = None
 
 
 class LogEventOutput(BaseModel):
@@ -125,11 +142,13 @@ class ConfigOutput(BaseModel):
     tts: Optional[TTSConfig] = None
     stt: Optional[STTConfig] = None
     language: Optional[str] = None
+    responding_to: Optional[str] = None
 
 
 class CustomOutput(BaseModel):
     type: Literal["custom"] = "custom"
     metadata: Dict[str, object]
+    responding_to: Optional[str] = None
 
 
 OutputMessage = Union[

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -18,29 +18,25 @@ from pydantic import BaseModel
 class TranscriptionInput(BaseModel):
     content: str
     type: Literal["message"] = "message"
-    event_id: Union[int, str, None] = None
-    turn_id: Union[int, str, None] = None
+    event_id: Optional[str] = None
 
 
 class DTMFInput(BaseModel):
     button: str
     type: Literal["dtmf"] = "dtmf"
-    event_id: Union[int, str, None] = None
-    turn_id: Union[int, str, None] = None
+    event_id: Optional[str] = None
 
 
 class UserStateInput(BaseModel):
     value: str
     type: Literal["user_state"] = "user_state"
-    event_id: Union[int, str, None] = None
-    turn_id: Union[int, str, None] = None
+    event_id: Optional[str] = None
 
 
 class AgentStateInput(BaseModel):
     value: str
     type: Literal["agent_state"] = "agent_state"
-    event_id: Union[int, str, None] = None
-    turn_id: Union[int, str, None] = None
+    event_id: Optional[str] = None
 
 
 class ValidationErrorInput(BaseModel):
@@ -52,15 +48,13 @@ class ValidationErrorInput(BaseModel):
 class AgentSpeechInput(BaseModel):
     content: str
     type: Literal["agent_speech"] = "agent_speech"
-    event_id: Union[int, str, None] = None
-    turn_id: Union[int, str, None] = None
+    event_id: Optional[str] = None
 
 
 class CustomInput(BaseModel):
     metadata: Dict[str, object]
     type: Literal["custom"] = "custom"
-    event_id: Union[int, str, None] = None
-    turn_id: Union[int, str, None] = None
+    event_id: Optional[str] = None
 
 
 InputMessage = Union[

--- a/line/events.py
+++ b/line/events.py
@@ -39,6 +39,7 @@ class AgentToolReturned(BaseModel):
     tool_name: str
     tool_args: Dict[str, Any] = Field(default_factory=dict)
     result: Any = None
+    responding_to: Optional[str] = None
 
 
 class AgentEndCall(BaseModel):
@@ -62,6 +63,7 @@ class LogMetric(BaseModel):
     type: Literal["log_metric"] = "log_metric"
     name: str
     value: Any
+    responding_to: Optional[str] = None
 
 
 class LogMessage(BaseModel):
@@ -70,6 +72,7 @@ class LogMessage(BaseModel):
     level: Literal["info", "error"]
     message: str
     metadata: Optional[Dict[str, Any]] = None
+    responding_to: Optional[str] = None
 
 
 class AgentUpdateCall(BaseModel):
@@ -85,17 +88,6 @@ class AgentSendCustom(BaseModel):
     metadata: Dict[str, Any]
     responding_to: Optional[str] = None
 
-
-# OutputEvent types that carry a responding_to field (harness-facing action events).
-RespondingToEvent = Union[
-    AgentSendText,
-    AgentSendDtmf,
-    AgentEndCall,
-    AgentTransferCall,
-    AgentToolCalled,
-    AgentUpdateCall,
-    AgentSendCustom,
-]
 
 OutputEvent = Union[
     AgentSendText,
@@ -263,7 +255,6 @@ __all__ = [
     "AgentUpdateCall",
     "AgentSendCustom",
     "OutputEvent",
-    "RespondingToEvent",
     # Custom
     "CustomHistoryEntry",
     # Input

--- a/line/events.py
+++ b/line/events.py
@@ -22,6 +22,7 @@ class AgentSendText(BaseModel):
     type: Literal["agent_send_text"] = "agent_send_text"
     text: str
     interruptible: bool = True
+    responding_to: Optional[str] = None
 
 
 class AgentToolCalled(BaseModel):
@@ -29,6 +30,7 @@ class AgentToolCalled(BaseModel):
     tool_call_id: str
     tool_name: str
     tool_args: Dict[str, Any] = Field(default_factory=dict)
+    responding_to: Optional[str] = None
 
 
 class AgentToolReturned(BaseModel):
@@ -41,16 +43,19 @@ class AgentToolReturned(BaseModel):
 
 class AgentEndCall(BaseModel):
     type: Literal["end_call"] = "end_call"
+    responding_to: Optional[str] = None
 
 
 class AgentTransferCall(BaseModel):
     type: Literal["agent_transfer_call"] = "agent_transfer_call"
     target_phone_number: str
+    responding_to: Optional[str] = None
 
 
 class AgentSendDtmf(BaseModel):
     type: Literal["agent_send_dtmf"] = "agent_send_dtmf"
     button: str
+    responding_to: Optional[str] = None
 
 
 class LogMetric(BaseModel):
@@ -72,12 +77,25 @@ class AgentUpdateCall(BaseModel):
     voice_id: Optional[str] = None
     pronunciation_dict_id: Optional[str] = None
     language: Optional[str] = None
+    responding_to: Optional[str] = None
 
 
 class AgentSendCustom(BaseModel):
     type: Literal["agent_send_custom"] = "agent_send_custom"
     metadata: Dict[str, Any]
+    responding_to: Optional[str] = None
 
+
+# OutputEvent types that carry a responding_to field (harness-facing action events).
+RespondingToEvent = Union[
+    AgentSendText,
+    AgentSendDtmf,
+    AgentEndCall,
+    AgentTransferCall,
+    AgentToolCalled,
+    AgentUpdateCall,
+    AgentSendCustom,
+]
 
 OutputEvent = Union[
     AgentSendText,
@@ -245,6 +263,7 @@ __all__ = [
     "AgentUpdateCall",
     "AgentSendCustom",
     "OutputEvent",
+    "RespondingToEvent",
     # Custom
     "CustomHistoryEntry",
     # Input

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -177,7 +177,6 @@ class LlmAgent:
         # The triggering event is the last element in event.history
         current_event_id = event.history[-1].event_id if event.history else ""
         self.history._set_input(event.history or [], current_event_id)
-        responding_to_id = current_event_id or None
 
         # Compute effective config and tools for this #process invocation
         effective_config = _merge_configs(self._config, config) if config else self._config
@@ -187,7 +186,7 @@ class LlmAgent:
         if self._handoff_target is not None:
             async for output in self._handoff_target(env, event):
                 self.history._append_local(output)
-                yield _set_responding_to(output, responding_to_id)
+                yield _set_responding_to(output, event.event_id)
             # Keep turn timing consistent across all process paths, including handoffs.
             yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
             return
@@ -202,7 +201,7 @@ class LlmAgent:
                 self.history._append_local(output)
                 self._introduction_sent = True
 
-                yield _set_responding_to(output, responding_to_id)
+                yield _set_responding_to(output, event.event_id)
             yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
             try:
                 await warmup_task
@@ -221,7 +220,7 @@ class LlmAgent:
         async for output in self._generate_response(
             env, event, effective_tools, effective_config, context=context, history=history
         ):
-            yield _set_responding_to(output, responding_to_id)
+            yield _set_responding_to(output, event.event_id)
 
         yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
 
@@ -777,6 +776,6 @@ def _set_responding_to(event: OutputEvent, event_id: Optional[str]) -> OutputEve
     responding_to is left unset. Skips events that already have responding_to set
     (e.g., from a custom agent or handed-off agent that set it explicitly).
     """
-    if event_id is not None and event.responding_to is None:
+    if event_id and event.responding_to is None:
         event.responding_to = event_id
     return event

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -21,7 +21,6 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    get_args,
 )
 
 from loguru import logger
@@ -40,7 +39,6 @@ from line.events import (
     InputEvent,
     LogMetric,
     OutputEvent,
-    RespondingToEvent,
     UserTextSent,
 )
 from line.llm_agent.background_queue import BackgroundQueue
@@ -204,8 +202,7 @@ class LlmAgent:
                 self.history._append_local(output)
                 self._introduction_sent = True
 
-                # Introduction is not responding to any event, so we don't set responding_to
-                yield output
+                yield _set_responding_to(output, responding_to_id)
             yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
             try:
                 await warmup_task
@@ -772,17 +769,13 @@ def _construct_tool_events(
     return called, returned
 
 
-def _set_responding_to(event: OutputEvent, event_id: Optional[str]) -> OutputEvent:
+def _set_responding_to(event: OutputEvent, event_id: str) -> OutputEvent:
     """Set responding_to on harness-facing events if not already set.
 
     Called at the process() yield boundary so the harness knows which input event
     triggered each output event. Skips events that already have responding_to set
     (e.g., from a custom agent or handed-off agent that set it explicitly).
     """
-    if (
-        event_id is not None
-        and isinstance(event, get_args(RespondingToEvent))
-        and event.responding_to is None
-    ):
+    if event.responding_to is None:
         event.responding_to = event_id
     return event

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -769,13 +769,14 @@ def _construct_tool_events(
     return called, returned
 
 
-def _set_responding_to(event: OutputEvent, event_id: str) -> OutputEvent:
+def _set_responding_to(event: OutputEvent, event_id: Optional[str]) -> OutputEvent:
     """Set responding_to on harness-facing events if not already set.
 
     Called at the process() yield boundary so the harness knows which input event
-    triggered each output event. Skips events that already have responding_to set
+    triggered each output event. When event_id is None (e.g., no history available),
+    responding_to is left unset. Skips events that already have responding_to set
     (e.g., from a custom agent or handed-off agent that set it explicitly).
     """
-    if event.responding_to is None:
+    if event_id is not None and event.responding_to is None:
         event.responding_to = event_id
     return event

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -350,6 +350,10 @@ class LlmAgent:
                     self._tool_signatures[tc.id] = tc.thought_signature
 
             ctx = ToolEnv(turn_env=env)
+
+            # Track before tool calls are processed so backgrounded tools can reference the triggering event
+            triggering_event_id = event.event_id
+
             for tc in tool_calls_dict.values():
                 if not tc.is_complete:
                     continue
@@ -369,7 +373,7 @@ class LlmAgent:
                     # Backgroundable tool: run in a shielded task that survives cancellation
                     # Each yielded value triggers a loopback with AgentToolCalled/AgentToolReturned pair
                     self._execute_backgroundable_tool(
-                        normalized_func, ctx, tool_args, tc.id, tc.name, event.event_id
+                        normalized_func, ctx, tool_args, tc.id, tc.name, triggering_event_id
                     )
                     continue
 

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -166,6 +166,23 @@ class LlmAgent:
         Raises:
             TypeError: If config, tools, context, or history have invalid types.
         """
+        async for output in self._process_impl(
+            env, event, config=config, tools=tools, context=context, history=history
+        ):
+            yield _set_responding_to(output, event.event_id)
+
+    async def _process_impl(
+        self,
+        env: TurnEnv,
+        event: InputEvent,
+        *,
+        config: Optional[LlmConfig] = None,
+        tools: Optional[List[ToolSpec]] = None,
+        context: Union[str, List[HistoryEvent], None] = None,
+        history: Optional[List[HistoryEvent]] = None,
+    ) -> AsyncIterable[OutputEvent]:
+        """Internal implementation of process(). All yielded events are stamped
+        with responding_to by the process() wrapper."""
         turn_start_time = time.perf_counter()
 
         self._validate_config(config)
@@ -186,7 +203,7 @@ class LlmAgent:
         if self._handoff_target is not None:
             async for output in self._handoff_target(env, event):
                 self.history._append_local(output)
-                yield _set_responding_to(output, event.event_id)
+                yield output
             # Keep turn timing consistent across all process paths, including handoffs.
             yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
             return
@@ -200,8 +217,7 @@ class LlmAgent:
                 output = AgentSendText(text=effective_config.introduction)
                 self.history._append_local(output)
                 self._introduction_sent = True
-
-                yield _set_responding_to(output, event.event_id)
+                yield output
             yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
             try:
                 await warmup_task
@@ -220,7 +236,7 @@ class LlmAgent:
         async for output in self._generate_response(
             env, event, effective_tools, effective_config, context=context, history=history
         ):
-            yield _set_responding_to(output, event.event_id)
+            yield output
 
         yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
 
@@ -352,7 +368,9 @@ class LlmAgent:
                 if tool.tool_type == ToolType.LOOPBACK and tool.is_background:
                     # Backgroundable tool: run in a shielded task that survives cancellation
                     # Each yielded value triggers a loopback with AgentToolCalled/AgentToolReturned pair
-                    self._execute_backgroundable_tool(normalized_func, ctx, tool_args, tc.id, tc.name)
+                    self._execute_backgroundable_tool(
+                        normalized_func, ctx, tool_args, tc.id, tc.name, event.event_id
+                    )
                     continue
 
                 if tool.tool_type == ToolType.LOOPBACK:
@@ -611,6 +629,7 @@ class LlmAgent:
         tool_args: Dict[str, Any],
         tc_id: str,
         tc_name: str,
+        triggering_event_id: str,
     ) -> None:
         """Execute a backgroundable tool via the background queue.
 
@@ -622,6 +641,10 @@ class LlmAgent:
         from cancellation. Events are tagged with the CURRENT event_id at
         yield time so background tool results appear at the end of history
         when yielded after a new process() call has started.
+
+        responding_to is set to the triggering_event_id (captured at subscription
+        time) so background results reference the event that originally triggered
+        the tool, not whatever event happens to be processing when results are drained.
         """
 
         async def generate_events() -> AsyncIterable[Tuple[AgentToolCalled, AgentToolReturned]]:
@@ -630,6 +653,8 @@ class LlmAgent:
                 async for value in normalized_func(ctx, **tool_args):
                     call_id = f"{tc_id}-{n}"
                     called, returned = _construct_tool_events(call_id, tc_name, tool_args, value)
+                    called.responding_to = triggering_event_id
+                    returned.responding_to = triggering_event_id
                     self.history._append_local(called)
                     self.history._append_local(returned)
                     yield (called, returned)
@@ -637,6 +662,8 @@ class LlmAgent:
             except Exception as e:
                 logger.error(f"Error in Tool Call {tc_name}: {e}\n{traceback.format_exc(limit=-10)}")
                 called, returned = _construct_tool_events(f"{tc_id}-{n}", tc_name, tool_args, f"error: {e}")
+                called.responding_to = triggering_event_id
+                returned.responding_to = triggering_event_id
                 self.history._append_local(called)
                 self.history._append_local(returned)
                 yield (called, returned)

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -21,6 +21,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    get_args,
 )
 
 from loguru import logger
@@ -39,6 +40,7 @@ from line.events import (
     InputEvent,
     LogMetric,
     OutputEvent,
+    RespondingToEvent,
     UserTextSent,
 )
 from line.llm_agent.background_queue import BackgroundQueue
@@ -177,6 +179,7 @@ class LlmAgent:
         # The triggering event is the last element in event.history
         current_event_id = event.history[-1].event_id if event.history else ""
         self.history._set_input(event.history or [], current_event_id)
+        responding_to_id = current_event_id or None
 
         # Compute effective config and tools for this #process invocation
         effective_config = _merge_configs(self._config, config) if config else self._config
@@ -186,7 +189,7 @@ class LlmAgent:
         if self._handoff_target is not None:
             async for output in self._handoff_target(env, event):
                 self.history._append_local(output)
-                yield output
+                yield _set_responding_to(output, responding_to_id)
             # Keep turn timing consistent across all process paths, including handoffs.
             yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
             return
@@ -200,6 +203,8 @@ class LlmAgent:
                 output = AgentSendText(text=effective_config.introduction)
                 self.history._append_local(output)
                 self._introduction_sent = True
+
+                # Introduction is not responding to any event, so we don't set responding_to
                 yield output
             yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
             try:
@@ -219,7 +224,7 @@ class LlmAgent:
         async for output in self._generate_response(
             env, event, effective_tools, effective_config, context=context, history=history
         ):
-            yield output
+            yield _set_responding_to(output, responding_to_id)
 
         yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
 
@@ -765,3 +770,19 @@ def _construct_tool_events(
         result=result,
     )
     return called, returned
+
+
+def _set_responding_to(event: OutputEvent, event_id: Optional[str]) -> OutputEvent:
+    """Set responding_to on harness-facing events if not already set.
+
+    Called at the process() yield boundary so the harness knows which input event
+    triggered each output event. Skips events that already have responding_to set
+    (e.g., from a custom agent or handed-off agent that set it explicitly).
+    """
+    if (
+        event_id is not None
+        and isinstance(event, get_args(RespondingToEvent))
+        and event.responding_to is None
+    ):
+        event.responding_to = event_id
+    return event

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -768,11 +768,11 @@ def _construct_tool_events(
     return called, returned
 
 
-def _set_responding_to(event: OutputEvent, event_id: Optional[str]) -> OutputEvent:
+def _set_responding_to(event: OutputEvent, event_id: str) -> OutputEvent:
     """Set responding_to on harness-facing events if not already set.
 
     Called at the process() yield boundary so the harness knows which input event
-    triggered each output event. When event_id is None (e.g., no history available),
+    triggered each output event. When event_id is empty string (e.g., no history available),
     responding_to is left unset. Skips events that already have responding_to set
     (e.g., from a custom agent or handed-off agent that set it explicitly).
     """

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -476,7 +476,7 @@ class ConversationRunner:
         so the agent can reference it in responding_to.
         """
         # Use harness-provided event_id if available, otherwise fall back to auto-generated UUID
-        harness_id = getattr(message, "event_id", None)
+        harness_id = message.model_dump().get("event_id", None)
         event_id_kwargs = {"event_id": harness_id} if harness_id is not None else {}
 
         if isinstance(message, UserStateInput):

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -475,9 +475,7 @@ class ConversationRunner:
         When the harness provides an event_id, it is used as the framework event_id
         so the agent can reference it in responding_to.
         """
-        # Use harness-provided event_id if available, otherwise fall back to auto-generated UUID
-        harness_id = message.model_dump().get("event_id", None)
-        event_id_kwargs = {"event_id": harness_id} if harness_id is not None else {}
+        event_id_kwargs = {"event_id": message.event_id} if message.event_id is not None else {}
 
         if isinstance(message, UserStateInput):
             if message.value == UserState.SPEAKING:

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -16,7 +16,7 @@ import json
 import os
 import re
 import traceback
-from typing import Any, AsyncIterable, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, AsyncIterable, Awaitable, Callable, Dict, List, Optional, Tuple, get_args
 from urllib.parse import urlencode
 
 from dotenv import load_dotenv
@@ -68,6 +68,7 @@ from line.events import (
     LogMessage,
     LogMetric,
     OutputEvent,
+    RespondingToEvent,
     UserCustomSent,
     UserDtmfSent,
     UserTextSent,
@@ -422,9 +423,15 @@ class ConversationRunner:
         """Start the agent async iterable for the given event."""
         await self._cancel_agent_task()
 
+        # Use the triggering event's event_id for responding_to stamping
+        responding_to_id = event.event_id
+
         async def runner():
             try:
                 async for output in self.agent_callable(turn_env, event):
+                    # Set responding_to at the harness boundary (outermost layer)
+                    if isinstance(output, get_args(RespondingToEvent)) and output.responding_to is None:
+                        output.responding_to = responding_to_id
                     if isinstance(output, AgentSendText):
                         self.emitted_agent_text.append((output.text, output.interruptible))
                     mapped = self._map_output_event(output)
@@ -433,7 +440,10 @@ class ConversationRunner:
                         break
                     if mapped is None:
                         continue
-                    await self.websocket.send_json(mapped.model_dump())
+                    dump = mapped.model_dump()
+                    if dump.get("responding_to") is None:
+                        dump.pop("responding_to", None)
+                    await self.websocket.send_json(dump)
             except asyncio.CancelledError:
                 pass
             except Exception:
@@ -464,40 +474,48 @@ class ConversationRunner:
 
     ######### Event Parsing Methods #########
     def _convert_input_message(self, message: InputMessage) -> Optional[InputEvent]:
-        """Convert an InputMessage to an InputEvent (with history=None)."""
+        """Convert an InputMessage to an InputEvent (with history=None).
+
+        When the harness provides an event_id, it is used as the framework event_id
+        so the agent can reference it in responding_to.
+        """
+        # Use harness-provided event_id if available, otherwise fall back to auto-generated UUID
+        harness_id = getattr(message, "event_id", None)
+        event_id_kwargs = {"event_id": str(harness_id)} if harness_id is not None else {}
+
         if isinstance(message, UserStateInput):
             if message.value == UserState.SPEAKING:
-                return UserTurnStarted()
+                return UserTurnStarted(**event_id_kwargs)
             elif message.value == UserState.IDLE:
                 content = self._turn_content(
                     self.history,
                     UserTurnStarted,
                     (UserTextSent, UserDtmfSent),
                 )
-                return UserTurnEnded(content=content)
+                return UserTurnEnded(content=content, **event_id_kwargs)
 
         elif isinstance(message, TranscriptionInput):
-            return UserTextSent(content=message.content)
+            return UserTextSent(content=message.content, **event_id_kwargs)
 
         elif isinstance(message, AgentStateInput):
             if message.value == UserState.SPEAKING:
-                return AgentTurnStarted()
+                return AgentTurnStarted(**event_id_kwargs)
             elif message.value == UserState.IDLE:
                 content = self._turn_content(
                     self.history,
                     AgentTurnStarted,
                     (AgentTextSent, AgentDtmfSent),
                 )
-                return AgentTurnEnded(content=content)
+                return AgentTurnEnded(content=content, **event_id_kwargs)
 
         elif isinstance(message, AgentSpeechInput):
-            return AgentTextSent(content=message.content)
+            return AgentTextSent(content=message.content, **event_id_kwargs)
 
         elif isinstance(message, DTMFInput):
-            return UserDtmfSent(button=message.button)
+            return UserDtmfSent(button=message.button, **event_id_kwargs)
 
         elif isinstance(message, CustomInput):
-            return UserCustomSent(metadata=message.metadata)
+            return UserCustomSent(metadata=message.metadata, **event_id_kwargs)
 
         elif isinstance(message, ValidationErrorInput):
             # TODO: parse to a real event if we want to expose validation errors to the agent; for now just
@@ -628,16 +646,20 @@ class ConversationRunner:
                 logger.info(f'<- 🤖🗣️ Agent said: "{event.text}"')
             else:
                 logger.info(f'<- 🤖🔒 Agent said (uninterruptible): "{event.text}"')
-            return MessageOutput(content=event.text, interruptible=event.interruptible)
+            return MessageOutput(
+                content=event.text, interruptible=event.interruptible, responding_to=event.responding_to
+            )
         if isinstance(event, AgentSendDtmf):
             logger.info(f"<- 🤖🔔 Agent DTMF sent: {event.button}")
-            return DTMFOutput(button=event.button)
+            return DTMFOutput(button=event.button, responding_to=event.responding_to)
         if isinstance(event, AgentEndCall):
             logger.info("<- 📞 End call")
-            return EndCallOutput()
+            return EndCallOutput(responding_to=event.responding_to)
         if isinstance(event, AgentTransferCall):
             logger.info(f"<- 📱 Transfer to: {event.target_phone_number}")
-            return TransferOutput(target_phone_number=event.target_phone_number)
+            return TransferOutput(
+                target_phone_number=event.target_phone_number, responding_to=event.responding_to
+            )
         if isinstance(event, LogMetric):
             logger.debug(f"<- 📈 Log metric: {event.name}={event.value}")
             return LogMetricOutput(name=event.name, value=event.value)
@@ -651,7 +673,11 @@ class ConversationRunner:
             return LogEventOutput(event=event.name, metadata=metadata)
         if isinstance(event, AgentToolCalled):
             logger.info(f"<- 🔧 Tool called: {event.tool_name}({event.tool_args})")
-            return ToolCallOutput(name=event.tool_name, arguments=self._truncate_dict_for_ws(event.tool_args))
+            return ToolCallOutput(
+                name=event.tool_name,
+                arguments=self._truncate_dict_for_ws(event.tool_args),
+                responding_to=event.responding_to,
+            )
         if isinstance(event, AgentToolReturned):
             logger.info(f"<- 🔧 Tool returned: {event.tool_name}({event.tool_args}) -> {event.result}")
             result_str = self._truncate_for_ws(event.result) if event.result is not None else None
@@ -679,10 +705,11 @@ class ConversationRunner:
                 ),
                 stt=STTConfig(language=effective_language) if event.language is not None else None,
                 language=effective_language,
+                responding_to=event.responding_to,
             )
         if isinstance(event, AgentSendCustom):
             logger.debug(f"<- 📦 Custom event with metadata: {event.metadata}")
-            return CustomOutput(metadata=event.metadata)
+            return CustomOutput(metadata=event.metadata, responding_to=event.responding_to)
 
         return ErrorOutput(content=f"Unhandled output event type: {type(event).__name__}")
 

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -477,7 +477,7 @@ class ConversationRunner:
         """
         # Use harness-provided event_id if available, otherwise fall back to auto-generated UUID
         harness_id = getattr(message, "event_id", None)
-        event_id_kwargs = {"event_id": str(harness_id)} if harness_id is not None else {}
+        event_id_kwargs = {"event_id": harness_id} if harness_id is not None else {}
 
         if isinstance(message, UserStateInput):
             if message.value == UserState.SPEAKING:

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -16,7 +16,7 @@ import json
 import os
 import re
 import traceback
-from typing import Any, AsyncIterable, Awaitable, Callable, Dict, List, Optional, Tuple, get_args
+from typing import Any, AsyncIterable, Awaitable, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlencode
 
 from dotenv import load_dotenv
@@ -68,7 +68,6 @@ from line.events import (
     LogMessage,
     LogMetric,
     OutputEvent,
-    RespondingToEvent,
     UserCustomSent,
     UserDtmfSent,
     UserTextSent,
@@ -423,14 +422,14 @@ class ConversationRunner:
         """Start the agent async iterable for the given event."""
         await self._cancel_agent_task()
 
-        # Use the triggering event's event_id for responding_to stamping
+        # Use the triggering event's event_id for setting responding_to
         responding_to_id = event.event_id
 
         async def runner():
             try:
                 async for output in self.agent_callable(turn_env, event):
                     # Set responding_to at the harness boundary (outermost layer)
-                    if isinstance(output, get_args(RespondingToEvent)) and output.responding_to is None:
+                    if output.responding_to is None:
                         output.responding_to = responding_to_id
                     if isinstance(output, AgentSendText):
                         self.emitted_agent_text.append((output.text, output.interruptible))
@@ -440,10 +439,7 @@ class ConversationRunner:
                         break
                     if mapped is None:
                         continue
-                    dump = mapped.model_dump()
-                    if dump.get("responding_to") is None:
-                        dump.pop("responding_to", None)
-                    await self.websocket.send_json(dump)
+                    await self.websocket.send_json(mapped.model_dump())
             except asyncio.CancelledError:
                 pass
             except Exception:
@@ -662,7 +658,7 @@ class ConversationRunner:
             )
         if isinstance(event, LogMetric):
             logger.debug(f"<- 📈 Log metric: {event.name}={event.value}")
-            return LogMetricOutput(name=event.name, value=event.value)
+            return LogMetricOutput(name=event.name, value=event.value, responding_to=event.responding_to)
         if isinstance(event, LogMessage):
             logger.debug(f"<- 🪵 Log message: {event.name} [{event.level}] {event.message}")
             metadata = {
@@ -670,7 +666,7 @@ class ConversationRunner:
                 "message": event.message,
                 "metadata": self._truncate_dict_for_ws(event.metadata),
             }
-            return LogEventOutput(event=event.name, metadata=metadata)
+            return LogEventOutput(event=event.name, metadata=metadata, responding_to=event.responding_to)
         if isinstance(event, AgentToolCalled):
             logger.info(f"<- 🔧 Tool called: {event.tool_name}({event.tool_args})")
             return ToolCallOutput(
@@ -685,6 +681,7 @@ class ConversationRunner:
                 name=event.tool_name,
                 arguments=self._truncate_dict_for_ws(event.tool_args),
                 result=result_str,
+                responding_to=event.responding_to,
             )
         if isinstance(event, AgentUpdateCall):
             # "multilingual" is a special sentinel: STT gets None (auto-detect),

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -2066,3 +2066,138 @@ async def test_background_tool_event_not_lost_on_cancellation(turn_env):
         f"Expected to find 'success' tool result in second process(), "
         f"but only found: {[e.result for e in tool_returned_events]}"
     )
+
+
+# =============================================================================
+# Background tool responding_to
+# =============================================================================
+
+
+async def test_background_tool_responding_to_references_triggering_event(turn_env):
+    """Background tool events should have responding_to set to the event that
+    triggered the tool, not the event being processed when results are drained.
+
+    Scenario:
+    1. Event "evt-A" triggers a background tool
+    2. Tool yields "pending", agent responds
+    3. User speaks again (event "evt-B"), cancelling current process()
+    4. Tool completes and yields "success"
+    5. New process() for "evt-B" drains the success result
+    6. The success AgentToolCalled/AgentToolReturned should have responding_to="evt-A"
+    """
+    import asyncio
+
+    tool_started = asyncio.Event()
+    tool_can_complete = asyncio.Event()
+
+    @loopback_tool(is_background=True)
+    async def bg_tool(ctx, value: Annotated[str, "A value"]):
+        """Background tool that yields pending, waits, then yields success."""
+        yield {"status": "pending", "value": value}
+        tool_started.set()
+        await tool_can_complete.wait()
+        yield {"status": "success", "value": value}
+
+    responses = [
+        # Response 1: LLM calls the tool
+        [
+            StreamChunk(text="Working on it..."),
+            StreamChunk(
+                tool_calls=[
+                    ToolCall(id="tc1", name="bg_tool", arguments='{"value":"test"}', is_complete=True)
+                ]
+            ),
+            StreamChunk(is_final=True),
+        ],
+        # Response 2: LLM responds to pending status
+        [
+            StreamChunk(text="Please wait..."),
+            StreamChunk(is_final=True),
+        ],
+        # Response 3: LLM responds to second user message + success status
+        [
+            StreamChunk(text="Done!"),
+            StreamChunk(is_final=True),
+        ],
+        # Response 4: LLM responds to success result
+        [
+            StreamChunk(text="All complete!"),
+            StreamChunk(is_final=True),
+        ],
+    ]
+
+    agent, mock_llm = create_agent_with_mock(responses, tools=[bg_tool])
+
+    # First process() - event "evt-A" triggers the background tool
+    first_event = UserTextSent(
+        content="Do the thing",
+        event_id="evt-A",
+        history=[UserTextSent(content="Do the thing", event_id="evt-A")],
+    )
+
+    async def run_first_process():
+        outputs = []
+        async for output in agent.process(turn_env, first_event):
+            if not isinstance(output, LogMetric):
+                outputs.append(output)
+        return outputs
+
+    first_task = asyncio.create_task(run_first_process())
+
+    # Wait for tool to start and yield pending
+    await asyncio.wait_for(tool_started.wait(), timeout=5.0)
+
+    # Wait for agent to process the pending status
+    for _ in range(100):
+        if mock_llm._call_count >= 2:
+            break
+        await asyncio.sleep(0)
+
+    # Cancel first process (simulating user speaking)
+    first_task.cancel()
+    try:
+        await first_task
+    except asyncio.CancelledError:
+        pass
+
+    # Allow tool to complete
+    tool_can_complete.set()
+    await asyncio.wait_for(agent._get_background_event_queue().wait(), timeout=5.0)
+
+    # Second process() - event "evt-B" drains the background tool results
+    second_event = UserTextSent(
+        content="Status?",
+        event_id="evt-B",
+        history=[
+            UserTextSent(content="Do the thing", event_id="evt-A"),
+            AgentTextSent(content="Working on it..."),
+            AgentTextSent(content="Please wait..."),
+            UserTextSent(content="Status?", event_id="evt-B"),
+        ],
+    )
+
+    second_outputs = await collect_outputs(agent, turn_env, second_event)
+
+    # Find background tool events (success result drained during second process)
+    bg_tool_called = [
+        o for o in second_outputs if isinstance(o, AgentToolCalled) and "tc1-" in o.tool_call_id
+    ]
+    bg_tool_returned = [
+        o for o in second_outputs if isinstance(o, AgentToolReturned) and "tc1-" in o.tool_call_id
+    ]
+    success_returned = [e for e in bg_tool_returned if e.result.get("status") == "success"]
+
+    assert len(success_returned) >= 1, (
+        f"Expected background tool success result, got: {[e.result for e in bg_tool_returned]}"
+    )
+
+    # The key assertion: background tool events should reference "evt-A" (the triggering event),
+    # not "evt-B" (the event being processed when results were drained)
+    for evt in bg_tool_called:
+        assert evt.responding_to == "evt-A", (
+            f"AgentToolCalled responding_to should be 'evt-A', got '{evt.responding_to}'"
+        )
+    for evt in bg_tool_returned:
+        assert evt.responding_to == "evt-A", (
+            f"AgentToolReturned responding_to should be 'evt-A', got '{evt.responding_to}'"
+        )


### PR DESCRIPTION
## What does this PR do?
- Adds responding_to: Optional[str] to harness-facing output events so the harness can correlate which input event triggered each output                                                                                                                                                                             
- Sets responding_to at two layers: LlmAgent.process() yield boundary and the ConversationRunner harness boundary (catch-all for custom/wrapper agents) . This ensures wrapper agents that re-yield events don't lose the correlation.
- Threads harness-provided event_id through to framework InputEvent.event_id, so responding_to references the same ID the harness originally assigned                                                               
- Only includes responding_to in WebSocket JSON when non-null to avoid upstream validation errors                                                                                                                                                                                  

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
- Verify responding_to is set correctly on all harness-facing output events during a live call                                                                                                                                                                                                  
- Verify wrapper agents that re-yield events still get responding_to stamped at the harness boundary                                                                                                                
- Verify pre-set responding_to from custom agents is preserved (not overwritten)                                                                                                                                    
- Run pytest tests/ — all existing tests pass

## Checklist
- [ ] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have formatted my code with `make format`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new optional correlation fields on websocket I/O and stamps them across the agent/harness boundary; mistakes could break harness validation or mis-correlate responses, especially for background tool results and wrappers.
> 
> **Overview**
> Adds end-to-end *event correlation* between harness inputs and agent outputs by threading harness-provided `event_id` into framework `InputEvent.event_id` and emitting a new optional `responding_to` field on all harness-facing output event/message types.
> 
> `LlmAgent.process()` now stamps `responding_to` on yielded `OutputEvent`s (without overwriting pre-set values), and background tool emissions capture the *triggering* event id so late/drained tool results still reference the original input. `ConversationRunner` also stamps `responding_to` at the websocket boundary and includes it when mapping events back to websocket JSON.
> 
> Adds a regression test ensuring background tool `AgentToolCalled`/`AgentToolReturned` events keep `responding_to` pointing at the triggering event even when the original `process()` is cancelled and results are drained in a later turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c4e044c71b493047b78f0f24a6f140f197a411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->