### PR TITLE
Revert "Treat AgentHandedOff equivalent to CallStarted in LlmAgent (#207)"

### DIFF
--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -209,7 +209,7 @@ class LlmAgent:
             return
 
         # Handle CallStarted
-        if isinstance(event, (CallStarted, AgentHandedOff)):
+        if isinstance(event, CallStarted):
             warmup_task = asyncio.create_task(
                 self._llm.warmup(config=effective_config, tools=effective_tools)
             )

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -787,19 +787,6 @@ async def test_introduction_sent_on_call_started(turn_env):
     assert outputs[0].text == "Hello! How can I help you?"
 
 
-async def test_introduction_sent_on_agent_handed_off(turn_env):
-    """Test that introduction is sent on CallStarted event."""
-    config = LlmConfig(introduction="Hello! How can I help you?")
-
-    agent, _ = create_agent_with_mock([], config=config)
-
-    outputs = await collect_outputs(agent, turn_env, AgentHandedOff())
-
-    assert len(outputs) == 1
-    assert isinstance(outputs[0], AgentSendText)
-    assert outputs[0].text == "Hello! How can I help you?"
-
-
 async def test_introduction_only_sent_once(turn_env):
     """Test that introduction is not sent on subsequent CallStarted events."""
     config = LlmConfig(introduction="Hello!")


### PR DESCRIPTION
This reverts commit 989e99b686af68401cee53a498b8be7144570045.

## What does this PR do?
We already handle this in `agent_to_handoff`, so this is redundant.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
N/A

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior revert limited to `CallStarted` handling; main impact is that `introduction`/warmup no longer triggers on `AgentHandedOff`, which could change UX for handoff flows if any relied on it.
> 
> **Overview**
> Reverts the prior change that treated `AgentHandedOff` like `CallStarted` in `LlmAgent._process_impl`.
> 
> `introduction` sending and provider `warmup` now run **only** for `CallStarted` events (not on handoff events), and the corresponding test asserting intro-on-handoff behavior is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ce22c9a946daff0ab7414a282fd29e35d7a08c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->