### PR TITLE
Bump version to 0.2.9

### DIFF
--- a/example_integrations/browserbase/pyproject.toml
+++ b/example_integrations/browserbase/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Voice agent that fills web forms using Stagehand browser automation (Line SDK)"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
     "stagehand>=3.0.0",
     "google-genai>=1.26.0",
     "loguru>=0.7.0",

--- a/example_integrations/cerebras/pyproject.toml
+++ b/example_integrations/cerebras/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "An interviewer agent using Cerebras via LiteLLM with Line SDK v0.2"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
     "python-dotenv>=1.0.0",
     "loguru>=0.7.0",
     "pydantic>=2.0.0",

--- a/example_integrations/exa/pyproject.toml
+++ b/example_integrations/exa/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A web research voice agent using Exa API and Cartesia Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
     "exa-py>=1.0.0",
     "loguru>=0.7.0",
     "python-dotenv>=1.0.0",

--- a/examples/basic_chat/pyproject.toml
+++ b/examples/basic_chat/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Basic chat example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
     "loguru>=0.7.0",
 ]
 

--- a/examples/chat_supervisor/pyproject.toml
+++ b/examples/chat_supervisor/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Chat/Supervisor example: A fast Haiku agent that consults Opus for complex questions"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
 ]
 
 [tool.setuptools]

--- a/examples/echo/pyproject.toml
+++ b/examples/echo/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Handoff echo example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
     "loguru>=0.7.0",
 ]
 

--- a/examples/form_filler/pyproject.toml
+++ b/examples/form_filler/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Voice agent that helps patients schedule doctor appointments and complete intake forms."
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
     "loguru>=0.7.0",
 ]
 

--- a/examples/guardrails_wrapper/pyproject.toml
+++ b/examples/guardrails_wrapper/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Guardrails wrapper example - LLM agent with preprocessing/postprocessing for content filtering"
 requires-python = ">=3.10"
 dependencies = [
-   "cartesia-line==0.2.8",
+   "cartesia-line==0.2.9",
 ]
 
 [tool.setuptools]

--- a/examples/sales_with_leads/pyproject.toml
+++ b/examples/sales_with_leads/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Sales agent with stateful leads extraction and company research"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
     "loguru>=0.7.0",
 ]
 

--- a/examples/transfer_agent/pyproject.toml
+++ b/examples/transfer_agent/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Multi-agent handoff example demonstrating agent-to-agent transfers using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
 ]
 
 [tool.setuptools]

--- a/examples/transfer_phone_call/pyproject.toml
+++ b/examples/transfer_phone_call/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Phone transfer example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.8",
+    "cartesia-line==0.2.9",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cartesia-line"
-version = "0.2.8"
+version = "0.2.9"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Bump `cartesia-line` to 0.2.9 and pin example/integration projects to the new release.

## Changes since 0.2.8
- Make websocket backend opt-in only (#217)
- [VA-507] Updating litellm dependency and adding more tests (#213)
- Fix "real API" provider tests (#216)
- Enforce case sensitivity for realtime/websocket model lookup (#214)
- Fix silent failures in WebSocket stream handling (#215)

## Test plan
- [x] CI passes
- [x] Verify \`pyproject.toml\` version is \`0.2.9\` and every example pins \`cartesia-line==0.2.9\`