### PR TITLE
Tighten websocket provider criteria

### DIFF
--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -478,18 +478,20 @@ def _is_realtime_model(model: str) -> bool:
     return _is_openai_model(model) and "realtime" in model.lower().split("/", 1)[-1]
 
 
+_WEBSOCKET_MODELS = ("gpt-5.2", "gpt-5.2-pro", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro")
 def _is_websocket_model(model: str) -> bool:
     """Check if a model should use the WebSocket (Responses API) backend.
 
     Returns True for OpenAI models that support the /v1/responses endpoint,
     as detected via LiteLLM's model_cost registry.
     """
-    info = _get_model_info(model)
-    if info.get("litellm_provider") not in ("openai", "chatgpt"):
+    if model in _WEBSOCKET_MODELS:
+        return True
+    match = model.lower().split("/", 1)
+    if len(match) == 1:
         return False
-    endpoints = info.get("supported_endpoints", [])
-    return "/v1/responses" in endpoints
-
+    model_prefix, model_suffix = match
+    return model_suffix in _WEBSOCKET_MODELS and model_prefix in ("openai", "chatgpt")
 
 # Backward-compat alias — emits a deprecation warning on instantiation.
 def LLMProvider(*args, **kwargs):

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -479,6 +479,8 @@ def _is_realtime_model(model: str) -> bool:
 
 
 _WEBSOCKET_MODELS = ("gpt-5.2", "gpt-5.2-pro", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro")
+
+
 def _is_websocket_model(model: str) -> bool:
     """Check if a model should use the WebSocket (Responses API) backend.
 
@@ -492,6 +494,7 @@ def _is_websocket_model(model: str) -> bool:
         return False
     model_prefix, model_suffix = match
     return model_suffix in _WEBSOCKET_MODELS and model_prefix in ("openai", "chatgpt")
+
 
 # Backward-compat alias — emits a deprecation warning on instantiation.
 def LLMProvider(*args, **kwargs):

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -400,17 +400,10 @@ class TestGetModelConfig:
 
     def test_websocket_model_with_reasoning_support(self):
         """Reasoning models (e.g. o3) routed via websocket get reasoning enabled."""
-        cfg = _get_model_config("openai/o3")
+        cfg = _get_model_config("openai/gpt-5.2")
         assert cfg.backend == "websocket"
         assert cfg.supports_reasoning_effort is True
         assert cfg.default_reasoning_effort == "low"
-
-    def test_websocket_model_without_reasoning_support(self):
-        """Non-reasoning websocket models (e.g. gpt-4.1) must not get reasoning params."""
-        cfg = _get_model_config("openai/gpt-4.1")
-        assert cfg.backend == "websocket"
-        assert cfg.supports_reasoning_effort is False
-        assert cfg.default_reasoning_effort is None
 
     # -- Reasoning effort for HTTP models --------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Use specific whitelist, rather than deferring to LiteLLM's list of supported models. Because websocket API's less reliable? maybe?

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: sliding along the pareto frontier

## Testing
How did you test this?

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backend selection logic, which can alter which transport/API is used for certain model strings and potentially affect production behavior if callers relied on the previous auto-detection.
> 
> **Overview**
> Tightens WebSocket backend routing by replacing LiteLLM endpoint introspection with an explicit allowlist of OpenAI/ChatGPT model names (e.g. `gpt-5.2`, `gpt-5.4` variants), so other providers or unlisted models no longer auto-select the Responses/WebSocket path.
> 
> Updates tests to reflect the new routing criteria and removes coverage for a previously-expected “websocket but no reasoning support” model case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39990354734f0e5298d93e48151e62cf5bffd337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->