### PR TITLE
Add Knowledge Base querying support to line SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ async def get_agent(env: AgentEnv, call_request: CallRequest):
 Ready-to-use tools for common actions:
 
 ```python
-from line.llm_agent import LlmAgent, LlmConfig, end_call, send_dtmf, transfer_call, web_search
+from line.llm_agent import LlmAgent, LlmConfig, end_call, knowledge_base, send_dtmf, transfer_call, web_search
 
 agent = LlmAgent(
     model="gemini/gemini-2.5-flash-preview-09-2025",
-    tools=[end_call, send_dtmf, transfer_call, web_search],
+    tools=[end_call, send_dtmf, transfer_call, web_search, knowledge_base],
     config=LlmConfig(...),
 )
 ```
@@ -136,6 +136,7 @@ agent = LlmAgent(
 | `send_dtmf` | Presses phone buttons (0-9, *, #) |
 | `transfer_call` | Transfers to a phone number (E.164 format) |
 | `web_search` | Searches the web (native LLM search or DuckDuckGo fallback) |
+| `knowledge_base` | Looks up information from the agent's knowledge base via natural-language query. Call `knowledge_base(filters={...}, top_k=10)` to pre-filter retrievals or override `top_k` |
 
 ### Loopback Tools — Fetch Data & Call APIs
 

--- a/examples/basic_chat/main.py
+++ b/examples/basic_chat/main.py
@@ -2,7 +2,7 @@ import os
 
 from loguru import logger
 
-from line.llm_agent import LlmAgent, LlmConfig, web_search
+from line.llm_agent import LlmAgent, LlmConfig, knowledge_base
 from line.voice_agent_app import AgentEnv, CallRequest, VoiceAgentApp
 
 #  ANTHROPIC_API_KEY=your-key uv python main.py
@@ -64,7 +64,7 @@ async def get_agent(env: AgentEnv, call_request: CallRequest):
     return LlmAgent(
         model="anthropic/claude-haiku-4-5-20251001",
         api_key=os.getenv("ANTHROPIC_API_KEY"),
-        tools=[web_search],
+        tools=[knowledge_base],
         config=LlmConfig.from_call_request(
             call_request, fallback_system_prompt=SYSTEM_PROMPT, fallback_introduction=INTRODUCTION
         ),

--- a/examples/basic_chat/pyproject.toml
+++ b/examples/basic_chat/pyproject.toml
@@ -10,3 +10,6 @@ dependencies = [
 
 [tool.setuptools]
 py-modules = ["main"]
+
+[tool.uv.sources]
+cartesia-line = { path = "../../", editable=true }

--- a/line/__init__.py
+++ b/line/__init__.py
@@ -41,6 +41,7 @@ from line.events import (
     UserTurnEnded,
     UserTurnStarted,
 )
+from line.knowledge_base import KnowledgeBase, KnowledgeBaseError
 from line.voice_agent_app import (
     AgentConfig,
     AgentEnv,
@@ -96,6 +97,9 @@ __all__ = [
     "CustomHistoryEntry",
     # History
     "HistoryEvent",
+    # Knowledge base
+    "KnowledgeBase",
+    "KnowledgeBaseError",
     # Utilities
     "word_buffer",
 ]

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -186,5 +186,13 @@ class StartInput(BaseModel):
     agent_call_id: str = "unknown"
     agent: Dict[str, Any] = Field(default_factory=dict)
     metadata: Optional[Dict[str, Any]] = None
+    # Agent-scoped JWT minted by the API. Forwarded by inferno so agent code
+    # can authenticate calls back to the API on behalf of the agent (e.g.
+    # knowledge base document queries).
+    agent_token: Optional[str] = None
+    # Base URL for callbacks to the Cartesia API. Forwarded by inferno so
+    # the agent uses the same API endpoint that minted its credentials,
+    # rather than guessing via env var or a hardcoded prod default.
+    api_base_url: Optional[str] = None
 
     model_config = ConfigDict(populate_by_name=True)

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -186,11 +186,11 @@ class StartInput(BaseModel):
     agent_call_id: str = "unknown"
     agent: Dict[str, Any] = Field(default_factory=dict)
     metadata: Optional[Dict[str, Any]] = None
-    # Agent-scoped JWT minted by the API. Forwarded by inferno so agent code
-    # can authenticate calls back to the API on behalf of the agent (e.g.
+    # Agent-scoped JWT minted by the API. Forwarded by the harness so agent
+    # code can authenticate calls back to the API on behalf of the agent (e.g.
     # knowledge base document queries).
     agent_token: Optional[str] = None
-    # Base URL for callbacks to the Cartesia API. Forwarded by inferno so
+    # Base URL for callbacks to the Cartesia API. Forwarded by the harness so
     # the agent uses the same API endpoint that minted its credentials,
     # rather than guessing via env var or a hardcoded prod default.
     api_base_url: Optional[str] = None

--- a/line/agent.py
+++ b/line/agent.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import AsyncIterable, Callable, Protocol, Sequence, Union
+import asyncio
+from typing import AsyncIterable, Callable, Optional, Protocol, Sequence, Union
 
 from line.events import InputEvent, OutputEvent
 
@@ -25,10 +26,18 @@ EventFilter = Union[Callable[[InputEvent], bool], Sequence[type[InputEvent]]]
 AgentSpec = Union[Agent, tuple[Agent, EventFilter, EventFilter]]
 
 
-# Intentionally empty for now
-# We can add more context here later as needed.
+class AgentEnv:
+    """Per-call environment created by the harness once per websocket connection."""
+
+    def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None):
+        self.loop = loop
+
+
 class TurnEnv:
-    pass
+    """Per-turn environment passed to agents and tools."""
+
+    def __init__(self, agent_env: AgentEnv):
+        self.agent_env = agent_env
 
 
 def call_agent(agent: Agent, turn_env: TurnEnv, event: InputEvent) -> AsyncIterable[OutputEvent]:

--- a/line/agent.py
+++ b/line/agent.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import AsyncIterable, Callable, Optional, Protocol, Sequence, Union
 
 from line.events import InputEvent, OutputEvent
+from line.knowledge_base import KnowledgeBase
 
 
 # Equivalent to a constructor type in TS where a class provides a process method.
@@ -27,17 +28,46 @@ AgentSpec = Union[Agent, tuple[Agent, EventFilter, EventFilter]]
 
 
 class AgentEnv:
-    """Per-call environment created by the harness once per websocket connection."""
+    """Per-call environment created by the harness once per websocket connection.
 
-    def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None):
+    Owns the long-lived, call-scoped data: the asyncio loop and the
+    agent-scoped credentials needed to call back into the Cartesia API on
+    behalf of the agent (e.g. for knowledge base queries).
+    """
+
+    def __init__(
+        self,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        agent_id: Optional[str] = None,
+        agent_token: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ):
         self.loop = loop
+        self.agent_id = agent_id
+        self.agent_token = agent_token
+        self.base_url = base_url
+
+    def knowledge_base(self) -> KnowledgeBase:
+        """Return a KnowledgeBase client scoped to the calling agent."""
+        return KnowledgeBase(
+            agent_id=self.agent_id,
+            agent_token=self.agent_token,
+            base_url=self.base_url,
+        )
 
 
 class TurnEnv:
-    """Per-turn environment passed to agents and tools."""
+    """Per-turn environment passed to agents and tools.
+
+    Holds a reference to the call's `AgentEnv` and delegates call-scoped
+    operations (like knowledge base lookups) to it.
+    """
 
     def __init__(self, agent_env: AgentEnv):
         self.agent_env = agent_env
+
+    def knowledge_base(self) -> KnowledgeBase:
+        return self.agent_env.knowledge_base()
 
 
 def call_agent(agent: Agent, turn_env: TurnEnv, event: InputEvent) -> AsyncIterable[OutputEvent]:

--- a/line/knowledge_base.py
+++ b/line/knowledge_base.py
@@ -1,0 +1,97 @@
+"""Knowledge base client for querying agent-scoped documents via the Cartesia API."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+from loguru import logger
+
+DEFAULT_BASE_URL = "https://api.cartesia.ai"
+DEFAULT_TOP_K = 5
+DEFAULT_TIMEOUT_S = 3.0
+LOG_TRUNCATION = 500
+
+
+class KnowledgeBaseError(RuntimeError):
+    """Raised when a knowledge base query fails."""
+
+
+class KnowledgeBase:
+    """Client for the agent knowledge base query endpoint.
+
+    Calls `GET /agents/{agent_id}/documents/query` with the agent-scoped
+    JWT minted by the Cartesia API at session start.
+    """
+
+    def __init__(
+        self,
+        agent_id: Optional[str],
+        agent_token: Optional[str],
+        base_url: Optional[str] = None,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ):
+        self.agent_id = agent_id
+        self.agent_token = agent_token
+        self.base_url = (base_url or os.getenv("CARTESIA_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        self.timeout_s = timeout_s
+
+    async def query(
+        self,
+        query: str,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = DEFAULT_TOP_K,
+        timeout_s: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        """Run a query against the agent's knowledge base.
+
+        Returns the raw result objects from the API, each currently shaped as
+        ``{"content": str}``. Pass-through is intentional so new fields the
+        API adds (scores, metadata, document IDs, …) flow to callers without
+        a SDK change. Callers are responsible for extracting fields they
+        care about and formatting for downstream use (e.g. LLM consumption).
+
+        ``timeout_s`` overrides the per-call timeout for this query; falls
+        back to the client's configured timeout when None.
+        """
+        if not self.agent_id or not self.agent_token:
+            raise KnowledgeBaseError(
+                "Knowledge base is not available in this session "
+                "(missing agent_id or agent_token from start message)."
+            )
+
+        params: Dict[str, str] = {"query": query, "top_k": str(top_k)}
+        if filters:
+            params["filters"] = json.dumps(filters)
+
+        url = f"{self.base_url}/agents/{self.agent_id}/documents/query"
+        headers = {"Authorization": f"Bearer {self.agent_token}"}
+
+        effective_timeout = timeout_s if timeout_s is not None else self.timeout_s
+        timeout = aiohttp.ClientTimeout(total=effective_timeout)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url, params=params, headers=headers) as resp:
+                    body = await resp.text()
+                    if resp.status != 200:
+                        logger.warning(
+                            "knowledge_base query failed: status={} body={}",
+                            resp.status,
+                            body[:LOG_TRUNCATION],
+                        )
+                        raise KnowledgeBaseError(
+                            f"Knowledge base query failed with status {resp.status}: {body[:LOG_TRUNCATION]}"
+                        )
+                    try:
+                        payload = json.loads(body)
+                    except json.JSONDecodeError as e:
+                        raise KnowledgeBaseError(f"Invalid JSON from knowledge base: {e}") from e
+        except asyncio.TimeoutError as e:
+            raise KnowledgeBaseError(f"Knowledge base query timed out after {effective_timeout}s") from e
+        except aiohttp.ClientError as e:
+            raise KnowledgeBaseError(f"Knowledge base query transport error: {e}") from e
+
+        return payload.get("results") or []

--- a/line/knowledge_base.py
+++ b/line/knowledge_base.py
@@ -14,10 +14,25 @@ DEFAULT_BASE_URL = "https://api.cartesia.ai"
 DEFAULT_TOP_K = 5
 DEFAULT_TIMEOUT_S = 3.0
 LOG_TRUNCATION = 500
+# Threshold above which we surface a warning so a developer who accidentally
+# set an unreasonably long timeout (e.g. ``60.0``) can spot the misconfiguration
+# from the logs rather than wondering why the call appears to hang.
+LONG_TIMEOUT_WARN_S = 10.0
 
 
 class KnowledgeBaseError(RuntimeError):
     """Raised when a knowledge base query fails."""
+
+
+def _warn_if_long_timeout(timeout_s: Optional[float], *, source: str) -> None:
+    if timeout_s is not None and timeout_s > LONG_TIMEOUT_WARN_S:
+        logger.warning(
+            "{} timeout_s={}s exceeds {}s; long timeouts can stall the call "
+            "while a slow knowledge base query is in flight.",
+            source,
+            timeout_s,
+            LONG_TIMEOUT_WARN_S,
+        )
 
 
 class KnowledgeBase:
@@ -38,6 +53,7 @@ class KnowledgeBase:
         self.agent_token = agent_token
         self.base_url = (base_url or os.getenv("CARTESIA_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
         self.timeout_s = timeout_s
+        _warn_if_long_timeout(timeout_s, source="KnowledgeBase")
 
     async def query(
         self,

--- a/line/knowledge_base.py
+++ b/line/knowledge_base.py
@@ -92,6 +92,7 @@ class KnowledgeBase:
             async with aiohttp.ClientSession(timeout=timeout) as session:
                 async with session.get(url, params=params, headers=headers) as resp:
                     body = await resp.text()
+                    logger.info("knowledge_base query: url={} params={} status={} body={}", url, params, resp.status, body[:LOG_TRUNCATION])
                     if resp.status != 200:
                         logger.warning(
                             "knowledge_base query failed: status={} body={}",
@@ -103,6 +104,7 @@ class KnowledgeBase:
                         )
                     try:
                         payload = json.loads(body)
+                        logger.debug("knowledge_base query payload: {}", payload)
                     except json.JSONDecodeError as e:
                         raise KnowledgeBaseError(f"Invalid JSON from knowledge base: {e}") from e
         except asyncio.TimeoutError as e:

--- a/line/llm_agent/__init__.py
+++ b/line/llm_agent/__init__.py
@@ -1,8 +1,9 @@
 """
 LLM Agent module for the Line SDK.
 
-Provides a unified interface for 100+ LLM providers via LiteLLM with three
-tool calling paradigms: loopback, passthrough, and handoff.
+Provides a unified interface for 100+ LLM providers via LiteLLM. Tool calls
+either feed back to the LLM (raw values) or pass directly through to the user
+(OutputEvent yields); handoff tools transfer control to another agent.
 
 See README.md for examples and detailed documentation.
 """
@@ -19,7 +20,7 @@ from line.llm_agent.llm_agent import LlmAgent
 # Provider facade
 from line.llm_agent.provider import ChatStream, LLMProvider, LlmProvider
 
-# Tool type decorators
+# Tool decorators
 from line.llm_agent.tools.decorators import handoff_tool, loopback_tool, passthrough_tool
 
 # Built-in tools
@@ -30,6 +31,7 @@ from line.llm_agent.tools.system import (
     send_dtmf,
     transfer_call,
     web_search,
+    knowledge_base,
 )
 
 # Function tool definitions and types
@@ -56,7 +58,7 @@ __all__ = [
     "LlmConfig",
     "FALLBACK_SYSTEM_PROMPT",
     "FALLBACK_INTRODUCTION",
-    # Tool type decorators
+    # Tool decorators
     "loopback_tool",
     "passthrough_tool",
     "handoff_tool",
@@ -67,6 +69,7 @@ __all__ = [
     "web_search",
     "agent_as_handoff",
     "mcp_tool",
+    "knowledge_base",
     # Tool types
     "ToolEnv",
     "LoopbackToolFn",

--- a/line/llm_agent/tools/__init__.py
+++ b/line/llm_agent/tools/__init__.py
@@ -14,7 +14,6 @@ from line.llm_agent.tools.decorators import (
 # System tools
 from line.llm_agent.tools.system import (
     DtmfButton,
-    KnowledgeBaseTool,
     WebSearchTool,
     agent_as_handoff,
     end_call,
@@ -49,7 +48,6 @@ __all__ = [
     "send_dtmf",
     "transfer_call",
     "agent_as_handoff",
-    "KnowledgeBaseTool",
     "knowledge_base",
     # Utility types
     "ToolType",

--- a/line/llm_agent/tools/__init__.py
+++ b/line/llm_agent/tools/__init__.py
@@ -14,9 +14,11 @@ from line.llm_agent.tools.decorators import (
 # System tools
 from line.llm_agent.tools.system import (
     DtmfButton,
+    KnowledgeBaseTool,
     WebSearchTool,
     agent_as_handoff,
     end_call,
+    knowledge_base,
     send_dtmf,
     transfer_call,
     web_search,
@@ -47,6 +49,8 @@ __all__ = [
     "send_dtmf",
     "transfer_call",
     "agent_as_handoff",
+    "KnowledgeBaseTool",
+    "knowledge_base",
     # Utility types
     "ToolType",
     "ToolEnv",

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -517,8 +517,8 @@ class KnowledgeBaseTool:
     knowledge base by issuing a natural-language query.
 
     Filters, ``top_k``, and ``timeout_s`` are set at construction
-    (``KnowledgeBaseTool(...)`` / ``knowledge_base(...)``), not by the LLM at
-    tool-call time. The LLM only chooses the query string.
+    (``knowledge_base(...)``), not by the LLM at tool-call time. The LLM only
+    chooses the query string.
 
     Usage:
         # Default behavior — no filters
@@ -532,7 +532,7 @@ class KnowledgeBaseTool:
     """
 
     DEFAULT_DESCRIPTION = (
-        "Look up information from the agent's knowledge base. "
+        "Look up information from your knowledge base. "
         "Use when the user asks about facts, policies, products, or other domain "
         "information that may be stored in reference documents. "
         "Pass a focused natural-language query describing what you need to find."

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -18,7 +18,7 @@ from line.events import (
     AgentUpdateCall,
     CallStarted,
 )
-from line.knowledge_base import DEFAULT_TOP_K, KnowledgeBaseError
+from line.knowledge_base import DEFAULT_TOP_K, KnowledgeBaseError, _warn_if_long_timeout
 from line.llm_agent.tools.decorators import passthrough_tool
 from line.llm_agent.tools.utils import FunctionTool, ToolEnv, ToolType, construct_function_tool
 
@@ -529,6 +529,10 @@ class KnowledgeBaseTool:
 
         # Override the per-tool description (e.g. domain-specific guidance)
         LlmAgent(tools=[knowledge_base(description="Look up insurance policy terms.")])
+
+        # Run lookups as a background loopback tool so the LLM can keep
+        # talking to the user while the query is in flight.
+        LlmAgent(tools=[knowledge_base(is_background=True)])
     """
 
     DEFAULT_DESCRIPTION = (
@@ -546,11 +550,14 @@ class KnowledgeBaseTool:
         top_k: int = DEFAULT_TOP_K,
         description: Optional[str] = None,
         timeout_s: Optional[float] = None,
+        is_background: bool = False,
     ):
         self._filters = filters
         self._top_k = top_k
         self._description = description if description else self.DEFAULT_DESCRIPTION
         self._timeout_s = timeout_s
+        self._is_background = is_background
+        _warn_if_long_timeout(timeout_s, source="KnowledgeBaseTool")
         self._function_tool = self._create_function_tool()
 
     @property
@@ -588,6 +595,7 @@ class KnowledgeBaseTool:
             name="knowledge_base",
             description=self._description,
             tool_type=ToolType.LOOPBACK,
+            is_background=self._is_background,
         )
 
     def as_function_tool(self) -> FunctionTool:
@@ -599,12 +607,14 @@ class KnowledgeBaseTool:
         top_k: Optional[int] = None,
         description: Optional[str] = None,
         timeout_s: Optional[float] = None,
+        is_background: Optional[bool] = None,
     ) -> "KnowledgeBaseTool":
         return KnowledgeBaseTool(
             filters=filters if filters is not None else self._filters,
             top_k=top_k if top_k is not None else self._top_k,
             description=description if description is not None else self._description,
             timeout_s=timeout_s if timeout_s is not None else self._timeout_s,
+            is_background=is_background if is_background is not None else self._is_background,
         )
 
 

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -18,6 +18,7 @@ from line.events import (
     AgentUpdateCall,
     CallStarted,
 )
+from line.knowledge_base import DEFAULT_TOP_K, KnowledgeBaseError
 from line.llm_agent.tools.decorators import passthrough_tool
 from line.llm_agent.tools.utils import FunctionTool, ToolEnv, ToolType, construct_function_tool
 
@@ -508,6 +509,110 @@ def mcp_tool(name: str, server_url: Optional[str] = None, **server_config: Any) 
         "or with tool_name and tool_args to invoke one.",
         tool_type=ToolType.LOOPBACK,
     )
+
+
+class KnowledgeBaseTool:
+    """
+    knowledge_base tool: lets the LLM look up information from the agent's
+    knowledge base by issuing a natural-language query.
+
+    Filters, ``top_k``, and ``timeout_s`` are set at construction
+    (``KnowledgeBaseTool(...)`` / ``knowledge_base(...)``), not by the LLM at
+    tool-call time. The LLM only chooses the query string.
+
+    Usage:
+        # Default behavior — no filters
+        LlmAgent(tools=[knowledge_base])
+
+        # Pre-filter every retrieval to a specific subset
+        LlmAgent(tools=[knowledge_base(filters={"category": "billing"})])
+
+        # Override the per-tool description (e.g. domain-specific guidance)
+        LlmAgent(tools=[knowledge_base(description="Look up insurance policy terms.")])
+    """
+
+    DEFAULT_DESCRIPTION = (
+        "Look up information from the agent's knowledge base. "
+        "Use when the user asks about facts, policies, products, or other domain "
+        "information that may be stored in reference documents. "
+        "Pass a focused natural-language query describing what you need to find."
+    )
+
+    CHUNK_SEPARATOR = "\n\n---\n\n"
+
+    def __init__(
+        self,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = DEFAULT_TOP_K,
+        description: Optional[str] = None,
+        timeout_s: Optional[float] = None,
+    ):
+        self._filters = filters
+        self._top_k = top_k
+        self._description = description if description else self.DEFAULT_DESCRIPTION
+        self._timeout_s = timeout_s
+        self._function_tool = self._create_function_tool()
+
+    @property
+    def name(self) -> str:
+        return "knowledge_base"
+
+    def _create_function_tool(self) -> FunctionTool:
+        filters = self._filters
+        top_k = self._top_k
+        timeout_s = self._timeout_s
+        separator = self.CHUNK_SEPARATOR
+
+        async def _knowledge_base_impl(
+            ctx: ToolEnv,
+            query: Annotated[str, "Natural-language query describing what to look up"],
+        ) -> str:
+            kb = ctx.knowledge_base()
+            try:
+                results = await kb.query(
+                    query,
+                    filters=filters,
+                    top_k=top_k,
+                    timeout_s=timeout_s,
+                )
+            except KnowledgeBaseError as e:
+                logger.warning("knowledge_base tool error: %s", e)
+                return "Knowledge base lookup is currently unavailable."
+            chunks = [r["content"] for r in results if r.get("content")]
+            if not chunks:
+                return "No relevant information found in the knowledge base."
+            return separator.join(chunks)
+
+        return construct_function_tool(
+            _knowledge_base_impl,
+            name="knowledge_base",
+            description=self._description,
+            tool_type=ToolType.LOOPBACK,
+        )
+
+    def as_function_tool(self) -> FunctionTool:
+        return self._function_tool
+
+    def __call__(
+        self,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        description: Optional[str] = None,
+        timeout_s: Optional[float] = None,
+    ) -> "KnowledgeBaseTool":
+        return KnowledgeBaseTool(
+            filters=filters if filters is not None else self._filters,
+            top_k=top_k if top_k is not None else self._top_k,
+            description=description if description is not None else self._description,
+            timeout_s=timeout_s if timeout_s is not None else self._timeout_s,
+        )
+
+
+# Default instance - can be used directly or called to configure
+# Examples:
+#   knowledge_base                                      # Default lookup, no filters
+#   knowledge_base(filters={"category": "billing"})     # Pre-filtered lookup
+knowledge_base = KnowledgeBaseTool()
 
 
 @passthrough_tool

--- a/line/llm_agent/tools/utils.py
+++ b/line/llm_agent/tools/utils.py
@@ -51,10 +51,16 @@ from typing import (
 
 from line.agent import TurnEnv
 from line.events import InputEvent, OutputEvent
+from line.knowledge_base import KnowledgeBase
 
 if TYPE_CHECKING:
     from line.llm_agent.provider import ParsedModelId
-    from line.llm_agent.tools.system import EndCallTool, TransferCallTool, WebSearchTool
+    from line.llm_agent.tools.system import (
+        EndCallTool,
+        KnowledgeBaseTool,
+        TransferCallTool,
+        WebSearchTool,
+    )
 
 # -------------------------
 # Tool Type Enum
@@ -79,6 +85,10 @@ class ToolEnv:
     """Context passed to tool functions."""
 
     turn_env: TurnEnv
+
+    def knowledge_base(self) -> KnowledgeBase:
+        """Return a KnowledgeBase client scoped to the calling agent."""
+        return self.turn_env.knowledge_base()
 
 
 # -------------------------
@@ -142,7 +152,14 @@ class FunctionTool:
 # Type alias for tools that can be passed to LlmAgent/LlmProvider.
 # Plain callables are automatically wrapped as loopback tools.
 # Uses string literal because WebSearchTool/EndCallTool are TYPE_CHECKING-only imports.
-ToolSpec = Union[FunctionTool, "WebSearchTool", "EndCallTool", "TransferCallTool", Callable]
+ToolSpec = Union[
+    FunctionTool,
+    "WebSearchTool",
+    "EndCallTool",
+    "TransferCallTool",
+    "KnowledgeBaseTool",
+    Callable,
+]
 
 
 @dataclass
@@ -332,7 +349,12 @@ def _normalize_tools(
         FunctionTool in the first list.
     """
     from line.llm_agent.tools.decorators import loopback_tool
-    from line.llm_agent.tools.system import EndCallTool, TransferCallTool, WebSearchTool
+    from line.llm_agent.tools.system import (
+        EndCallTool,
+        KnowledgeBaseTool,
+        TransferCallTool,
+        WebSearchTool,
+    )
 
     function_tools: List[FunctionTool] = []
     web_search_tool: Optional[Any] = None
@@ -340,7 +362,7 @@ def _normalize_tools(
     for tool in tool_specs:
         if isinstance(tool, FunctionTool):
             function_tools.append(tool)
-        elif isinstance(tool, (EndCallTool, TransferCallTool)):
+        elif isinstance(tool, (EndCallTool, TransferCallTool, KnowledgeBaseTool)):
             function_tools.append(tool.as_function_tool())
         elif isinstance(tool, WebSearchTool):
             web_search_tool = tool
@@ -349,7 +371,8 @@ def _normalize_tools(
         else:
             raise TypeError(
                 f"Unsupported tool type: {type(tool).__name__}. "
-                f"Expected FunctionTool, EndCallTool, TransferCallTool, WebSearchTool, or callable."
+                f"Expected FunctionTool, EndCallTool, TransferCallTool, "
+                f"KnowledgeBaseTool, WebSearchTool, or callable."
             )
 
     web_search_options: Optional[Dict[str, Any]] = None
@@ -358,6 +381,16 @@ def _normalize_tools(
             web_search_options = web_search_tool.get_web_search_options()
         else:
             function_tools.append(_web_search_tool_to_function_tool(web_search_tool))
+
+    seen: Dict[str, int] = {}
+    for ft in function_tools:
+        seen[ft.name] = seen.get(ft.name, 0) + 1
+    duplicates = sorted(name for name, count in seen.items() if count > 1)
+    if duplicates:
+        raise ValueError(
+            f"Duplicate tool name(s): {', '.join(duplicates)}. "
+            f"Each tool passed to LlmAgent must have a unique name."
+        )
 
     return function_tools, web_search_options
 

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -49,7 +49,7 @@ from line._harness_types import (
     UserStateInput,
     ValidationErrorInput,
 )
-from line.agent import Agent, AgentSpec, EventFilter, TurnEnv
+from line.agent import Agent, AgentEnv, AgentSpec, EventFilter, TurnEnv
 from line.events import (
     AgentDtmfSent,
     AgentEndCall,
@@ -113,11 +113,6 @@ class UserState:
 
     SPEAKING = "speaking"
     IDLE = "idle"
-
-
-class AgentEnv:
-    def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None):
-        self.loop = loop
 
 
 CARTESIA_VERSION = "2026-04-03"
@@ -230,8 +225,8 @@ class VoiceAgentApp:
             return
 
         runner: Optional[ConversationRunner] = None
-        # Create the AgentEnv with the current event loop
         loop = asyncio.get_running_loop()
+        # Create the AgentEnv with the current event loop.
         env = AgentEnv(loop)
         try:
             agent_spec = await self.get_agent(env, call_request)
@@ -284,7 +279,8 @@ class ConversationRunner:
         Args:
             websocket: The WebSocket connection.
             agent_spec: Agent or (Agent, run_filter, cancel_filter).
-            env: Environment passed to the agent.
+            env: Per-call environment, passed through to TurnEnv for each
+                agent turn.
         """
         self.websocket = websocket
         self.env = env
@@ -357,7 +353,7 @@ class ConversationRunner:
         """
         # Emit call_started to seed history/context
         start_event, self.history = self._process_input_event(self.history, CallStarted())
-        await self._handle_event(TurnEnv(), start_event)
+        await self._handle_event(TurnEnv(agent_env=self.env), start_event)
 
         while not self.shutdown_event.is_set():
             try:
@@ -376,13 +372,13 @@ class ConversationRunner:
                 ev, self.history = self._process_input_event(self.history, event)
                 if ev is None:
                     continue
-                await self._handle_event(TurnEnv(), ev)
+                await self._handle_event(TurnEnv(agent_env=self.env), ev)
 
             except WebSocketDisconnect:
                 logger.info("WebSocket disconnected in loop")
                 self.shutdown_event.set()
                 end_event, self.history = self._process_input_event(self.history, CallEnded())
-                await self._handle_event(TurnEnv(), end_event)
+                await self._handle_event(TurnEnv(agent_env=self.env), end_event)
             except json.JSONDecodeError as e:
                 # Don't send EndCall event, as that may trigger side effects
                 # we accept the risk of incomplete call cleanup in this case,

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -226,6 +226,7 @@ class VoiceAgentApp:
 
         try:
             start_data = await websocket.receive_json()
+            logger.info(f"Received start message: {start_data}")
             call_request = _call_request_from_start_data(start_data)
         except WebSocketDisconnect:
             logger.error("WebSocket disconnected before start message received")

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -88,6 +88,9 @@ class PreCallResult(BaseModel):
 class AgentConfig(BaseModel):
     """Agent information for the call."""
 
+    # Persistent agent ID forwarded by inferno on the start message. Used to
+    # scope call-back operations (e.g. knowledge base queries) to this agent.
+    id: Optional[str] = None
     system_prompt: Optional[str] = None  # System prompt to define the agent's role and behavior
     introduction: Optional[str] = None  # Introduction message for the agent to start the call with
 
@@ -101,6 +104,14 @@ class CallRequest(BaseModel):
     agent_call_id: str  # Agent call ID for logging and correlation
     agent: AgentConfig
     metadata: Optional[Dict[str, Any]] = None
+    # Agent-scoped JWT minted by the API and forwarded by inferno over the
+    # websocket start message. Used to authenticate calls back to the API
+    # on behalf of the agent (e.g. knowledge base queries).
+    agent_token: Optional[str] = None
+    # Base URL for callbacks to the Cartesia API, forwarded by inferno on
+    # the start message. Threaded into AgentEnv so call-scoped clients
+    # (e.g. KnowledgeBase) hit the same API that minted agent_token.
+    api_base_url: Optional[str] = None
 
     model_config = ConfigDict(
         # Allow both field name (from_) and alias (from) for input
@@ -225,9 +236,20 @@ class VoiceAgentApp:
             return
 
         runner: Optional[ConversationRunner] = None
+        # Create the AgentEnv with the current event loop and the
+        # agent-scoped credentials forwarded by inferno on the start message.
         loop = asyncio.get_running_loop()
-        # Create the AgentEnv with the current event loop.
-        env = AgentEnv(loop)
+        if call_request.agent.id is None:
+            logger.error(
+                "Start message missing agent.id; agent-scoped operations "
+                "(e.g. knowledge base) will be unavailable for this call."
+            )
+        env = AgentEnv(
+            loop=loop,
+            agent_id=call_request.agent.id,
+            agent_token=call_request.agent_token,
+            base_url=call_request.api_base_url,
+        )
         try:
             agent_spec = await self.get_agent(env, call_request)
             runner = ConversationRunner(websocket, agent_spec, env)
@@ -258,6 +280,8 @@ def _call_request_from_start_data(data: dict) -> CallRequest:
         agent_call_id=start_msg.agent_call_id,
         agent=AgentConfig(**start_msg.agent),
         metadata=start_msg.metadata or {},
+        agent_token=start_msg.agent_token,
+        api_base_url=start_msg.api_base_url,
     )
 
 
@@ -279,8 +303,8 @@ class ConversationRunner:
         Args:
             websocket: The WebSocket connection.
             agent_spec: Agent or (Agent, run_filter, cancel_filter).
-            env: Per-call environment, passed through to TurnEnv for each
-                agent turn.
+            env: Per-call environment, passed through to TurnEnv so tools
+                can resolve call-scoped resources (e.g. knowledge base).
         """
         self.websocket = websocket
         self.env = env

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -88,8 +88,8 @@ class PreCallResult(BaseModel):
 class AgentConfig(BaseModel):
     """Agent information for the call."""
 
-    # Persistent agent ID forwarded by inferno on the start message. Used to
-    # scope call-back operations (e.g. knowledge base queries) to this agent.
+    # Persistent agent ID forwarded by the harness on the start message. Used
+    # to scope call-back operations (e.g. knowledge base queries) to this agent.
     id: Optional[str] = None
     system_prompt: Optional[str] = None  # System prompt to define the agent's role and behavior
     introduction: Optional[str] = None  # Introduction message for the agent to start the call with
@@ -104,11 +104,11 @@ class CallRequest(BaseModel):
     agent_call_id: str  # Agent call ID for logging and correlation
     agent: AgentConfig
     metadata: Optional[Dict[str, Any]] = None
-    # Agent-scoped JWT minted by the API and forwarded by inferno over the
+    # Agent-scoped JWT minted by the API and forwarded by the harness over the
     # websocket start message. Used to authenticate calls back to the API
     # on behalf of the agent (e.g. knowledge base queries).
     agent_token: Optional[str] = None
-    # Base URL for callbacks to the Cartesia API, forwarded by inferno on
+    # Base URL for callbacks to the Cartesia API, forwarded by the harness on
     # the start message. Threaded into AgentEnv so call-scoped clients
     # (e.g. KnowledgeBase) hit the same API that minted agent_token.
     api_base_url: Optional[str] = None
@@ -237,7 +237,7 @@ class VoiceAgentApp:
 
         runner: Optional[ConversationRunner] = None
         # Create the AgentEnv with the current event loop and the
-        # agent-scoped credentials forwarded by inferno on the start message.
+        # agent-scoped credentials forwarded by the harness on the start message.
         loop = asyncio.get_running_loop()
         if call_request.agent.id is None:
             logger.error(

--- a/tests/real_api_test_provider.py
+++ b/tests/real_api_test_provider.py
@@ -47,7 +47,7 @@ import warnings
 import litellm
 from loguru import logger
 
-from line.agent import TurnEnv
+from line.agent import AgentEnv, TurnEnv
 from line.events import (
     AgentSendText,
     AgentToolCalled,
@@ -190,7 +190,7 @@ async def test_tool_calling(model: str, api_key: str, backend: Optional[str] = N
         backend=backend,
     )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     user_message = "What's the weather in Tokyo? Also, what's 25 * 4?"
     event = UserTextSent(
         content=user_message,
@@ -233,7 +233,7 @@ async def test_introduction(model: str, api_key: str, backend: Optional[str] = N
         backend=backend,
     )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     event = CallStarted()
 
     print("Event: CallStarted")
@@ -271,7 +271,7 @@ async def test_web_search(
         backend=backend,
     )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     user_message = "What is the current weather in New York City? Search the web for this information."
     event = UserTextSent(
         content=user_message,
@@ -326,7 +326,7 @@ async def test_function_tools_with_web_search(model: str, api_key: str, backend:
         backend=backend,
     )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     user_message = "Hi, how are you?"
     event = UserTextSent(
         content=user_message,
@@ -377,7 +377,7 @@ async def test_mcp_list_tools(model: str, api_key: str, backend: Optional[str] =
         backend=backend,
     )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     user_message = "What tools are available?"
     event = UserTextSent(
         content=user_message,
@@ -429,7 +429,7 @@ async def test_mcp_tool_execution(model: str, api_key: str, backend: Optional[st
         backend=backend,
     )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     user_message = "Roll 3 six-sided dice for me."
     event = UserTextSent(
         content=user_message,
@@ -568,7 +568,7 @@ Always include menu_item_id, quantity, and modifiers (can be empty list).""",
         backend=backend,
     )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     user_message = "I'd like to order 2 grilled oysters please"
     event = UserTextSent(
         content=user_message,
@@ -678,7 +678,7 @@ Always include menu_item_id and quantity.""",
             backend=backend,
         )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     user_message = "Order 2 grilled oysters"
     event = UserTextSent(
         content=user_message,

--- a/tests/real_api_test_realtime_provider.py
+++ b/tests/real_api_test_realtime_provider.py
@@ -33,7 +33,7 @@ import warnings
 import litellm
 from loguru import logger
 
-from line.agent import TurnEnv
+from line.agent import AgentEnv, TurnEnv
 from line.events import (
     AgentSendText,
     AgentToolCalled,
@@ -142,7 +142,7 @@ async def test_tools(api_key: str, model: str):
         config=LlmConfig(system_prompt="You are a helpful assistant. Use tools when needed."),
     )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     user_message = "What's the weather in Tokyo? Also, what's 25 * 4?"
     event = UserTextSent(
         content=user_message,

--- a/tests/real_api_test_websocket_provider.py
+++ b/tests/real_api_test_websocket_provider.py
@@ -35,7 +35,7 @@ import warnings
 import litellm
 from loguru import logger
 
-from line.agent import TurnEnv
+from line.agent import AgentEnv, TurnEnv
 from line.events import (
     AgentSendText,
     AgentToolCalled,
@@ -243,7 +243,7 @@ async def test_tools(api_key: str, model: str):
         config=LlmConfig(system_prompt="You are a helpful assistant. Use tools when needed."),
     )
 
-    env = TurnEnv()
+    env = TurnEnv(agent_env=AgentEnv())
     user_message = "What's the weather in Tokyo? Also, what's 25 * 4?"
     event = UserTextSent(
         content=user_message,

--- a/tests/test_knowledge_base.py
+++ b/tests/test_knowledge_base.py
@@ -1,0 +1,268 @@
+"""Tests for KnowledgeBase client and environment wiring."""
+
+import asyncio
+import json
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+import pytest
+
+from line.agent import AgentEnv, TurnEnv
+from line.knowledge_base import KnowledgeBase, KnowledgeBaseError
+from line.llm_agent.tools.utils import ToolEnv
+
+pytestmark = [pytest.mark.anyio, pytest.mark.parametrize("anyio_backend", ["asyncio"])]
+
+
+class FakeKBEndpoint:
+    """Mock the aiohttp boundary for the bifrost KB query endpoint."""
+
+    def __init__(self, results: Optional[list] = None, status: int = 200, body: Optional[str] = None):
+        self.results = results if results is not None else []
+        self.status = status
+        self.body = body
+        self.raise_on_get: Optional[BaseException] = None
+        self.last_url: Optional[str] = None
+        self.last_path: Optional[str] = None
+        self.last_query: Optional[Dict[str, str]] = None
+        self.last_auth: Optional[str] = None
+        self.session_timeout_s: Optional[float] = None
+
+    def client_session_factory(self):
+        endpoint = self
+
+        class FakeClientSession:
+            def __init__(self, timeout):
+                endpoint.session_timeout_s = timeout.total
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, url, params=None, headers=None):
+                if endpoint.raise_on_get is not None:
+                    raise endpoint.raise_on_get
+                endpoint.last_url = url
+                endpoint.last_path = urlparse(url).path
+                endpoint.last_query = dict(params or {})
+                endpoint.last_auth = (headers or {}).get("Authorization")
+                return FakeKBResponse(endpoint)
+
+        return FakeClientSession
+
+
+class FakeKBResponse:
+    def __init__(self, endpoint: FakeKBEndpoint):
+        self._endpoint = endpoint
+        self.status = endpoint.status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self) -> str:
+        endpoint = self._endpoint
+        if endpoint.body is not None:
+            return endpoint.body
+        return json.dumps({"results": endpoint.results})
+
+
+@pytest.fixture
+def kb_endpoint(monkeypatch):
+    fake = FakeKBEndpoint()
+    monkeypatch.setattr(
+        "line.knowledge_base.aiohttp.ClientSession",
+        fake.client_session_factory(),
+    )
+    return fake
+
+
+# =============================================================================
+# KnowledgeBase client
+# =============================================================================
+
+
+async def test_query_sends_bearer_token_and_returns_results(kb_endpoint, anyio_backend):
+    fake = kb_endpoint
+    fake.results = [{"content": "first chunk"}, {"content": "second chunk"}]
+
+    kb = KnowledgeBase(
+        agent_id="agent-123",
+        agent_token="tok-abc",
+        base_url="https://kb.example.test",
+    )
+    results = await kb.query("hello world")
+
+    assert results == [{"content": "first chunk"}, {"content": "second chunk"}]
+    assert fake.last_path == "/agents/agent-123/documents/query"
+    assert fake.last_query == {"query": "hello world", "top_k": "5"}
+    assert fake.last_auth == "Bearer tok-abc"
+
+
+async def test_query_passes_through_unknown_fields(kb_endpoint, anyio_backend):
+    # If bifrost adds fields (e.g. score, document_id, metadata), the client
+    # forwards them untouched so callers can use them without an SDK bump.
+    fake = kb_endpoint
+    fake.results = [
+        {"content": "x", "score": 0.91, "document_id": "doc-1"},
+    ]
+
+    kb = KnowledgeBase(
+        agent_id="agent-123",
+        agent_token="tok-abc",
+        base_url="https://kb.example.test",
+    )
+    results = await kb.query("q")
+
+    assert results == [{"content": "x", "score": 0.91, "document_id": "doc-1"}]
+
+
+async def test_query_serializes_filters_as_json(kb_endpoint, anyio_backend):
+    fake = kb_endpoint
+    fake.results = []
+
+    kb = KnowledgeBase(
+        agent_id="agent-123",
+        agent_token="tok-abc",
+        base_url="https://kb.example.test",
+    )
+    await kb.query("q", filters={"category": "billing"}, top_k=3)
+
+    assert fake.last_query is not None
+    assert json.loads(fake.last_query["filters"]) == {"category": "billing"}
+    assert fake.last_query["top_k"] == "3"
+
+
+async def test_query_empty_results_returns_empty_list(kb_endpoint, anyio_backend):
+    fake = kb_endpoint
+    fake.results = []
+
+    kb = KnowledgeBase(
+        agent_id="agent-123",
+        agent_token="tok-abc",
+        base_url="https://kb.example.test",
+    )
+    results = await kb.query("anything")
+
+    assert results == []
+
+
+async def test_query_raises_on_non_200(kb_endpoint, anyio_backend):
+    fake = kb_endpoint
+    fake.status = 401
+    fake.body = "unauthorized"
+
+    kb = KnowledgeBase(
+        agent_id="agent-123",
+        agent_token="bad-token",
+        base_url="https://kb.example.test",
+    )
+
+    with pytest.raises(KnowledgeBaseError, match="401"):
+        await kb.query("q")
+
+
+async def test_query_without_credentials_raises(anyio_backend):
+    kb = KnowledgeBase(agent_id=None, agent_token=None, base_url="http://localhost")
+    with pytest.raises(KnowledgeBaseError, match="not available"):
+        await kb.query("q")
+
+
+async def test_query_per_call_timeout_overrides_client_default(kb_endpoint, anyio_backend):
+    # Per-query timeout takes precedence over the client-configured default.
+    # Timeouts are wrapped as KnowledgeBaseError at the client boundary so
+    # the tool layer's single-exception catch handles them gracefully.
+    fake = kb_endpoint
+    fake.raise_on_get = asyncio.TimeoutError()
+
+    kb = KnowledgeBase(
+        agent_id="agent-123",
+        agent_token="tok-abc",
+        base_url="https://kb.example.test",
+        timeout_s=5.0,
+    )
+    with pytest.raises(KnowledgeBaseError, match="timed out"):
+        await kb.query("q", timeout_s=0.05)
+
+    assert fake.session_timeout_s == 0.05
+
+
+# =============================================================================
+# TurnEnv / ToolEnv wiring
+# =============================================================================
+
+
+def test_agent_env_knowledge_base_threads_creds(anyio_backend):
+    agent_env = AgentEnv(agent_id="a1", agent_token="t1", base_url="http://example.com")
+    kb = agent_env.knowledge_base()
+
+    assert isinstance(kb, KnowledgeBase)
+    assert kb.agent_id == "a1"
+    assert kb.agent_token == "t1"
+    assert kb.base_url == "http://example.com"
+
+
+def test_turn_env_delegates_to_agent_env(anyio_backend):
+    agent_env = AgentEnv(agent_id="a1", agent_token="t1")
+    env = TurnEnv(agent_env=agent_env)
+
+    kb = env.knowledge_base()
+    assert isinstance(kb, KnowledgeBase)
+    assert kb.agent_id == "a1"
+    assert kb.agent_token == "t1"
+
+
+def test_tool_env_delegates_to_turn_env(anyio_backend):
+    agent_env = AgentEnv(agent_id="a1", agent_token="t1")
+    ctx = ToolEnv(turn_env=TurnEnv(agent_env=agent_env))
+
+    kb = ctx.knowledge_base()
+    assert isinstance(kb, KnowledgeBase)
+    assert kb.agent_id == "a1"
+
+
+def test_api_base_url_threads_from_start_message(anyio_backend):
+    # Inferno forwards api_base_url on the start message; it should land on
+    # the KnowledgeBase client untouched, taking precedence over the env
+    # var and the hardcoded prod fallback.
+    from line.voice_agent_app import _call_request_from_start_data
+
+    call_request = _call_request_from_start_data(
+        {
+            "type": "start",
+            "call_id": "c1",
+            "agent": {},
+            "agent_token": "tok",
+            "api_base_url": "https://api.staging.example",
+        }
+    )
+    assert call_request.api_base_url == "https://api.staging.example"
+
+    agent_env = AgentEnv(
+        agent_id="a1",
+        agent_token=call_request.agent_token,
+        base_url=call_request.api_base_url,
+    )
+    kb = agent_env.knowledge_base()
+    assert kb.base_url == "https://api.staging.example"
+
+
+def test_agent_id_threads_from_start_message_agent_id_field(anyio_backend):
+    # Inferno's AgentConfig carries `id` on the start message; it should land
+    # on CallRequest.agent.id verbatim.
+    from line.voice_agent_app import _call_request_from_start_data
+
+    call_request = _call_request_from_start_data(
+        {
+            "type": "start",
+            "call_id": "c1",
+            "agent": {"id": "agent-from-config"},
+            "agent_token": "tok",
+            "api_base_url": "https://api.staging.example",
+        }
+    )
+    assert call_request.agent.id == "agent-from-config"

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -11,7 +11,7 @@ from typing import Annotated, List, Optional
 
 import pytest
 
-from line.agent import TurnEnv
+from line.agent import AgentEnv, TurnEnv
 from line.events import (
     AgentEndCall,
     AgentHandedOff,
@@ -182,7 +182,7 @@ async def build_messages_with(agent, input_history, local_history, current_event
 @pytest.fixture
 def turn_env():
     """Create a basic TurnEnv."""
-    return TurnEnv()
+    return TurnEnv(agent_env=AgentEnv())
 
 
 # =============================================================================

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -155,6 +155,50 @@ async def test_knowledge_base_tool_handles_kb_error_gracefully(anyio_backend):
     assert "currently unavailable" in result.lower()
 
 
+def test_knowledge_base_tool_default_is_not_background(anyio_backend):
+    assert knowledge_base.as_function_tool().is_background is False
+
+
+def test_knowledge_base_tool_is_background_propagates_to_function_tool(anyio_backend):
+    configured = knowledge_base(is_background=True)
+    assert configured._is_background is True
+    assert configured.as_function_tool().is_background is True
+
+
+def test_knowledge_base_tool_call_inherits_is_background(anyio_backend):
+    # is_background must round-trip through __call__ chaining like the
+    # other config fields, otherwise re-configuring (e.g. tweaking top_k)
+    # would silently flip it back to the default.
+    configured = knowledge_base(is_background=True)
+    rechained = configured(top_k=7)
+    assert rechained._is_background is True
+    assert rechained.as_function_tool().is_background is True
+
+
+def test_knowledge_base_tool_warns_on_long_timeout(anyio_backend):
+    from loguru import logger as loguru_logger
+
+    messages: List[str] = []
+    handler_id = loguru_logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+    try:
+        knowledge_base(timeout_s=30.0)
+    finally:
+        loguru_logger.remove(handler_id)
+    assert any("timeout_s=30.0" in m for m in messages)
+
+
+def test_knowledge_base_tool_does_not_warn_on_short_timeout(anyio_backend):
+    from loguru import logger as loguru_logger
+
+    messages: List[str] = []
+    handler_id = loguru_logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+    try:
+        knowledge_base(timeout_s=2.0)
+    finally:
+        loguru_logger.remove(handler_id)
+    assert not any("timeout_s" in m for m in messages)
+
+
 # =============================================================================
 # Tests: transfer_call
 # =============================================================================

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -4,14 +4,23 @@ Tests for built-in tools.
 uv run pytest tests/test_llm_agent_tools_system.py -v
 """
 
-from typing import List
+from typing import List, Optional
 from unittest.mock import MagicMock
 
 import pytest
 
 from line.events import AgentEndCall, AgentSendDtmf, AgentSendText, AgentTransferCall
+from line.knowledge_base import KnowledgeBaseError
 from line.llm_agent.provider import parse_model_id
-from line.llm_agent.tools.system import EndCallTool, TransferCallTool, end_call, send_dtmf, transfer_call
+from line.llm_agent.tools.system import (
+    EndCallTool,
+    KnowledgeBaseTool,
+    TransferCallTool,
+    end_call,
+    knowledge_base,
+    send_dtmf,
+    transfer_call,
+)
 from line.llm_agent.tools.utils import ToolType
 
 # Use anyio for async test support with asyncio backend only
@@ -30,6 +39,120 @@ async def collect_events(gen) -> List:
 def mock_ctx():
     """Create a mock ToolEnv context."""
     return MagicMock()
+
+
+class FakeKnowledgeBase:
+    def __init__(self, results=None, error: Optional[Exception] = None):
+        self.results = results if results is not None else []
+        self.error = error
+        self.last_query = None
+        self.last_filters = None
+        self.last_top_k = None
+        self.last_timeout_s = None
+
+    async def query(self, query, filters=None, top_k=None, timeout_s=None):
+        self.last_query = query
+        self.last_filters = filters
+        self.last_top_k = top_k
+        self.last_timeout_s = timeout_s
+        if self.error is not None:
+            raise self.error
+        return self.results
+
+
+def tool_ctx_with_kb(kb: FakeKnowledgeBase):
+    ctx = MagicMock()
+    ctx.knowledge_base.return_value = kb
+    return ctx
+
+
+# =============================================================================
+# Tests: knowledge_base
+# =============================================================================
+
+
+def test_knowledge_base_tool_default_metadata(anyio_backend):
+    ft = knowledge_base.as_function_tool()
+    assert ft.name == "knowledge_base"
+    assert ft.tool_type == ToolType.LOOPBACK
+    assert "knowledge base" in ft.description.lower()
+    assert "query" in ft.parameters
+
+
+def test_knowledge_base_tool_configured_filters(anyio_backend):
+    configured = knowledge_base(filters={"k": "v"}, top_k=2, timeout_s=1.5)
+    assert isinstance(configured, KnowledgeBaseTool)
+    assert configured._filters == {"k": "v"}
+    assert configured._top_k == 2
+    assert configured._timeout_s == 1.5
+
+
+def test_knowledge_base_tool_call_inherits_existing_config(anyio_backend):
+    # Calling an already-configured tool with no overrides preserves the
+    # original config rather than silently resetting it to defaults.
+    configured = knowledge_base(filters={"k": "v"}, top_k=2, timeout_s=1.5)
+    rechained = configured()
+    assert rechained._filters == {"k": "v"}
+    assert rechained._top_k == 2
+    assert rechained._timeout_s == 1.5
+
+    # Per-arg overrides win, the rest are inherited.
+    overridden = configured(top_k=7)
+    assert overridden._filters == {"k": "v"}
+    assert overridden._top_k == 7
+    assert overridden._timeout_s == 1.5
+
+
+async def test_knowledge_base_tool_invokes_kb_with_configured_filters(anyio_backend):
+    kb = FakeKnowledgeBase(results=[{"content": "doc"}])
+    ctx = tool_ctx_with_kb(kb)
+
+    tool = knowledge_base(filters={"category": "billing"}, top_k=2, timeout_s=1.5).as_function_tool()
+    result = await tool.func(ctx, "what is X?")
+
+    assert result == "doc"
+    assert kb.last_query == "what is X?"
+    assert kb.last_filters == {"category": "billing"}
+    assert kb.last_top_k == 2
+    assert kb.last_timeout_s == 1.5
+
+
+async def test_knowledge_base_tool_joins_multiple_chunks(anyio_backend):
+    kb = FakeKnowledgeBase(results=[{"content": "first"}, {"content": "second"}])
+    ctx = tool_ctx_with_kb(kb)
+
+    result = await knowledge_base.as_function_tool().func(ctx, "q")
+
+    assert result == "first\n\n---\n\nsecond"
+
+
+async def test_knowledge_base_tool_skips_blank_content(anyio_backend):
+    # Blank/missing content is dropped at the tool layer (presentation concern),
+    # not at the client layer (transport concern).
+    kb = FakeKnowledgeBase(results=[{"content": ""}, {"content": "real"}, {"foo": "bar"}])
+    ctx = tool_ctx_with_kb(kb)
+
+    result = await knowledge_base.as_function_tool().func(ctx, "q")
+
+    assert result == "real"
+
+
+async def test_knowledge_base_tool_returns_friendly_no_results(anyio_backend):
+    kb = FakeKnowledgeBase(results=[])
+    ctx = tool_ctx_with_kb(kb)
+
+    result = await knowledge_base.as_function_tool().func(ctx, "anything")
+
+    assert "no relevant" in result.lower()
+
+
+async def test_knowledge_base_tool_handles_kb_error_gracefully(anyio_backend):
+    kb = FakeKnowledgeBase(error=KnowledgeBaseError("missing credentials"))
+    ctx = tool_ctx_with_kb(kb)
+
+    result = await knowledge_base.as_function_tool().func(ctx, "anything")
+
+    assert "currently unavailable" in result.lower()
 
 
 # =============================================================================
@@ -390,3 +513,26 @@ async def test_normalize_tools_handles_end_call_tool(anyio_backend):
     assert len(tools) == 1
     assert isinstance(tools[0], FunctionTool)
     assert tools[0].name == "end_call"
+
+
+async def test_normalize_tools_handles_knowledge_base_tool(anyio_backend):
+    """Test that _normalize_tools correctly handles a single KnowledgeBaseTool."""
+    from line.llm_agent.tools.utils import _normalize_tools
+
+    function_tools, web_search_options = _normalize_tools(
+        [knowledge_base(filters={"x": "y"})],
+        parse_model_id("openai/gpt-4o"),
+    )
+
+    assert web_search_options is None
+    assert [t.name for t in function_tools] == ["knowledge_base"]
+
+
+async def test_normalize_tools_rejects_duplicate_names(anyio_backend):
+    from line.llm_agent.tools.utils import _normalize_tools
+
+    with pytest.raises(ValueError, match="Duplicate tool name"):
+        _normalize_tools(
+            [knowledge_base, knowledge_base(filters={"x": "y"})],
+            parse_model_id("openai/gpt-4o"),
+        )

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -702,7 +702,7 @@ class TestUninterruptibleMessages:
                 yield AgentSendText(text="How can I help?", interruptible=True)
 
         runner = ConversationRunner(ws, scripted_agent, env)
-        await runner._start_agent_task(TurnEnv(), CallStarted())
+        await runner._start_agent_task(TurnEnv(agent_env=env), CallStarted())
         if runner.agent_task:
             await runner.agent_task
 
@@ -874,11 +874,11 @@ class TestUninterruptibleMessages:
 
         runner = ConversationRunner(ws, scripted_agent, env)
 
-        await runner._start_agent_task(TurnEnv(), CallStarted())
+        await runner._start_agent_task(TurnEnv(agent_env=env), CallStarted())
         await first_turn_started.wait()
 
         # UserTurnEnded starts a new LM run and cancels the old task.
-        await runner._start_agent_task(TurnEnv(), UserTurnEnded())
+        await runner._start_agent_task(TurnEnv(agent_env=env), UserTurnEnded())
         if runner.agent_task:
             await runner.agent_task
 

--- a/tests/test_word_buffer.py
+++ b/tests/test_word_buffer.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 import pytest
 
-from line.agent import TurnEnv
+from line.agent import AgentEnv, TurnEnv
 from line.events import (
     AgentSendText,
     AgentToolCalled,
@@ -48,7 +48,7 @@ async def _collect(wrapper: WordBufferingWrapper, event: Optional[InputEvent] = 
     if event is None:
         event = UserTurnEnded()
     results = []
-    async for output in wrapper.process(TurnEnv(), event):
+    async for output in wrapper.process(TurnEnv(agent_env=AgentEnv()), event):
         results.append(output)
     return results
 


### PR DESCRIPTION
## What does this PR do?
[Design Doc](https://www.notion.so/cartesia/Agent-Knowledge-Bases-317e125e355580a18466eaf5d093ba62?source=copy_link#318e125e355580ab89eef7d88d3d4c52)

Two access patterns during a call:

**1. System tool: `knowledge_base`**

```
def knowledge_base(
	env: ToolEnv, 
	query: Annotated[str, "query to ask the knowledge has"],
)

# developers can either pass it in "raw"
LlmAgent(tools=[knowledge_base])
# or pre-filtered
LlmAgent(tools=[knowledge_base(filters={...}, top_k=10))])
```

**2. Programmatic access**

For users who want retrieval in custom logic (e.g., pre-fetching context in parallel with the inference call)

```python
class TurnEnv:
    def knowledge_base() -> KnowledgeBase

class ToolEnv:
    def knowledge_base() -> KnowledgeBase

class KnowledgeBase:
    def query(
        query: str,
        filters: Optional[Dict[str, str]] = None,
        top_k: int = 5
    ) -> List[Dict[str, Any]] # Currently {"content": str}, may expand to include metadata fields in the future
```

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Unit tests

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`
