### PR TITLE
Bump version to 0.2.10a0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cartesia-line"
-version = "0.2.9a0"
+version = "0.2.10a0"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cartesia-line"
-version = "0.2.9"
+version = "0.2.9a0"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What does this PR do?
[Forward "multilingual" sentinel in AgentUpdateCall (](https://github.com/cartesia-ai/line/commit/b009b728e8821581f5a46ab9375a48d38a65ae51)https://github.com/cartesia-ai/line/pull/219[)](https://github.com/cartesia-ai/line/commit/b009b728e8821581f5a46ab9375a48d38a65ae51)
[[VA-496] Adding interruptible configuration to Transfer and EndCall tools (](https://github.com/cartesia-ai/line/commit/5e98dd4f5e05c835fadb6752b4aa19a6f4466e97)https://github.com/cartesia-ai/line/pull/210[)](https://github.com/cartesia-ai/line/commit/5e98dd4f5e05c835fadb6752b4aa19a6f4466e97)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How did you test this?

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a package metadata-only change updating the published version, with no runtime or behavior changes.
> 
> **Overview**
> Bumps the project version in `pyproject.toml` from `0.2.9` to `0.2.10a0` for the next pre-release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d414364e2ef68d2ad2afc3d9dda72aaa9015cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->