### PR TITLE
Fix openai-4.1 bug

### DIFF
--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -382,58 +382,47 @@ def _get_model_config(model: str, *, backend: Optional[str] = None) -> _ModelCon
         raise ValueError(f"Invalid backend {backend!r}. Must be one of: {', '.join(sorted(_VALID_BACKENDS))}")
 
     # Realtime models — dedicated realtime backend, no override allowed.
+    if backend == "realtime" and not _is_realtime_model(model):
+        raise ValueError(
+            f"Backend 'realtime' requires a realtime model (e.g. gpt-4o-realtime-preview), got {model!r}"
+        )
+    if backend is not None and backend != "realtime" and _is_realtime_model(model):
+        raise ValueError(f"Realtime model {model!r} is incompatible with backend {backend!r}")
     if _is_realtime_model(model):
-        if backend is not None and backend != "realtime":
-            raise ValueError(f"Realtime model {model!r} is incompatible with backend {backend!r}")
         return _ModelConfig(
             backend="realtime",
             supports_reasoning_effort=False,
             default_reasoning_effort=None,
         )
 
-    # WebSocket models — auto-select websocket, but allow http override.
-    if _is_websocket_model(model):
-        effective = backend or "websocket"
-        if effective == "realtime":
-            raise ValueError(
-                f"Backend 'realtime' requires a realtime model (e.g. gpt-4o-realtime-preview), got {model!r}"
-            )
-        # Not all websocket-capable models support reasoning_effort (e.g. gpt-4.1).
-        from litellm import get_supported_openai_params
 
+    # WebSocket models — auto-select websocket, but allow http override.
+    from litellm import get_supported_openai_params
+    if backend == "websocket" and not _is_websocket_model(model):
+        raise ValueError(
+            f"Backend 'websocket' requires a websocket-compatible model (e.g. gpt-5.2), got {model!r}"
+        )
+    if _is_websocket_model(model) and backend in (None, "websocket"):
         ws_supported = get_supported_openai_params(model=model) or []
         ws_supports_reasoning = "reasoning_effort" in ws_supported
         return _ModelConfig(
-            backend=effective,
+            backend="websocket",
             supports_reasoning_effort=ws_supports_reasoning,
             default_reasoning_effort="low" if ws_supports_reasoning else None,
         )
 
-    # WebSocket/realtime backends require specific OpenAI models.
-    if backend == "websocket":
-        raise ValueError(
-            f"Backend 'websocket' requires a websocket-compatible model (e.g. gpt-5.2), got {model!r}"
-        )
-    if backend == "realtime":
-        raise ValueError(
-            f"Backend 'realtime' requires a realtime model (e.g. gpt-4o-realtime-preview), got {model!r}"
-        )
-
     # Everything else — HTTP via LiteLLM.
-    from litellm import get_supported_openai_params
 
     supported = get_supported_openai_params(model=model)
     if supported is None:
         raise ValueError(
             f"Model {model} is not supported. See https://models.litellm.ai/ for supported models."
         )
-
     supports = "reasoning_effort" in supported
     default: Optional[str] = "low" if supports else None
     if supports:
         from litellm import get_llm_provider
         from litellm.utils import get_optional_params
-
         try:
             _, provider, _, _ = get_llm_provider(model=model)
             get_optional_params(model=model, custom_llm_provider=provider, reasoning_effort="none")

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -395,9 +395,9 @@ def _get_model_config(model: str, *, backend: Optional[str] = None) -> _ModelCon
             default_reasoning_effort=None,
         )
 
-
     # WebSocket models — auto-select websocket, but allow http override.
     from litellm import get_supported_openai_params
