### PR TITLE
Forward "multilingual" sentinel in AgentUpdateCall

### DIFF
--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -686,11 +686,6 @@ class ConversationRunner:
                 responding_to=event.responding_to,
             )
         if isinstance(event, AgentUpdateCall):
-            # "multilingual" is a special sentinel: STT gets None (auto-detect),
-            # TTS gets None (use voice default language).
-            is_multilingual = event.language == "multilingual"
-            effective_language = None if is_multilingual else event.language
-
             logger.info(
                 f"<- ⚙️ Update call: voice_id={event.voice_id}, "
                 f"pronunciation_dict_id={event.pronunciation_dict_id}, "
@@ -700,10 +695,10 @@ class ConversationRunner:
                 tts=TTSConfig(
                     voice_id=event.voice_id,
                     pronunciation_dict_id=event.pronunciation_dict_id,
-                    language=effective_language,
+                    language=event.language,
                 ),
-                stt=STTConfig(language=effective_language) if event.language is not None else None,
-                language=effective_language,
+                stt=STTConfig(language=event.language) if event.language is not None else None,
+                language=event.language,
                 responding_to=event.responding_to,
             )
         if isinstance(event, AgentSendCustom):

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -1198,13 +1198,13 @@ class TestUpdateCallMapping:
         assert result.stt is not None
         assert result.stt.language == "fr"
 
-    def test_multilingual_sets_both_to_none(self):
-        """language='multilingual' maps to None for both STT and TTS."""
+    def test_multilingual_forwards_sentinel(self):
+        """language='multilingual' forwards the sentinel verbatim on all three fields."""
         result = self._map(AgentUpdateCall(language="multilingual"))
-        assert result.tts.language is None
+        assert result.tts.language == "multilingual"
         assert result.stt is not None
-        assert result.stt.language is None
-        assert result.language is None
+        assert result.stt.language == "multilingual"
+        assert result.language == "multilingual"
 
     def test_all_none_defaults(self):
         """No fields set -> TTS language None, STT config None (no change)."""


### PR DESCRIPTION
## What does this PR do?

`AgentUpdateCall(language="multilingual")` is currently a no-op on the server for both TTS and STT. We collapse the sentinel to `None` on the wire, which means the language is never actually reset.

Forward `event.language` verbatim instead and let the server resolve the sentinel per provider.

## Type of change
- [x] Bug fix

## Testing
- Unit tests