### PR TITLE
[VA-456] Move to python 3.10 since deprecation of supporting 3.9 in 4/22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Welcome to the Line Voice Agents SDK repository. This file contains guidelines f
 
 
 ## Python Version Support
-Line SDK supports Python 3.10+. All code should be written to be compatible with Python 3.10+.
+Line SDK supports Python 3.10+. All code should be written to be compatible with Python 3.10+. (Versions <=3.9 are no longer supported as of April 22, 2026)
 
 ## Coding Style
 We follow the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) with some modifications (listed below).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Welcome to the Line Voice Agents SDK repository. This file contains guidelines f
 
 
 ## Python Version Support
-Line SDK supports Python 3.9+. All code should be written to be compatible with Python 3.9+.
+Line SDK supports Python 3.10+. All code should be written to be compatible with Python 3.10+.
 
 ## Coding Style
 We follow the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) with some modifications (listed below).

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -120,9 +120,8 @@ class LlmAgent:
         self.history = History()
         self._handoff_target: Optional[AgentCallable] = None  # Normalized process function
         # Queue for events from backgrounded tools that need to trigger loopback
-        # Lazy-init: asyncio.Queue() requires a running event loop on Python 3.9.
-        self._background_event_queue: Optional[BackgroundQueue[Tuple[AgentToolCalled, AgentToolReturned]]] = (
-            None
+        self._background_event_queue: BackgroundQueue[Tuple[AgentToolCalled, AgentToolReturned]] = (
+            BackgroundQueue()
         )
         # Cache for thought signatures (Gemini 3+ models)
         # Maps tool_call_id -> thought_signature
@@ -134,8 +133,6 @@ class LlmAgent:
     def _get_background_event_queue(
         self,
     ) -> "BackgroundQueue[Tuple[AgentToolCalled, AgentToolReturned]]":
-        if self._background_event_queue is None:
-            self._background_event_queue = BackgroundQueue()
         return self._background_event_queue
 
     def set_tools(self, tools: List[ToolSpec]) -> None:

--- a/line/llm_agent/realtime_provider.py
+++ b/line/llm_agent/realtime_provider.py
@@ -67,11 +67,9 @@ class _RealtimeProvider:
         self._ws_url = f"{WS_URL}?model={model_id.model}"
         self._ws: Optional[WebSocketClientProtocol] = None
         self._history: List[ConversationEntry] = []
-        # Lazy-init: asyncio.Lock() requires a running event loop on Python 3.9.
-        self._lock: Optional[asyncio.Lock] = None
+        self._lock: asyncio.Lock = asyncio.Lock()
 
     def _get_lock(self) -> asyncio.Lock:
-        self._lock = self._lock or asyncio.Lock()
         return self._lock
 
     # --- Public interface ---

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -288,8 +288,7 @@ class ConversationRunner:
         """
         self.websocket = websocket
         self.env = env
-        # Lazy-init: asyncio.Event() requires a running event loop on Python 3.9.
-        self._shutdown_event: Optional[asyncio.Event] = None
+        self._shutdown_event: asyncio.Event = asyncio.Event()
         self.history: List[InputEvent] = []
         self.emitted_agent_text: List[Tuple[str, bool]] = []  # (content, interruptible)
 
@@ -298,8 +297,6 @@ class ConversationRunner:
 
     @property
     def shutdown_event(self) -> asyncio.Event:
-        if self._shutdown_event is None:
-            self._shutdown_event = asyncio.Event()
         return self._shutdown_event
 
     ######### Initialization Methods #########

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cartesia-line"
 version = "0.2.10"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Cartesia AI, Inc.", email = "support@cartesia.ai"}
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -43,7 +42,7 @@ dependencies = [
     "ddgs>=9.8.0,<10",
     "phonenumbers>=9.0.22,<10",
     "build>=1.4.0,<2",
-    "mcp>=1.0.0,<2; python_version >= '3.10'",
+    "mcp>=1.0.0,<2",
 ]
 
 [project.optional-dependencies]
@@ -64,9 +63,7 @@ include = ["line*"]
 
 [tool.ruff]
 line-length = 110
-# We want to format the code with respect to Python 3.10 syntax.
-# even though we support 3.9+.
-target-version = 'py39'
+target-version = 'py310'
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
@@ -82,13 +79,12 @@ known-first-party = ["line"]
 force-sort-within-sections = true
 split-on-trailing-comma = true
 
-# type checking for python 3.9 syntax.
 # We only want to use this type checking for the main codebase.
 # We don't want to use it for the examples.
 [tool.pyright]
 include = ["line/", "tests/"]
 exclude = ["examples/"]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 typeCheckingMode = "off"
 reportIndexIssue = true
 reportGeneralTypeIssues = true


### PR DESCRIPTION
## What does this PR do?
- Bump minimum Python version from 3.9 to 3.10 across project config, CI, and documentation                                                                       
- Remove Python 3.9 lazy-init workarounds for asyncio.Queue, asyncio.Event, and asyncio.Lock (no longer needed since 3.10+ allows creating these outside a running event loop)                                                                         
- Remove the python_version >= '3.10' environment marker on the mcp dependency since 3.10 is now the floor                                                              
                                                                                   
Changed files                                                                       
- CONTRIBUTING.md — version support string                                         
- pyproject.toml — requires-python, classifiers, ruff target, pyright version, mcp
dep marker                                                                          
- .github/workflows/ci.yaml — lint and test matrix versions
- line/llm_agent/llm_agent.py — inline BackgroundQueue() init                       
- line/voice_agent_app.py — inline asyncio.Event() init                             
- line/llm_agent/realtime_provider.py — inline asyncio.Lock() init                  

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation
- [ ] Other: ___________

## Testing
- CI passes on 3.10–3.13 matrix                                                     
- Verify mcp installs unconditionally on 3.10+ 

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking change for users on Python 3.9 and slightly alters initialization timing for asyncio primitives, which could surface edge-case event-loop/lifecycle issues. Otherwise the changes are mechanical and low in complexity.
> 
> **Overview**
> **Drops Python 3.9 support** by raising the minimum version to `>=3.10` in `pyproject.toml`, updating docs, and removing `3.9` from the GitHub Actions lint/test matrices.
> 
> Cleans up runtime code that previously lazy-initialized asyncio primitives for 3.9 compatibility, now constructing `BackgroundQueue`, `asyncio.Lock`, and `asyncio.Event` eagerly, and makes `mcp` an unconditional dependency (no `python_version` marker).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d2b254fe41363cb026803f9de76bd6e3f3b09f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->