+
     if backend == "websocket" and not _is_websocket_model(model):
         raise ValueError(
             f"Backend 'websocket' requires a websocket-compatible model (e.g. gpt-5.2), got {model!r}"
@@ -423,6 +423,7 @@ def _get_model_config(model: str, *, backend: Optional[str] = None) -> _ModelCon
     if supports:
         from litellm import get_llm_provider
         from litellm.utils import get_optional_params
+
         try:
             _, provider, _, _ = get_llm_provider(model=model)
             get_optional_params(model=model, custom_llm_provider=provider, reasoning_effort="none")

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -398,10 +398,15 @@ def _get_model_config(model: str, *, backend: Optional[str] = None) -> _ModelCon
             raise ValueError(
                 f"Backend 'realtime' requires a realtime model (e.g. gpt-4o-realtime-preview), got {model!r}"
             )
+        # Not all websocket-capable models support reasoning_effort (e.g. gpt-4.1).
+        from litellm import get_supported_openai_params
+
+        ws_supported = get_supported_openai_params(model=model) or []
+        ws_supports_reasoning = "reasoning_effort" in ws_supported
         return _ModelConfig(
             backend=effective,
-            supports_reasoning_effort=True,
-            default_reasoning_effort="low",
+            supports_reasoning_effort=ws_supports_reasoning,
+            default_reasoning_effort="low" if ws_supports_reasoning else None,
         )
 
     # WebSocket/realtime backends require specific OpenAI models.
@@ -424,7 +429,7 @@ def _get_model_config(model: str, *, backend: Optional[str] = None) -> _ModelCon
         )
 
     supports = "reasoning_effort" in supported
-    default: Optional[str] = "low"
+    default: Optional[str] = "low" if supports else None
     if supports:
         from litellm import get_llm_provider
         from litellm.utils import get_optional_params

--- a/tests/real_api_test_provider.py
+++ b/tests/real_api_test_provider.py
@@ -726,7 +726,7 @@ MODELS = [
     ("ANTHROPIC_API_KEY", "anthropic/claude-haiku-4-5"),
     ("GEMINI_API_KEY", "gemini/gemini-2.5-flash"),
     ("GEMINI_API_KEY", "gemini/gemini-3-flash-preview"),
-    ("OPENAI_API_KEY", "openai/gpt-4.1")
+    ("OPENAI_API_KEY", "openai/gpt-4.1"),
 ]
 
 # Available test names

--- a/tests/real_api_test_provider.py
+++ b/tests/real_api_test_provider.py
@@ -726,6 +726,7 @@ MODELS = [
     ("ANTHROPIC_API_KEY", "anthropic/claude-haiku-4-5"),
     ("GEMINI_API_KEY", "gemini/gemini-2.5-flash"),
     ("GEMINI_API_KEY", "gemini/gemini-3-flash-preview"),
+    ("OPENAI_API_KEY", "openai/gpt-4.1")
 ]
 
 # Available test names

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -319,6 +319,128 @@ def test_backend_override_invalid_value():
         raise AssertionError("Expected ValueError for invalid backend value")
 
 
