### PR TITLE
Delay transfer and end_call until agent finishes speaking

### DIFF
--- a/line/events.py
+++ b/line/events.py
@@ -41,11 +41,13 @@ class AgentToolReturned(BaseModel):
 
 class AgentEndCall(BaseModel):
     type: Literal["end_call"] = "end_call"
+    after_speech: bool = False
 
 
 class AgentTransferCall(BaseModel):
     type: Literal["agent_transfer_call"] = "agent_transfer_call"
     target_phone_number: str
+    after_speech: bool = False
 
 
 class AgentSendDtmf(BaseModel):

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -207,7 +207,7 @@ is possible."""
             ctx: ToolEnv,
             reason: Annotated[str, "The reason for ending the call"],
         ):
-            yield AgentEndCall()
+            yield AgentEndCall(after_speech=True)
 
         return construct_function_tool(
             _end_call_impl,
@@ -463,7 +463,7 @@ async def transfer_call(
 
     if message is not None:
         yield AgentSendText(text=message)
-    yield AgentTransferCall(target_phone_number=normalized_number)
+    yield AgentTransferCall(target_phone_number=normalized_number, after_speech=True)
 
 
 def agent_as_handoff(

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -290,6 +290,7 @@ class ConversationRunner:
         self.env = env
         # Lazy-init: asyncio.Event() requires a running event loop on Python 3.9.
         self._shutdown_event: Optional[asyncio.Event] = None
+        self._speech_done: Optional[asyncio.Event] = None
         self.history: List[InputEvent] = []
         self.emitted_agent_text: List[Tuple[str, bool]] = []  # (content, interruptible)
 
@@ -301,6 +302,14 @@ class ConversationRunner:
         if self._shutdown_event is None:
             self._shutdown_event = asyncio.Event()
         return self._shutdown_event
+
+    @property
+    def speech_done(self) -> asyncio.Event:
+        """Event that is set when the agent is not speaking (TTS idle)."""
+        if self._speech_done is None:
+            self._speech_done = asyncio.Event()
+            self._speech_done.set()  # Start in "done" state (no speech pending)
+        return self._speech_done
 
     ######### Initialization Methods #########
 
@@ -423,16 +432,28 @@ class ConversationRunner:
         await self._cancel_agent_task()
 
         async def runner():
+            has_sent_text = False
             try:
                 async for output in self.agent_callable(turn_env, event):
                     if isinstance(output, AgentSendText):
                         self.emitted_agent_text.append((output.text, output.interruptible))
+                        has_sent_text = True
                     mapped = self._map_output_event(output)
 
                     if self.shutdown_event.is_set():
                         break
                     if mapped is None:
                         continue
+
+                    # Wait for TTS to finish speaking before sending after_speech events
+                    if getattr(output, "after_speech", False) and has_sent_text:
+                        try:
+                            await asyncio.wait_for(self.speech_done.wait(), timeout=30.0)
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                f"Timed out waiting for speech to complete before {type(output).__name__}"
+                            )
+
                     await self.websocket.send_json(mapped.model_dump())
             except asyncio.CancelledError:
                 pass
@@ -481,8 +502,10 @@ class ConversationRunner:
 
         elif isinstance(message, AgentStateInput):
             if message.value == UserState.SPEAKING:
+                self.speech_done.clear()
                 return AgentTurnStarted()
             elif message.value == UserState.IDLE:
+                self.speech_done.set()
                 content = self._turn_content(
                     self.history,
                     AgentTurnStarted,


### PR DESCRIPTION
## Summary
- Adds `after_speech: bool = False` flag to `AgentTransferCall` and `AgentEndCall` events
- When `after_speech=True`, `ConversationRunner` waits for the TTS idle signal before sending the event over the websocket, preventing the agent from being cut off mid-sentence
- Built-in `transfer_call` and `end_call` tools set `after_speech=True` by default
- Custom tools can opt out by setting `after_speech=False`

## Problem
When the LLM generates speech text and a transfer/end_call tool call in the same turn, the transfer fires immediately while TTS is still playing, cutting off the agent mid-sentence. A fixed sleep delay is not a good solution since speech length varies.

## How it works
- `ConversationRunner` tracks TTS state via `AgentStateInput` (speaking/idle) using an `asyncio.Event`
- Before sending an `after_speech=True` event, the runner waits for the idle signal (with a 30s safety timeout)
- If no text was sent in the current turn, the wait is skipped entirely

## Test plan
- [x] All existing tests pass (380 passed)
- [ ] Manual test: agent says long farewell + transfers in same turn — speech completes before transfer
- [ ] Manual test: `after_speech=False` — transfer fires immediately, cutting off speech
- [ ] Manual test: transfer with no preceding text — no hang, transfers immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes call-control timing by delaying `end_call`/`transfer_call` until TTS reports idle, which could introduce waits/timeouts or ordering differences in live call flows.
> 
> **Overview**
> Adds an `after_speech` flag to `AgentEndCall` and `AgentTransferCall` output events so call-control actions can be deferred until the agent finishes speaking.
> 
> Updates `ConversationRunner` to track TTS speaking/idle via an `asyncio.Event` and, when an output event has `after_speech=True` (and text was sent this turn), waits up to 30s for speech to complete before sending the event over the websocket.
> 
> Sets the built-in `end_call` and `transfer_call` tools to emit `after_speech=True` by default, preventing transfers/hangups from cutting off same-turn TTS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5d41cafc5c8375db925c693ff2154b1e808e8db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->