### PR TITLE
Make websocket backend opt-in only

### DIFF
--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -84,12 +84,13 @@ class LlmAgent:
         tools: Optional[List[ToolSpec]] = None,
         config: Optional[LlmConfig] = None,
         max_tool_iterations: int = 10,
+        backend: Optional[str] = None,
     ):
         if not api_key:
             raise ValueError("Missing API key in LLmAgent initialization")
 
         model_id = parse_model_id(model)
-        model_config = _get_model_config(model_id)
+        model_config = _get_model_config(model_id, backend=backend)
 
         # Resolve the base config to insert default values for any _UNSET sentinels.
         effective_config = _normalize_config(config or LlmConfig())
@@ -112,6 +113,7 @@ class LlmAgent:
             api_key=api_key,
             config=effective_config,
             tools=self._tools,
+            backend=backend,
         )
 
         self._introduction_sent = False

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -441,16 +441,15 @@ def _get_model_config(model_id: ParsedModelId, *, backend: Optional[str] = None)
             default_reasoning_effort=None,
         )
 
-    # WebSocket models — auto-select websocket, but allow http override.
+    # WebSocket models — opt-in via backend="websocket"; default is HTTP.
     from litellm import get_supported_openai_params
 
     litellm_model = str(model_id)
-
     if backend == "websocket" and not _is_websocket_model(model_id):
         raise ValueError(
             f"Backend 'websocket' requires a websocket-compatible model (e.g. gpt-5.2), got {str(model_id)!r}"
         )
-    if _is_websocket_model(model_id) and backend in (None, "websocket"):
+    if _is_websocket_model(model_id) and backend == "websocket":
         ws_supported = get_supported_openai_params(model=litellm_model) or []
         ws_supports_reasoning = "reasoning_effort" in ws_supported
         return _ModelConfig(

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -278,13 +278,13 @@ class LlmProvider:
         if not api_key:
             raise ValueError("Missing API key in LlmProvider initialization")
         model_id = parse_model_id(model)
-        mcfg = _get_model_config(model_id, backend=backend)
 
         self._model_id = model_id
         self._tools = list(tools or [])
         normalized_config = _normalize_config(config or LlmConfig())
         self._config = normalized_config
-        self._http_fallback_backend: Optional[ProviderProtocol] = None
+        self._backend_override = backend
+        mcfg = _get_model_config(model_id, backend=backend, config=normalized_config)
 
         if mcfg.backend == "realtime":
             from line.llm_agent.realtime_provider import _RealtimeProvider
@@ -296,7 +296,6 @@ class LlmProvider:
                 api_key=api_key,
             )
         elif mcfg.backend == "websocket":
-            from line.llm_agent.http_provider import _HttpProvider
             from line.llm_agent.websocket_provider import _WebSocketProvider
 
             logger.info(f"WebSocket provider selected for model: {model_id}")
@@ -304,12 +303,6 @@ class LlmProvider:
             self._backend = _WebSocketProvider(
                 model_id=model_id,
                 api_key=api_key,
-                default_reasoning_effort=mcfg.default_reasoning_effort,
-            )
-            self._http_fallback_backend = _HttpProvider(
-                model_id=model_id,
-                api_key=api_key,
-                supports_reasoning_effort=mcfg.supports_reasoning_effort,
                 default_reasoning_effort=mcfg.default_reasoning_effort,
             )
         else:
@@ -338,12 +331,12 @@ class LlmProvider:
         effective_tools, web_search_options = _normalize_tools(
             _merge_tools(self._tools, tools), model_id=self._model_id
         )
-        backend = self._select_backend(effective_config)
+        _get_model_config(self._model_id, backend=self._backend_override, config=effective_config)
 
         if web_search_options is not None:
             kwargs = {**kwargs, "web_search_options": web_search_options}
 
-        return backend.chat(normalized, effective_tools, config=effective_config, **kwargs)
+        return self._backend.chat(normalized, effective_tools, config=effective_config, **kwargs)
 
     def _set_tools(self, tools: Optional[List[Any]]) -> None:
         """Replace the provider's default tool specs."""
@@ -358,8 +351,8 @@ class LlmProvider:
         effective_tools, web_search_options = _normalize_tools(
             _merge_tools(self._tools, tools), model_id=self._model_id
         )