+# ---------------------------------------------------------------------------
+# _get_model_config
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelConfig:
+    """Tests for _get_model_config backend routing and reasoning-effort detection."""
+
+    # -- Backend routing -------------------------------------------------------
+
+    def test_realtime_model_selects_realtime_backend(self):
+        cfg = _get_model_config("openai/gpt-4o-realtime-preview")
+        assert cfg.backend == "realtime"
+        assert cfg.supports_reasoning_effort is False
+        assert cfg.default_reasoning_effort is None
+
+    def test_websocket_model_selects_websocket_backend(self):
+        cfg = _get_model_config("openai/gpt-5.2")
+        assert cfg.backend == "websocket"
+
+    def test_websocket_model_with_http_override_selects_http(self):
+        cfg = _get_model_config("openai/gpt-5.2", backend="http")
+        assert cfg.backend == "http"
+
+    def test_websocket_model_with_explicit_websocket_backend(self):
+        cfg = _get_model_config("openai/gpt-5.2", backend="websocket")
+        assert cfg.backend == "websocket"
+
+    def test_plain_http_model_selects_http_backend(self):
+        cfg = _get_model_config("openai/gpt-4o")
+        assert cfg.backend == "http"
+
+    # -- Error cases -----------------------------------------------------------
+
+    def test_invalid_backend_raises(self):
+        try:
+            _get_model_config("openai/gpt-4o", backend="banana")
+        except ValueError as exc:
+            assert "Invalid backend" in str(exc)
+        else:
+            raise AssertionError("Expected ValueError")
+
+    def test_realtime_backend_with_non_realtime_model_raises(self):
+        try:
+            _get_model_config("openai/gpt-4o", backend="realtime")
+        except ValueError as exc:
+            assert "realtime" in str(exc).lower()
+        else:
+            raise AssertionError("Expected ValueError")
+
+    def test_non_realtime_backend_with_realtime_model_raises(self):
+        try:
+            _get_model_config("openai/gpt-4o-realtime-preview", backend="http")
+        except ValueError as exc:
+            assert "incompatible" in str(exc).lower()
+        else:
+            raise AssertionError("Expected ValueError")
+
+    def test_websocket_backend_with_non_websocket_model_raises(self):
+        try:
+            _get_model_config("openai/gpt-4o", backend="websocket")
+        except ValueError as exc:
+            assert "websocket" in str(exc).lower()
+        else:
+            raise AssertionError("Expected ValueError")
+
+    def test_unsupported_model_raises(self, monkeypatch):
+        import litellm
+
+        monkeypatch.setattr(litellm, "get_supported_openai_params", lambda model: None)
+        try:
+            _get_model_config("fake-provider/not-a-model")
+        except ValueError as exc:
+            assert "is not supported" in str(exc)
+        else:
+            raise AssertionError("Expected ValueError")
+
+    # -- Reasoning effort for websocket models ---------------------------------
+
+    def test_websocket_model_with_reasoning_support(self):
+        """Reasoning models (e.g. o3) routed via websocket get reasoning enabled."""
+        cfg = _get_model_config("openai/o3")
+        assert cfg.backend == "websocket"
+        assert cfg.supports_reasoning_effort is True
+        assert cfg.default_reasoning_effort == "low"
+
+    def test_websocket_model_without_reasoning_support(self):
+        """Non-reasoning websocket models (e.g. gpt-4.1) must not get reasoning params."""
+        cfg = _get_model_config("openai/gpt-4.1")
+        assert cfg.backend == "websocket"
+        assert cfg.supports_reasoning_effort is False
+        assert cfg.default_reasoning_effort is None
+
+    # -- Reasoning effort for HTTP models --------------------------------------
+
+    def test_http_model_without_reasoning_support(self):
+        cfg = _get_model_config("openai/gpt-4o")
+        assert cfg.supports_reasoning_effort is False
+        assert cfg.default_reasoning_effort is None
+
+    def test_http_model_with_reasoning_support(self):
+        """o4-mini goes through the HTTP path and supports reasoning."""
+        cfg = _get_model_config("openai/o4-mini")
+        assert cfg.backend == "http"
+        assert cfg.supports_reasoning_effort is True
+        assert cfg.default_reasoning_effort is not None
+
+    def test_websocket_model_forced_to_http_gets_correct_reasoning(self):
+        """gpt-4.1 forced to HTTP should still have reasoning disabled."""
+        cfg = _get_model_config("openai/gpt-4.1", backend="http")
+        assert cfg.backend == "http"
+        assert cfg.supports_reasoning_effort is False
+        assert cfg.default_reasoning_effort is None
+
+    def test_anthropic_model_reasoning_default_is_none(self):
+        """Anthropic models use None (not 'low') to skip the thinking block."""
+        cfg = _get_model_config("anthropic/claude-sonnet-4-20250514")
+        assert cfg.backend == "http"
+        assert cfg.supports_reasoning_effort is True
+        assert cfg.default_reasoning_effort is None
+
+
 def test_is_websocket_model_matches_gpt52_variants():
     assert _is_websocket_model("gpt-5.2")
     assert _is_websocket_model("gpt-5.2-pro")


### PR DESCRIPTION
## What does this PR do?
Core fix is just our provider resolution logic assumed all websocket models supported reasoning. That's not true, so added a check against that.

Also took the chance to cubscout the code:
1) Moved  line/llm_agent/scripts/test_provider.py => tests/real_api_test_provider.py, so it's not incorporated into build artefacts
2) Cleaned up `_get_model_config` logic to colocate the resolution of each branch ("realtime", "websocket", "http")

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Unit tests + integration tests

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backend routing and `reasoning_effort` defaulting for OpenAI websocket/responses models, which can affect live API request parameters. Added tests reduce risk but mis-detection could change behavior across models.
> 
> **Overview**
> Fixes model-config routing so `backend="realtime"` and `backend="websocket"` overrides error out unless the selected model is actually compatible.
> 
> Updates WebSocket model handling to *detect* whether `reasoning_effort` is supported via `litellm.get_supported_openai_params` and only set/forward a default when supported (preventing errors like `openai/gpt-4.1`). Adds a real-API model entry for `openai/gpt-4.1` and a new `TestGetModelConfig` suite covering routing, override errors, unsupported models, and reasoning-effort defaults across HTTP/WebSocket/realtime paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23b4ca58fc6b541d87af8724ca8408554318473a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->