### PR TITLE
Enforce case sensitivity for realtime/websocket model lookup

### DIFF
--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -463,11 +463,10 @@ def _get_model_info(model: str) -> dict:
     """
     import litellm
 
-    lower = model.lower()
-    if lower.startswith("openai/"):
-        lookup = lower[len("openai/") :]
+    if model.startswith("openai/"):
+        lookup = model[len("openai/") :]
     else:
-        lookup = lower
+        lookup = model
     return litellm.model_cost.get(lookup, {})
 
 
@@ -479,15 +478,14 @@ def _is_openai_model(model: str) -> bool:
         # "openai" for direct API, "chatgpt" for ChatGPT API - both use OpenAI endpoints
         return provider in ("openai", "chatgpt")
     # Fallback to pattern matching for models not yet in LiteLLM registry
-    lower = model.lower()
-    if lower.startswith("openai/"):
-        lower = lower[len("openai/") :]
-    return lower.startswith(("gpt-", "o1", "o3", "o4", "chatgpt/", "codex"))
+    if model.startswith("openai/"):
+        model = model[len("openai/") :]
+    return model.startswith(("gpt-", "o1", "o3", "o4", "chatgpt/", "codex"))
 
 
 def _is_realtime_model(model: str) -> bool:
     """Check if a model name indicates a direct OpenAI Realtime model."""
-    return _is_openai_model(model) and "realtime" in model.lower().split("/", 1)[-1]
+    return _is_openai_model(model) and "realtime" in model.split("/", 1)[-1]
 
 
 _WEBSOCKET_MODELS = ("gpt-5.2", "gpt-5.2-pro", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro")
@@ -501,7 +499,7 @@ def _is_websocket_model(model: str) -> bool:
     """
     if model in _WEBSOCKET_MODELS:
         return True
-    match = model.lower().split("/", 1)
+    match = model.split("/", 1)
     if len(match) == 1:
         return False
     model_prefix, model_suffix = match


### PR DESCRIPTION
## What does this PR do?

What it says on the tin; we want to match LiteLLM's behavior here.


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Unit tests

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches backend auto-selection logic; misclassification could route requests to the wrong HTTP/WS/realtime backend for unexpectedly cased model strings.
> 
> **Overview**
> Aligns model routing with LiteLLM by **removing implicit lowercasing** in `_get_model_info`, `_is_openai_model`, `_is_realtime_model`, and `_is_websocket_model`.
> 
> As a result, `openai/` prefix stripping and realtime/websocket detection now depend on the exact casing of the provided model string, which can change backend selection for mixed/uppercased model names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dff30714de3438ecce066bf33d7335cce54622b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->