### PR TITLE
Bump to 0.2.8a

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cartesia-line"
-version = "0.2.7"
+version = "0.2.8a"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What does this PR do?

Pull in:
  1. #198 — [Bug] Fixing websocket provider warmup                                                                                                                                                                                                                                            
  2. #201 — Fix missing response_id retry for o.ai websocket provider       

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: Alpha release

## Testing
N/A

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package version in `pyproject.toml` and does not change runtime code paths.
> 
> **Overview**
> Bumps `cartesia-line` package version in `pyproject.toml` from `0.2.7` to `0.2.8a` to cut an alpha release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c3f2ba33a99796c0baa6739f8cef7ca95521c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->