### PR TITLE
Treat AgentHandedOff equivalent to CallStarted in LlmAgent

### DIFF
--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -209,7 +209,7 @@ class LlmAgent:
             return
 
         # Handle CallStarted
-        if isinstance(event, CallStarted):
+        if isinstance(event, (CallStarted, AgentHandedOff)):
             warmup_task = asyncio.create_task(
                 self._llm.warmup(config=effective_config, tools=effective_tools)
             )

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -787,6 +787,19 @@ async def test_introduction_sent_on_call_started(turn_env):
     assert outputs[0].text == "Hello! How can I help you?"
 
 
+async def test_introduction_sent_on_agent_handed_off(turn_env):
+    """Test that introduction is sent on CallStarted event."""
+    config = LlmConfig(introduction="Hello! How can I help you?")
+
+    agent, _ = create_agent_with_mock([], config=config)
+
+    outputs = await collect_outputs(agent, turn_env, AgentHandedOff())
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], AgentSendText)
+    assert outputs[0].text == "Hello! How can I help you?"
+
+
 async def test_introduction_only_sent_once(turn_env):
     """Test that introduction is not sent on subsequent CallStarted events."""
     config = LlmConfig(introduction="Hello!")


### PR DESCRIPTION
## What does this PR do?

[Slack context](https://cartesia-ai.slack.com/archives/C08RSRJDQ2K/p1776126446674279)

Currently, when handing off to a new LlmAgent, we support the _handing off_ agent sending a goodbye message to the user. 

However, we don't support the _receiving_ agent sending a greeting message to the user. This PR adds support for this by treating the AgentHandedOff message as equivalent to CallStarted for the receiving agent, meaning the agent emits its `introduction`.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Unit test

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral change limited to the `CallStarted`/handoff startup path, plus a unit test to lock in the new greeting behavior.
> 
> **Overview**
> `LlmAgent.process` now treats `AgentHandedOff` the same as `CallStarted`, triggering provider warmup and emitting the configured `introduction` message for the receiving agent on handoff.
> 
> Adds a unit test ensuring the introduction is sent on `AgentHandedOff` (and remains one-time per agent instance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd892f04b3771641f06726e9ed11cfc7e0de904d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->