-        backend = self._select_backend(effective_config)
-        await backend.warmup(
+        _get_model_config(self._model_id, backend=self._backend_override, config=effective_config)
+        await self._backend.warmup(
             config=effective_config,
             tools=effective_tools,
             web_search_options=web_search_options,
@@ -367,33 +360,6 @@ class LlmProvider:
 
     async def aclose(self) -> None:
         await self._backend.aclose()
-        if self._http_fallback_backend is not None:
-            await self._http_fallback_backend.aclose()
-
-    def _select_backend(self, config: LlmConfig) -> ProviderProtocol:
-        """Use HTTP for websocket-incompatible config fields.
-
-        WebSocket mode is lower latency, but it cannot preserve every field on
-        ``LlmConfig``. Fall back to the HTTP backend when callers rely on
-        request options that only the LiteLLM/HTTP path currently supports.
-        """
-        if self._http_fallback_backend is None:
-            return self._backend
-
-        if (
-            config.temperature is not None
-            or config.top_p is not None
-            or config.stop is not None
-            or config.seed is not None
-            or config.presence_penalty is not None
-            or config.frequency_penalty is not None
-            or config.fallbacks
-            or config.timeout is not None
-            or config.extra
-        ):
-            return self._http_fallback_backend
-
-        return self._backend
 
 
 @dataclass
@@ -412,82 +378,133 @@ class _ModelConfig:
 _VALID_BACKENDS = frozenset({"http", "realtime", "websocket"})
 
 
-def _get_model_config(model_id: ParsedModelId, *, backend: Optional[str] = None) -> _ModelConfig:
+def _get_model_config(
+    model_id: ParsedModelId,
+    *,
+    backend: Optional[str] = None,
+    config: Optional[LlmConfig] = None,
+) -> _ModelConfig:
     """Return the unified configuration for *model_id*.
 
     This is the **single source of truth** for backend routing, reasoning-effort
-    support, and supported OpenAI parameter lists.
+    support, supported OpenAI parameter lists, and config applicability.
 
     Args:
         model_id: Parsed model identifier.
         backend: Force a specific backend.  Raises ``ValueError`` if
             incompatible with the model or if the model is unsupported.
+        config: When provided, validate that every field is compatible with the
+            selected backend. Raises ``ValueError`` otherwise.
     """
+    # WebSocket models — opt-in via backend="websocket"; default is HTTP.
+    from litellm import get_supported_openai_params
+
+    litellm_model = str(model_id)
+    litellm_support = get_supported_openai_params(model=litellm_model)
+
     if backend is not None and backend not in _VALID_BACKENDS:
         raise ValueError(f"Invalid backend {backend!r}. Must be one of: {', '.join(sorted(_VALID_BACKENDS))}")
 
     # Realtime models — dedicated realtime backend, no override allowed.
-    if backend == "realtime" and not _is_realtime_model(model_id):
+    elif backend == "realtime" and not _is_realtime_model(model_id):
         raise ValueError(
             "Backend 'realtime' requires a realtime model"
             + f"(e.g. gpt-4o-realtime-preview), got {str(model_id)!r}"
         )
-    if backend is not None and backend != "realtime" and _is_realtime_model(model_id):
+    elif backend is not None and backend != "realtime" and _is_realtime_model(model_id):
         raise ValueError(f"Realtime model {str(model_id)!r} is incompatible with backend {backend!r}")
-    if _is_realtime_model(model_id):
-        return _ModelConfig(
+    elif _is_realtime_model(model_id):
+        mcfg = _ModelConfig(
             backend="realtime",
             supports_reasoning_effort=False,
             default_reasoning_effort=None,
         )
 
-    # WebSocket models — opt-in via backend="websocket"; default is HTTP.
-    from litellm import get_supported_openai_params
-
-    litellm_model = str(model_id)
-    if backend == "websocket" and not _is_websocket_model(model_id):
+    elif backend == "websocket" and not _is_websocket_model(model_id):
         raise ValueError(
             f"Backend 'websocket' requires a websocket-compatible model (e.g. gpt-5.2), got {str(model_id)!r}"
         )
-    if _is_websocket_model(model_id) and backend == "websocket":
+    elif _is_websocket_model(model_id) and backend == "websocket":
         ws_supported = get_supported_openai_params(model=litellm_model) or []
         ws_supports_reasoning = "reasoning_effort" in ws_supported
-        return _ModelConfig(
+        mcfg = _ModelConfig(
             backend="websocket",
             supports_reasoning_effort=ws_supports_reasoning,
             default_reasoning_effort="low" if ws_supports_reasoning else None,
         )
 
-    # Everything else — HTTP via LiteLLM.
+    elif litellm_support:
+        supports = "reasoning_effort" in litellm_support
+        default: Optional[str] = "low" if supports else None
+        if supports:
+            from litellm import get_llm_provider
+            from litellm.utils import get_optional_params
 
-    supported = get_supported_openai_params(model=litellm_model)
-    if supported is None:
+            try:
+                _, provider, _, _ = get_llm_provider(model=litellm_model)
+                get_optional_params(
+                    model=litellm_model, custom_llm_provider=provider, reasoning_effort="none"
+                )
+                default = "none"
+            except Exception:
+                # HACK: Anthropic's LiteLLM mapping annoyingly doesn't support `"none"` (the string) as a
+                # value for reasoning_effort, so None (omitting the param) is the correct way
+                # to skip the thinking block entirely; "low" would still enable a 1024-token
+                # thinking budget.
+                if model_id.provider == "anthropic":
+                    default = None
+
+        mcfg = _ModelConfig(
+            backend="http",
+            supports_reasoning_effort=supports,
+            default_reasoning_effort=default,
+        )
+
+    else:
         raise ValueError(
             f"Model {str(model_id)} is not supported. See https://models.litellm.ai/ for supported models."
         )
-    supports = "reasoning_effort" in supported
-    default: Optional[str] = "low" if supports else None
-    if supports:
-        from litellm import get_llm_provider
-        from litellm.utils import get_optional_params
 
-        try:
-            _, provider, _, _ = get_llm_provider(model=litellm_model)
-            get_optional_params(model=litellm_model, custom_llm_provider=provider, reasoning_effort="none")
-            default = "none"
-        except Exception:
-            # HACK: Anthropic's LiteLLM mapping annoyingly doesn't support `"none"` (the string) as a
-            # value for reasoning_effort, so None (omitting the param) is the correct way
-            # to skip the thinking block entirely; "low" would still enable a 1024-token
-            # thinking budget.
-            if model_id.provider == "anthropic":
-                default = None
+    _check_config_applicability(mcfg.backend, config)
+    return mcfg
 
-    return _ModelConfig(
-        backend="http",
-        supports_reasoning_effort=supports,
-        default_reasoning_effort=default,
-    )
+
+# LlmConfig fields the WebSocket (Responses API) backend cannot honor. Setting
+# temperature or top_p on the Responses endpoint causes it to close the
+# connection silently, and the rest have no equivalent in the Responses request
+# schema. Callers that need these must use the HTTP backend.
+_WEBSOCKET_INCOMPATIBLE_FIELDS = (
+    "temperature",
+    "top_p",
+    "stop",
+    "seed",
+    "presence_penalty",
+    "frequency_penalty",
+    "fallbacks",
+    "timeout",
+    "extra",
+)
+
+
+def _check_config_applicability(backend: str, config: Optional[LlmConfig]) -> None:
+    """Raise ``ValueError`` if *config* sets fields *backend* cannot honor."""
+    if config is None:
+        return
+    elif backend != "websocket":
+        return
+    violations: List[str] = []
+    for name in _WEBSOCKET_INCOMPATIBLE_FIELDS:
+        value = getattr(config, name)
+        if name in ("fallbacks", "extra"):
+            if value:
+                violations.append(name)
+        elif value is not None:
+            violations.append(name)
+    if violations:
+        raise ValueError(
+            f"The 'websocket' backend does not support LlmConfig field(s): {', '.join(violations)}. "
+            "Use backend='http' (the default) to send these to LiteLLM."
+        )
 
 
 def _is_openai_model(model_id: ParsedModelId) -> bool:

--- a/tests/real_api_test_provider.py
+++ b/tests/real_api_test_provider.py
@@ -41,7 +41,7 @@ import logging
 import os
 import pathlib
 import sys
-from typing import Annotated, TypedDict
+from typing import Annotated, Optional, TypedDict
 import warnings
 
 import litellm
@@ -135,13 +135,13 @@ async def add_to_order_broken(
 # =============================================================================
 
 
-async def test_api_key(model: str, api_key: str) -> bool:
+async def test_api_key(model: str, api_key: str, backend: Optional[str] = None) -> bool:
     """Test that API key is valid and has permissions."""
     print("\n" + "=" * 60)
-    print(f"Testing API key for {model}")
+    print(f"Testing API key for {model} (backend={backend})")
     print("=" * 60)
 
-    provider = LlmProvider(model=model, api_key=api_key)
+    provider = LlmProvider(model=model, api_key=api_key, backend=backend)
 
     messages = [Message(role="user", content="Say 'ok'")]
 
@@ -157,13 +157,13 @@ async def test_api_key(model: str, api_key: str) -> bool:
         return False
 
 
-async def test_streaming_text(model: str, api_key: str):
+async def test_streaming_text(model: str, api_key: str, backend: Optional[str] = None):
     """Test basic streaming text response."""
     print("\n" + "=" * 60)
-    print(f"Testing streaming text with {model}")
+    print(f"Testing streaming text with {model} (backend={backend})")
     print("=" * 60)
 
-    provider = LlmProvider(model=model, api_key=api_key)
+    provider = LlmProvider(model=model, api_key=api_key, backend=backend)
 
     messages = [Message(role="user", content="Say 'Hello, World!' and nothing else.")]
 
@@ -174,10 +174,10 @@ async def test_streaming_text(model: str, api_key: str):
     print("\n✓ Streaming text test passed")
 
 
-async def test_tool_calling(model: str, api_key: str):
+async def test_tool_calling(model: str, api_key: str, backend: Optional[str] = None):
     """Test tool calling with LlmAgent."""
     print("\n" + "=" * 60)
-    print(f"Testing tool calling with {model}")
+    print(f"Testing tool calling with {model} (backend={backend})")
     print("=" * 60)
 
     agent = LlmAgent(
@@ -187,6 +187,7 @@ async def test_tool_calling(model: str, api_key: str):
         config=LlmConfig(
             system_prompt="You are a helpful assistant. Use tools when needed.",
         ),
+        backend=backend,
     )
 
     env = TurnEnv()
@@ -217,10 +218,10 @@ async def test_tool_calling(model: str, api_key: str):
         print("⚠ No tools were called (model may have answered directly)")
 
 
-async def test_introduction(model: str, api_key: str):
+async def test_introduction(model: str, api_key: str, backend: Optional[str] = None):
     """Test introduction message on CallStarted."""
     print("\n" + "=" * 60)
-    print(f"Testing introduction with {model}")
+    print(f"Testing introduction with {model} (backend={backend})")
     print("=" * 60)
 
     agent = LlmAgent(
@@ -229,6 +230,7 @@ async def test_introduction(model: str, api_key: str):
         config=LlmConfig(
             introduction="Hello! I'm your AI assistant. How can I help you today?",
         ),
+        backend=backend,
     )
 
     env = TurnEnv()
@@ -244,13 +246,18 @@ async def test_introduction(model: str, api_key: str):
     print("✓ Introduction test passed")
 
 
-async def test_web_search(model: str, api_key: str, search_context_size: str = "medium"):
+async def test_web_search(
+    model: str,
+    api_key: str,
+    backend: Optional[str] = None,
+    search_context_size: str = "medium",
+):
     """Test web search tool integration."""
     print("\n" + "=" * 60)
     if search_context_size != "medium":
-        print(f"Testing web search with {model} (context_size={search_context_size}")
+        print(f"Testing web search with {model} (backend={backend}, context_size={search_context_size})")
     else:
-        print(f"Testing web search with {model}")
+        print(f"Testing web search with {model} (backend={backend})")
     print("=" * 60)
 
     agent = LlmAgent(
@@ -261,6 +268,7 @@ async def test_web_search(model: str, api_key: str, search_context_size: str = "
             system_prompt="You are a helpful assistant with web search capabilities."
             + " Use web search to find current information.",
         ),
+        backend=backend,
     )
 
     env = TurnEnv()
@@ -295,7 +303,7 @@ async def test_web_search(model: str, api_key: str, search_context_size: str = "
     print("✓ Web search test completed")
 
 
-async def test_function_tools_with_web_search(model: str, api_key: str):
+async def test_function_tools_with_web_search(model: str, api_key: str, backend: Optional[str] = None):
     """Test combining function calling tools with web search.
 
     This reproduces the scenario from examples/basic_chat/main.py where
@@ -304,7 +312,7 @@ async def test_function_tools_with_web_search(model: str, api_key: str):
     with function calling tools in the same request.
     """
     print("\n" + "=" * 60)
-    print(f"Testing function tools + web search with {model}")
+    print(f"Testing function tools + web search with {model} (backend={backend})")
     print("=" * 60)
 
     agent = LlmAgent(
@@ -315,6 +323,7 @@ async def test_function_tools_with_web_search(model: str, api_key: str):
             system_prompt="You are a helpful assistant. Use web search when needed. "
             "Use end_call when the user says goodbye.",
         ),
+        backend=backend,
     )
 
     env = TurnEnv()
@@ -346,10 +355,10 @@ def _local_mcp_server_command() -> str:
     return f"{sys.executable} {server_path}"
 
 
-async def test_mcp_list_tools(model: str, api_key: str):
+async def test_mcp_list_tools(model: str, api_key: str, backend: Optional[str] = None):
     """Test MCP tool listing with the local test MCP server."""
     print(f"\n{'=' * 60}")
-    print(f"Testing MCP tool listing with {model}")
+    print(f"Testing MCP tool listing with {model} (backend={backend})")
     print("=" * 60)
 
     agent = LlmAgent(
@@ -365,6 +374,7 @@ async def test_mcp_list_tools(model: str, api_key: str):
             system_prompt="You are a helpful assistant with access to an MCP server. "
             "Use the available tools when asked.",
         ),
+        backend=backend,
     )
 
     env = TurnEnv()
@@ -397,10 +407,10 @@ async def test_mcp_list_tools(model: str, api_key: str):
         print("⚠ MCP tool was not called (model may have answered directly)")
 
 
-async def test_mcp_tool_execution(model: str, api_key: str):
+async def test_mcp_tool_execution(model: str, api_key: str, backend: Optional[str] = None):
     """Test MCP tool execution with the local test MCP server."""
     print(f"\n{'=' * 60}")
-    print(f"Testing MCP tool execution with {model}")
+    print(f"Testing MCP tool execution with {model} (backend={backend})")
     print("=" * 60)
 
     agent = LlmAgent(
@@ -416,6 +426,7 @@ async def test_mcp_tool_execution(model: str, api_key: str):
             system_prompt="You are a helpful assistant with access to an MCP server. "
             "First list available tools, then use them as requested.",
         ),
+        backend=backend,
     )
 
     env = TurnEnv()
@@ -449,7 +460,7 @@ async def test_mcp_tool_execution(model: str, api_key: str):
     print("✓ MCP tool execution test completed")
 
 
-async def test_conversation_reset(model: str, api_key: str):
+async def test_conversation_reset(model: str, api_key: str, backend: Optional[str] = None):
     """Test resetting a conversation to an earlier point.
 
     Exercises the WebSocket provider's divergence detection by:
@@ -461,10 +472,10 @@ async def test_conversation_reset(model: str, api_key: str):
        the provider rolled back correctly.
     """
     print("\n" + "=" * 60)
-    print(f"Testing conversation reset with {model}")
+    print(f"Testing conversation reset with {model} (backend={backend})")
     print("=" * 60)
 
-    provider = LlmProvider(model=model, api_key=api_key)
+    provider = LlmProvider(model=model, api_key=api_key, backend=backend)
 
     async def collect_text(stream) -> str:
         parts = []
@@ -524,7 +535,7 @@ async def test_conversation_reset(model: str, api_key: str):
         raise AssertionError(f"Branch B failed — expected 'giraffe', got: {response_b.strip()!r}")
 
 
-async def test_nested_objects(model: str, api_key: str):
+async def test_nested_objects(model: str, api_key: str, backend: Optional[str] = None):
     """Test tool calling with nested objects using TypedDict.
 
     This test validates that:
@@ -536,7 +547,7 @@ async def test_nested_objects(model: str, api_key: str):
     shapes fail at conversion before any API call.
     """
     print("\n" + "=" * 60)
-    print(f"Testing nested objects (TypedDict) with {model}")
+    print(f"Testing nested objects (TypedDict) with {model} (backend={backend})")
     print("=" * 60)
 
     agent = LlmAgent(
@@ -554,6 +565,7 @@ Available menu items:
 
 Always include menu_item_id, quantity, and modifiers (can be empty list).""",
         ),
+        backend=backend,
     )
 
     env = TurnEnv()
@@ -617,14 +629,14 @@ Always include menu_item_id, quantity, and modifiers (can be empty list).""",
             return False
 
 
-async def test_nested_objects_without_typeddict(model: str, api_key: str):
+async def test_nested_objects_without_typeddict(model: str, api_key: str, backend: Optional[str] = None):
     """list[dict] under default strict schemas raises at conversion; opt-out path still works.
 
     First asserts ``function_tool_to_litellm(..., strict=True)`` raises. Then runs the agent
     with ``LlmConfig(strict_tool_schemas=False)`` so non-strict tool definitions are allowed.
     """
     print("\n" + "=" * 60)
-    print(f"Testing nested objects WITHOUT TypedDict (list[dict]) with {model}")
+    print(f"Testing nested objects WITHOUT TypedDict (list[dict]) with {model} (backend={backend})")
     print("=" * 60)
 
     with warnings.catch_warnings():
@@ -663,6 +675,7 @@ Available menu items:
 
 Always include menu_item_id and quantity.""",
             ),
+            backend=backend,
         )
 
     env = TurnEnv()
@@ -717,16 +730,20 @@ Always include menu_item_id and quantity.""",
 # Main
 # =============================================================================
 
-MODELS = [
-    ("OPENAI_API_KEY", "openai/gpt-5.2"),
-    ("OPENAI_API_KEY", "openai/gpt-5.4"),
-    ("OPENAI_API_KEY", "openai/gpt-5.4-mini"),
-    ("OPENAI_API_KEY", "openai/gpt-5.4-nano"),
-    ("OPENAI_API_KEY", "openai/gpt-realtime"),
-    ("ANTHROPIC_API_KEY", "anthropic/claude-haiku-4-5"),
-    ("GEMINI_API_KEY", "gemini/gemini-2.5-flash"),
-    ("GEMINI_API_KEY", "gemini/gemini-3-flash-preview"),
-    ("OPENAI_API_KEY", "openai/gpt-4.1"),
+MODELS: list[tuple[str, str, Optional[str]]] = [
+    ("OPENAI_API_KEY", "openai/gpt-5.2", "http"),
+    ("OPENAI_API_KEY", "openai/gpt-5.2", "websocket"),
+    ("OPENAI_API_KEY", "openai/gpt-5.4", "http"),
+    ("OPENAI_API_KEY", "openai/gpt-5.4", "websocket"),
+    ("OPENAI_API_KEY", "openai/gpt-5.4-mini", "http"),
+    ("OPENAI_API_KEY", "openai/gpt-5.4-mini", "websocket"),
+    ("OPENAI_API_KEY", "openai/gpt-5.4-nano", "http"),
+    ("OPENAI_API_KEY", "openai/gpt-5.4-nano", "websocket"),
+    ("OPENAI_API_KEY", "openai/gpt-realtime", "realtime"),
+    ("ANTHROPIC_API_KEY", "anthropic/claude-haiku-4-5", "http"),
+    ("GEMINI_API_KEY", "gemini/gemini-2.5-flash", "http"),
+    ("GEMINI_API_KEY", "gemini/gemini-3-flash-preview", "http"),
+    ("OPENAI_API_KEY", "openai/gpt-4.1", "http"),
 ]
 
 # Available test names
@@ -794,36 +811,36 @@ async def main(args):
     print(f"Eval iterations: {args.runs}")
 
     # Find available models
-    available = []
-    for env_var, model in MODELS:
+    available: list[tuple[str, str, Optional[str]]] = []
+    for env_var, model, backend in MODELS:
         if args.model and model != args.model:
             continue
         if os.getenv(env_var):
-            available.append((env_var, model))
-            print(f"✓ {env_var} found - will test {model}")
+            available.append((env_var, model, backend))
+            print(f"✓ {env_var} found - will test {model} (backend={backend})")
         else:
-            print(f"✗ {env_var} not set - skipping {model}")
+            print(f"✗ {env_var} not set - skipping {model} (backend={backend})")
 
     if not available:
         print("\n⚠ No API keys found. Set at least one of:")
-        for env_var, _model in MODELS:
+        for env_var, _model, _backend in MODELS:
             print(f"  export {env_var}=your-key-here")
         return 1
 
-    failures: list[tuple[str, str, str]] = []  # (model, test_name, error)
+    failures: list[tuple[str, Optional[str], str, str]] = []  # (model, backend, test_name, error)
 
     # First, validate all API keys
     print("\n" + "=" * 60)
     print("PHASE 1: Validating API Keys")
     print("=" * 60)
 
-    valid_models = []
-    for env_var, model in available:
+    valid_models: list[tuple[str, str, Optional[str]]] = []
+    for env_var, model, backend in available:
         api_key = os.environ[env_var]
-        if await test_api_key(model, api_key):
-            valid_models.append((env_var, model))
+        if await test_api_key(model, api_key, backend):
+            valid_models.append((env_var, model, backend))
         else:
-            failures.append((model, "api_key", "API key validation failed"))
+            failures.append((model, backend, "api_key", "API key validation failed"))
 
     if not valid_models:
         print("\n⚠ No valid API keys. Check your keys and permissions.")
@@ -834,47 +851,49 @@ async def main(args):
         print("PHASE 2: Running Full Tests")
         print("=" * 60)
 
-    for env_var, model in valid_models:
+    for env_var, model, backend in valid_models:
         api_key = os.environ[env_var]
 
         test_plan: list[tuple[str, ...]] = []
         if "streaming" in tests_to_run:
-            test_plan.append(("streaming", test_streaming_text, model, api_key))
+            test_plan.append(("streaming", test_streaming_text, model, api_key, backend))
         if "introduction" in tests_to_run:
-            test_plan.append(("introduction", test_introduction, model, api_key))
+            test_plan.append(("introduction", test_introduction, model, api_key, backend))
         if "tools" in tests_to_run:
-            test_plan.append(("tools", test_tool_calling, model, api_key))
+            test_plan.append(("tools", test_tool_calling, model, api_key, backend))
         if "nested_objects" in tests_to_run:
-            test_plan.append(("nested_objects", test_nested_objects, model, api_key))
+            test_plan.append(("nested_objects", test_nested_objects, model, api_key, backend))
         if "nested_objects_fail" in tests_to_run:
-            test_plan.append(("nested_objects_fail", test_nested_objects_without_typeddict, model, api_key))
+            test_plan.append(
+                ("nested_objects_fail", test_nested_objects_without_typeddict, model, api_key, backend)
+            )
         if "web_search" in tests_to_run:
-            test_plan.append(("web_search", test_web_search, model, api_key))
-            test_plan.append(("web_search (high)", test_web_search, model, api_key, "high"))
+            test_plan.append(("web_search", test_web_search, model, api_key, backend))
+            test_plan.append(("web_search (high)", test_web_search, model, api_key, backend, "high"))
         if "web_search_fn" in tests_to_run:
-            test_plan.append(("web_search_fn", test_function_tools_with_web_search, model, api_key))
+            test_plan.append(("web_search_fn", test_function_tools_with_web_search, model, api_key, backend))
         if "mcp" in tests_to_run:
-            test_plan.append(("mcp_list_tools", test_mcp_list_tools, model, api_key))
-            test_plan.append(("mcp_tool_execution", test_mcp_tool_execution, model, api_key))
+            test_plan.append(("mcp_list_tools", test_mcp_list_tools, model, api_key, backend))
+            test_plan.append(("mcp_tool_execution", test_mcp_tool_execution, model, api_key, backend))
         if "reset" in tests_to_run:
-            test_plan.append(("reset", test_conversation_reset, model, api_key))
+            test_plan.append(("reset", test_conversation_reset, model, api_key, backend))
 
         for test_entry in test_plan:
             test_name, test_fn, *test_args = test_entry
             try:
                 await test_fn(*test_args)
             except Exception as e:
-                print(f"\n✗ Error in {test_name} for {model}: {e}")
+                print(f"\n✗ Error in {test_name} for {model} (backend={backend}): {e}")
                 import traceback
 
                 traceback.print_exc()
-                failures.append((model, test_name, str(e)))
+                failures.append((model, backend, test_name, str(e)))
 
     print("\n" + "=" * 60)
     if failures:
         print(f"DONE — {len(failures)} failure(s):")
-        for model, test_name, error in failures:
-            print(f"  ✗ {model} / {test_name}: {error}")
+        for model, backend, test_name, error in failures:
+            print(f"  ✗ {model} [backend={backend}] / {test_name}: {error}")
     else:
         print("All tests passed!")
     print("=" * 60)

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -190,7 +190,7 @@ def turn_env():
 # =============================================================================
 
 
-def _unsupported_model_config(model_id):
+def _unsupported_model_config(model_id, *, backend=None):
     return None
 
 
@@ -207,7 +207,7 @@ async def test_init_rejects_unsupported_model(monkeypatch, anyio_backend):
 async def test_init_accepts_direct_openai_websocket_model(monkeypatch, anyio_backend):
     """Direct OpenAI WebSocket models stay accepted even if LiteLLM doesn't know them yet."""
 
-    def _ws_or_unsupported(model_id):
+    def _ws_or_unsupported(model_id, *, backend=None):
         if model_id.model == "gpt-5-mini":
             return _ModelConfig(
                 backend="websocket",
@@ -226,7 +226,7 @@ async def test_init_rejects_unsupported_reasoning_effort(monkeypatch, anyio_back
     """Test that reasoning_effort is rejected for models that do not support it."""
     monkeypatch.setattr(
         "line.llm_agent.llm_agent._get_model_config",
-        lambda model_id: _ModelConfig(
+        lambda model_id, *, backend=None: _ModelConfig(
             backend="http",
             supports_reasoning_effort=False,
             default_reasoning_effort=None,

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -184,64 +184,85 @@ def test_llm_provider_warmup_preserves_native_web_search_defaults(monkeypatch):
     assert backend.warmup_calls[0]["kwargs"]["web_search_options"] == {"search_context_size": "high"}
 
 
-def test_llm_provider_routes_websocket_models_with_unsupported_config_to_http_backend():
+def test_llm_provider_rejects_websocket_incompatible_config_at_chat():
     provider = LlmProvider(
         model="openai/gpt-5.2",
         api_key="test-key",
         backend="websocket",
     )
     websocket_backend = _DummyBackend()
-    http_backend = _DummyBackend()
     provider._backend = websocket_backend
-    provider._http_fallback_backend = http_backend
 
-    result = provider.chat(
-        [Message(role="user", content="hi")],
-        config=LlmConfig(stop=["DONE"]),
-    )
+    try:
+        provider.chat(
+            [Message(role="user", content="hi")],
+            config=LlmConfig(stop=["DONE"]),
+        )
+    except ValueError as exc:
+        assert "websocket" in str(exc).lower()
+        assert "stop" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for websocket-incompatible config")
 
-    assert result == "ok"
     assert len(websocket_backend.calls) == 0
-    assert len(http_backend.calls) == 1
 
 
-def test_llm_provider_routes_temperature_to_http_backend():
+def test_llm_provider_rejects_temperature_on_websocket_backend():
     """temperature/top_p cause the OpenAI WebSocket endpoint to close silently,
-    so they must route to the HTTP fallback."""
+    so they must be rejected up-front."""
     provider = LlmProvider(
         model="openai/gpt-5.2",
         api_key="test-key",
         backend="websocket",
     )
     websocket_backend = _DummyBackend()
-    http_backend = _DummyBackend()
     provider._backend = websocket_backend
-    provider._http_fallback_backend = http_backend
 
-    provider.chat(
-        [Message(role="user", content="hi")],
-        config=LlmConfig(temperature=0.2, top_p=0.9),
-    )
+    try:
+        provider.chat(
+            [Message(role="user", content="hi")],
+            config=LlmConfig(temperature=0.2, top_p=0.9),
+        )
+    except ValueError as exc:
+        assert "temperature" in str(exc)
+        assert "top_p" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for websocket-incompatible config")
 
     assert len(websocket_backend.calls) == 0
-    assert len(http_backend.calls) == 1
 
 
-def test_llm_provider_warmup_routes_unsupported_websocket_config_to_http_backend():
+def test_llm_provider_warmup_rejects_websocket_incompatible_config():
     provider = LlmProvider(
         model="openai/gpt-5.2",
         api_key="test-key",
         backend="websocket",
     )
     websocket_backend = _DummyBackend()
-    http_backend = _DummyBackend()
     provider._backend = websocket_backend
-    provider._http_fallback_backend = http_backend
 
-    asyncio.run(provider.warmup(config=LlmConfig(extra={"service_tier": "flex"})))
+    try:
+        asyncio.run(provider.warmup(config=LlmConfig(extra={"service_tier": "flex"})))
+    except ValueError as exc:
+        assert "extra" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for websocket-incompatible config")
 
     assert len(websocket_backend.warmup_calls) == 0
-    assert len(http_backend.warmup_calls) == 1
+
+
+def test_llm_provider_rejects_websocket_incompatible_base_config_at_init():
+    try:
+        LlmProvider(
+            model="openai/gpt-5.2",
+            api_key="test-key",
+            backend="websocket",
+            config=LlmConfig(temperature=0.2),
+        )
+    except ValueError as exc:
+        assert "temperature" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for websocket-incompatible base config")
 
 
 def test_extract_instructions_includes_config_system_prompt():

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -188,6 +188,7 @@ def test_llm_provider_routes_websocket_models_with_unsupported_config_to_http_ba
     provider = LlmProvider(
         model="openai/gpt-5.2",
         api_key="test-key",
+        backend="websocket",
     )
     websocket_backend = _DummyBackend()
     http_backend = _DummyBackend()
@@ -210,6 +211,7 @@ def test_llm_provider_routes_temperature_to_http_backend():
     provider = LlmProvider(
         model="openai/gpt-5.2",
         api_key="test-key",
+        backend="websocket",
     )
     websocket_backend = _DummyBackend()
     http_backend = _DummyBackend()
@@ -229,6 +231,7 @@ def test_llm_provider_warmup_routes_unsupported_websocket_config_to_http_backend
     provider = LlmProvider(
         model="openai/gpt-5.2",
         api_key="test-key",
+        backend="websocket",
     )
     websocket_backend = _DummyBackend()
     http_backend = _DummyBackend()
@@ -310,7 +313,7 @@ def test_is_supported_model_accepts_direct_openai_websocket_model(monkeypatch):
     import litellm
 
     monkeypatch.setattr(litellm, "get_supported_openai_params", lambda model: None)
-    assert _get_model_config(parse_model_id("openai/gpt-5.2")) is not None
+    assert _get_model_config(parse_model_id("openai/gpt-5.2"), backend="websocket") is not None
 
 
 def test_backend_override_http_for_websocket_model():
@@ -365,7 +368,7 @@ class TestGetModelConfig:
 
     def test_websocket_model_selects_websocket_backend(self):
         cfg = _get_model_config(parse_model_id("openai/gpt-5.2"))
-        assert cfg.backend == "websocket"
+        assert cfg.backend == "http"
 
     def test_websocket_model_with_http_override_selects_http(self):
         cfg = _get_model_config(parse_model_id("openai/gpt-5.2"), backend="http")
@@ -428,7 +431,7 @@ class TestGetModelConfig:
 
     def test_websocket_model_with_reasoning_support(self):
         """Reasoning models (e.g. o3) routed via websocket get reasoning enabled."""
-        cfg = _get_model_config(parse_model_id("openai/gpt-5.2"))
+        cfg = _get_model_config(parse_model_id("openai/gpt-5.2"), backend="websocket")
         assert cfg.backend == "websocket"
         assert cfg.supports_reasoning_effort is True
         assert cfg.default_reasoning_effort == "low"


### PR DESCRIPTION
## What does this PR do?

Make `backend` an explicit pararmeter, and always default to `"http"`, no matter the model.


## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: Pareto tradeoff

## Testing
Unit/Integration tests.

## Checklist
- [ ] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backend routing defaults and removes the automatic HTTP fallback for WebSocket models, so some existing calls may now raise `ValueError` instead of working. Risk is moderate because it affects provider selection and request-time config validation across LlmAgent/LlmProvider.
> 
> **Overview**
> **WebSocket backend is now opt-in.** `LlmAgent`/`LlmProvider` accept an optional `backend` override and `_get_model_config` defaults websocket-capable models to **HTTP** unless `backend="websocket"` is explicitly requested.
> 
> **Removed WebSocket→HTTP fallback and added strict validation.** The provider no longer silently routes websocket-incompatible `LlmConfig` fields to an HTTP fallback; instead `_get_model_config(..., config=...)` enforces compatibility at init and per-call (`chat`/`warmup`) and raises clear errors listing unsupported fields.
> 
> Tests and the real API test harness were updated to pass `backend` explicitly and to assert the new rejection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf75a9cf0445e372317b5cebfbe7fd83c26b77d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->