### PR TITLE
Merge loopback/passthrough tools

### DIFF
--- a/line/knowledge_base.py
+++ b/line/knowledge_base.py
@@ -92,7 +92,13 @@ class KnowledgeBase:
             async with aiohttp.ClientSession(timeout=timeout) as session:
                 async with session.get(url, params=params, headers=headers) as resp:
                     body = await resp.text()
-                    logger.info("knowledge_base query: url={} params={} status={} body={}", url, params, resp.status, body[:LOG_TRUNCATION])
+                    logger.info(
+                        "knowledge_base query: url={} params={} status={} body={}",
+                        url,
+                        params,
+                        resp.status,
+                        body[:LOG_TRUNCATION],
+                    )
                     if resp.status != 200:
                         logger.warning(
                             "knowledge_base query failed: status={} body={}",

--- a/line/llm_agent/__init__.py
+++ b/line/llm_agent/__init__.py
@@ -27,11 +27,11 @@ from line.llm_agent.tools.decorators import handoff_tool, loopback_tool, passthr
 from line.llm_agent.tools.system import (
     agent_as_handoff,
     end_call,
+    knowledge_base,
     mcp_tool,
     send_dtmf,
     transfer_call,
     web_search,
-    knowledge_base,
 )
 
 # Function tool definitions and types

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -21,6 +21,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    get_args,
 )
 
 from loguru import logger
@@ -62,8 +63,11 @@ from line.llm_agent.tools.utils import (
 
 T = TypeVar("T")
 
-# Type alias for tools that can be passed to LlmAgent
-# Plain callables are automatically wrapped as loopback tools
+# Concrete OutputEvent types for isinstance checks (OutputEvent itself is a Union).
+_OUTPUT_EVENT_TYPES: Tuple[type, ...] = get_args(OutputEvent)
+
+# Type alias for tools that can be passed to LlmAgent.
+# Plain callables are automatically wrapped via the @tool decorator.
 ToolSpec = Union[FunctionTool, WebSearchTool, EndCallTool, TransferCallTool, Callable]
 
 
@@ -375,7 +379,7 @@ class LlmAgent:
 
                 # For backgrounded tools, we emit AgentToolCalled/AgentToolReturned pairs
                 # inside _execute_backgroundable_tool, not here
-                if tool.tool_type == ToolType.LOOPBACK and tool.is_background:
+                if tool.tool_type == ToolType.TOOL and tool.is_background:
                     # Backgroundable tool: run in a shielded task that survives cancellation
                     # Each yielded value triggers a loopback with AgentToolCalled/AgentToolReturned pair
                     self._execute_backgroundable_tool(
@@ -383,73 +387,68 @@ class LlmAgent:
                     )
                     continue
 
-                if tool.tool_type == ToolType.LOOPBACK:
-                    should_loopback = True
-                    # Regular loopback tool: collect results to send back to LLM
+                if tool.tool_type == ToolType.TOOL:
+                    # Branch per yielded value:
+                    #   - OutputEvent → emit directly to the user (passthrough)
+                    #   - raw value  → wrap as a synthetic tool result and trigger loopback
                     n = 0
+                    yielded_raw = False
+                    closed = False
                     try:
-                        async for value in normalized_func(ctx, **tool_args):
-                            call_id = f"{tc.id}-{n}"
+                        try:
+                            async for value in normalized_func(ctx, **tool_args):
+                                if isinstance(value, _OUTPUT_EVENT_TYPES):
+                                    self.history._append_local(value)
+                                    yield value
+                                else:
+                                    yielded_raw = True
+                                    should_loopback = True
+                                    call_id = f"{tc.id}-{n}"
+                                    tool_called_output, tool_returned_output = _construct_tool_events(
+                                        call_id, tc.name, tool_args, value
+                                    )
+                                    self.history._append_local(tool_called_output)
+                                    self.history._append_local(tool_returned_output)
+                                    yield tool_called_output
+                                    yield tool_returned_output
+                                    n += 1
+                        except Exception as e:
+                            # Use negative limit to show last 10 frames (most relevant)
+                            logger.error(
+                                f'Error in Tool Call to "{tc.name}":\n{traceback.format_exc(limit=-10)}'
+                            )
                             tool_called_output, tool_returned_output = _construct_tool_events(
-                                call_id, tc.name, tool_args, value
+                                f"{tc.id}-{n}", tc.name, tool_args, f"error: {e}"
                             )
                             self.history._append_local(tool_called_output)
                             self.history._append_local(tool_returned_output)
                             yield tool_called_output
                             yield tool_returned_output
-                            n += 1
-                    except Exception as e:
-                        # Use negative limit to show last 10 frames (most relevant)
-                        logger.error(f'Error in Tool Call to "{tc.name}":\n{traceback.format_exc(limit=-10)}')
-                        tool_called_output, tool_returned_output = _construct_tool_events(
-                            f"{tc.id}-{n}", tc.name, tool_args, f"error: {e}"
-                        )
-                        self.history._append_local(tool_called_output)
-                        self.history._append_local(tool_returned_output)
-                        yield tool_called_output
-                        yield tool_returned_output
+                            yielded_raw = True
+                            should_loopback = True
 
-                elif tool.tool_type == ToolType.PASSTHROUGH:
-                    # Emit AgentToolCalled before executing
-                    tool_called_output = AgentToolCalled(
-                        tool_call_id=tc.id,
-                        tool_name=tc.name,
-                        tool_args=tool_args,
-                    )
-                    self.history._append_local(tool_called_output)
-                    yield tool_called_output
-
-                    tool_returned = False
-                    try:
-                        async for evt in normalized_func(ctx, **tool_args):
-                            self.history._append_local(evt)
-                            yield evt
-                        # Emit AgentToolReturned after successful completion
-                        tool_returned_output = AgentToolReturned(
-                            tool_call_id=tc.id,
-                            tool_name=tc.name,
-                            tool_args=tool_args,
-                            result="success",
-                        )
-                        self.history._append_local(tool_returned_output)
-                        tool_returned = True
-                        yield tool_returned_output
-                    except Exception as e:
-                        # Use negative limit to show last 10 frames (most relevant)
-                        logger.error(f'Error in Tool Call to "{tc.name}":\n{traceback.format_exc(limit=-10)}')
-                        # Emit AgentToolReturned with error
-                        tool_returned_output = AgentToolReturned(
-                            tool_call_id=tc.id,
-                            tool_name=tc.name,
-                            tool_args=tool_args,
-                            result=f"error: {e}",
-                        )
-                        self.history._append_local(tool_returned_output)
-                        tool_returned = True
-                        yield tool_returned_output
+                        # If the tool yielded only OutputEvents (or nothing at all), close out the
+                        # LLM-issued tool_call_id with a success pair so the LLM has a tool result anchor.
+                        if not yielded_raw:
+                            tool_called_output, tool_returned_output = _construct_tool_events(
+                                tc.id, tc.name, tool_args, "success"
+                            )
+                            self.history._append_local(tool_called_output)
+                            self.history._append_local(tool_returned_output)
+                            yield tool_called_output
+                            yield tool_returned_output
+                        closed = True
                     finally:
-                        if not tool_returned:
-                            # CancelledError (BaseException) - ensure history stays consistent
+                        if not closed and not yielded_raw:
+                            # CancelledError before any tool result was produced — record a
+                            # cancelled pair in history so the LLM doesn't see an orphan call.
+                            self.history._append_local(
+                                AgentToolCalled(
+                                    tool_call_id=tc.id,
+                                    tool_name=tc.name,
+                                    tool_args=tool_args,
+                                )
+                            )
                             self.history._append_local(
                                 AgentToolReturned(
                                     tool_call_id=tc.id,

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -379,7 +379,7 @@ class LlmAgent:
 
                 # For backgrounded tools, we emit AgentToolCalled/AgentToolReturned pairs
                 # inside _execute_backgroundable_tool, not here
-                if tool.tool_type == ToolType.TOOL and tool.is_background:
+                if tool.tool_type == ToolType.GENERAL and tool.is_background:
                     # Backgroundable tool: run in a shielded task that survives cancellation
                     # Each yielded value triggers a loopback with AgentToolCalled/AgentToolReturned pair
                     self._execute_backgroundable_tool(
@@ -387,7 +387,7 @@ class LlmAgent:
                     )
                     continue
 
-                if tool.tool_type == ToolType.TOOL:
+                if tool.tool_type == ToolType.GENERAL:
                     # Branch per yielded value:
                     #   - OutputEvent → emit directly to the user (passthrough)
                     #   - raw value  → wrap as a synthetic tool result and trigger loopback

--- a/line/llm_agent/tools/decorators.py
+++ b/line/llm_agent/tools/decorators.py
@@ -7,6 +7,14 @@ Usage:
         '''Tool description from docstring.'''
         ...
 
+The runtime classifies each yielded value:
+- Raw values (str, dict, etc.) feed back to the LLM as tool results.
+- OutputEvent instances pass through directly to the user.
+
+`loopback_tool` and `passthrough_tool` are interchangeable — they construct
+identical FunctionTools. The distinction is legacy from when the runtime had separate handling for each,
+but now the runtime behavior is decided by what the tool yields.
+
 Works on both standalone functions and class methods.
 """
 
@@ -63,8 +71,6 @@ def loopback_tool(
     func: Callable = None, *, is_background: bool = False
 ) -> Union[FunctionTool, Callable[[Callable], FunctionTool]]:
     """
-    Decorator for loopback tools. Result is sent back to the LLM to trigger a new completion.
-
     Signature: (ctx: ToolEnv, **args) -> AsyncIterable[Any] | Awaitable[Any] | Any
 
     Can be used with or without arguments:
@@ -105,7 +111,7 @@ def loopback_tool(
     """
 
     def decorator(f: Callable) -> FunctionTool:
-        return _construct_tool_descriptor(f, ToolType.LOOPBACK, is_background=is_background)
+        return _construct_tool_descriptor(f, ToolType.TOOL, is_background=is_background)
 
     if func is not None:
         # Called without arguments: @loopback_tool
@@ -116,14 +122,9 @@ def loopback_tool(
 
 def passthrough_tool(func: Callable) -> FunctionTool:
     """
-    Decorator for passthrough tools. Response bypasses the LLM, and is sent directly downstream
-
-    Signature: (ctx: ToolEnv, **args) -> AsyncIterable[OutputEvent] | Awaitable[OutputEvent] | OutputEvent
-
-    Use for deterministic actions like EndCall, TransferCall.
-    Tool yields OutputEvent objects directly to the caller.
+    Legacy decorator for passthrough tools. Behaves identically to loopback_tool, but exported separately for backwards compatibility.
     """
-    return _construct_tool_descriptor(func, ToolType.PASSTHROUGH)
+    return _construct_tool_descriptor(func, ToolType.TOOL)
 
 
 def handoff_tool(func: Callable) -> FunctionTool:

--- a/line/llm_agent/tools/decorators.py
+++ b/line/llm_agent/tools/decorators.py
@@ -122,7 +122,8 @@ def loopback_tool(
 
 def passthrough_tool(func: Callable) -> FunctionTool:
     """
-    Legacy decorator for passthrough tools. Behaves identically to loopback_tool, but exported separately for backwards compatibility.
+    Legacy decorator for passthrough tools. Behaves identically to loopback_tool, but exported separately
+    for backwards compatibility.
     """
     return _construct_tool_descriptor(func, ToolType.GENERAL)
 

--- a/line/llm_agent/tools/decorators.py
+++ b/line/llm_agent/tools/decorators.py
@@ -111,7 +111,7 @@ def loopback_tool(
     """
 
     def decorator(f: Callable) -> FunctionTool:
-        return _construct_tool_descriptor(f, ToolType.TOOL, is_background=is_background)
+        return _construct_tool_descriptor(f, ToolType.GENERAL, is_background=is_background)
 
     if func is not None:
         # Called without arguments: @loopback_tool
@@ -124,7 +124,7 @@ def passthrough_tool(func: Callable) -> FunctionTool:
     """
     Legacy decorator for passthrough tools. Behaves identically to loopback_tool, but exported separately for backwards compatibility.
     """
-    return _construct_tool_descriptor(func, ToolType.TOOL)
+    return _construct_tool_descriptor(func, ToolType.GENERAL)
 
 
 def handoff_tool(func: Callable) -> FunctionTool:

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -216,7 +216,7 @@ is possible."""
             _end_call_impl,
             name="end_call",
             description=self.description,
-            tool_type=ToolType.TOOL,
+            tool_type=ToolType.GENERAL,
         )
 
     def as_function_tool(self) -> FunctionTool:
@@ -299,7 +299,7 @@ class TransferCallTool:
             _transfer_call_impl,
             name="transfer_call",
             description=_transfer_call_impl.__doc__,
-            tool_type=ToolType.TOOL,
+            tool_type=ToolType.GENERAL,
         )
 
     def as_function_tool(self) -> FunctionTool:

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -216,7 +216,7 @@ is possible."""
             _end_call_impl,
             name="end_call",
             description=self.description,
-            tool_type=ToolType.PASSTHROUGH,
+            tool_type=ToolType.TOOL,
         )
 
     def as_function_tool(self) -> FunctionTool:
@@ -299,7 +299,7 @@ class TransferCallTool:
             _transfer_call_impl,
             name="transfer_call",
             description=_transfer_call_impl.__doc__,
-            tool_type=ToolType.PASSTHROUGH,
+            tool_type=ToolType.TOOL,
         )
 
     def as_function_tool(self) -> FunctionTool:

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -507,7 +507,7 @@ def mcp_tool(name: str, server_url: Optional[str] = None, **server_config: Any) 
         description=f"Access the '{name}' MCP server. "
         "Call without arguments to list available tools, "
         "or with tool_name and tool_args to invoke one.",
-        tool_type=ToolType.LOOPBACK,
+        tool_type=ToolType.GENERAL,
     )
 
 
@@ -594,7 +594,7 @@ class KnowledgeBaseTool:
             _knowledge_base_impl,
             name="knowledge_base",
             description=self._description,
-            tool_type=ToolType.LOOPBACK,
+            tool_type=ToolType.GENERAL,
             is_background=self._is_background,
         )
 

--- a/line/llm_agent/tools/utils.py
+++ b/line/llm_agent/tools/utils.py
@@ -75,7 +75,7 @@ class ToolType(Enum):
     instances pass through directly to the user.
     """
 
-    TOOL = "tool"
+    GENERAL = "general"
     HANDOFF = "handoff"
 
 
@@ -146,7 +146,7 @@ class FunctionTool:
     description: str
     func: Callable
     parameters: Dict[str, "ParameterInfo"]
-    tool_type: ToolType = ToolType.TOOL
+    tool_type: ToolType = ToolType.GENERAL
     is_background: bool = False
 
 
@@ -421,7 +421,7 @@ def _web_search_tool_to_function_tool(web_search_tool: Any) -> FunctionTool:
         name="web_search",
         description="Search the web for real-time information."
         + " Use this when you need current information that may not be in your training data.",
-        tool_type=ToolType.TOOL,
+        tool_type=ToolType.GENERAL,
     )
 
 

--- a/line/llm_agent/tools/utils.py
+++ b/line/llm_agent/tools/utils.py
@@ -68,10 +68,14 @@ if TYPE_CHECKING:
 
 
 class ToolType(Enum):
-    """Tool execution paradigm type."""
+    """Tool execution paradigm.
 
-    LOOPBACK = "loopback"
-    PASSTHROUGH = "passthrough"
+    TOOL covers the unified loopback/passthrough behavior: branching now happens
+    per yielded value at runtime — raw values feed back to the LLM, OutputEvent
+    instances pass through directly to the user.
+    """
+
+    TOOL = "tool"
     HANDOFF = "handoff"
 
 
@@ -96,8 +100,11 @@ class ToolEnv:
 # -------------------------
 
 
-class LoopbackToolFn(Protocol):
-    """Loopback tool: result is sent back to the LLM for continued generation.
+class ToolFn(Protocol):
+    """Tool callable. Each yielded value is classified at runtime:
+
+    - OutputEvent instances pass through directly to the user.
+    - Raw values (str, dict, etc.) are sent back to the LLM as the tool result.
 
     Signature: (ctx: ToolEnv, **kwargs) -> AsyncIterable[Any] | Awaitable[Any] | Any
     """
@@ -105,16 +112,10 @@ class LoopbackToolFn(Protocol):
     def __call__(self, ctx: ToolEnv, /, **kwargs: Any) -> Union[AsyncIterable[Any], Awaitable[Any], Any]: ...
 
 
-class PassthroughToolFn(Protocol):
-    """Passthrough tool: response bypasses the LLM and goes directly to the user.
-
-    Signature: (ctx: ToolEnv, **kwargs) ->
-        AsyncIterable[OutputEvent] | Awaitable[OutputEvent] | OutputEvent
-    """
-
-    def __call__(
-        self, ctx: ToolEnv, /, **kwargs: Any
-    ) -> Union[AsyncIterable[OutputEvent], Awaitable[OutputEvent], OutputEvent]: ...
+# Aliases — the runtime no longer distinguishes loopback vs. passthrough at the
+# tool-type level, so the protocols collapse onto ToolFn.
+LoopbackToolFn = ToolFn
+PassthroughToolFn = ToolFn
 
 
 class HandoffToolFn(Protocol):
@@ -145,7 +146,7 @@ class FunctionTool:
     description: str
     func: Callable
     parameters: Dict[str, "ParameterInfo"]
-    tool_type: ToolType = ToolType.LOOPBACK
+    tool_type: ToolType = ToolType.TOOL
     is_background: bool = False
 
 
@@ -420,7 +421,7 @@ def _web_search_tool_to_function_tool(web_search_tool: Any) -> FunctionTool:
         name="web_search",
         description="Search the web for real-time information."
         + " Use this when you need current information that may not be in your training data.",
-        tool_type=ToolType.LOOPBACK,
+        tool_type=ToolType.TOOL,
     )
 
 

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -1107,7 +1107,7 @@ async def test_plain_function_wrapped_as_loopback_tool():
 
     # Should be a FunctionTool
     assert isinstance(tool, FunctionTool)
-    assert tool.tool_type == ToolType.TOOL
+    assert tool.tool_type == ToolType.GENERAL
 
     # Name and description should come from the function
     assert tool.name == "my_tool"
@@ -1194,8 +1194,8 @@ async def test_mixed_decorated_and_plain_functions(turn_env):
     resolved_tools, _ = _normalize_tools([decorated_tool, plain_tool], model_id=parse_model_id("gpt-4o"))
 
     assert len(resolved_tools) == 2
-    assert resolved_tools[0].tool_type == ToolType.TOOL
-    assert resolved_tools[1].tool_type == ToolType.TOOL
+    assert resolved_tools[0].tool_type == ToolType.GENERAL
+    assert resolved_tools[1].tool_type == ToolType.GENERAL
 
     # Names should be correct
     assert resolved_tools[0].name == "decorated_tool"

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -634,30 +634,32 @@ async def test_passthrough_tool_bypasses_llm(turn_env):
         agent, turn_env, UserTextSent(content="Bye", history=[UserTextSent(content="Bye")])
     )
 
-    # Expected outputs:
+    # Expected outputs (the runtime branches per yielded value: OutputEvents pass
+    # through directly, then a (Called, Returned-success) pair closes out the
+    # LLM-issued tool_call_id once the tool finishes without yielding raw values):
     # 1. AgentSendText "Goodbye! "
-    # 2. AgentToolCalled
-    # 3. AgentSendText "Have a great day!" (from passthrough)
-    # 4. AgentEndCall (from passthrough)
-    # 5. AgentToolReturned (emitted at the end of tool execution)
+    # 2. AgentSendText "Have a great day!" (from yield)
+    # 3. AgentEndCall (from yield)
+    # 4. AgentToolCalled (closing pair)
+    # 5. AgentToolReturned (closing pair)
 
     assert len(outputs) == 5
 
     assert isinstance(outputs[0], AgentSendText)
     assert outputs[0].text == "Goodbye! "
 
-    assert isinstance(outputs[1], AgentToolCalled)
-    assert outputs[1].tool_name == "end_call"
+    assert isinstance(outputs[1], AgentSendText)
+    assert outputs[1].text == "Have a great day!"
 
-    assert isinstance(outputs[2], AgentSendText)
-    assert outputs[2].text == "Have a great day!"
+    assert isinstance(outputs[2], AgentEndCall)
 
-    assert isinstance(outputs[3], AgentEndCall)
+    assert isinstance(outputs[3], AgentToolCalled)
+    assert outputs[3].tool_name == "end_call"
 
     assert isinstance(outputs[4], AgentToolReturned)
     assert outputs[4].result == "success"
 
-    # LLM should only be called ONCE - passthrough doesn't loop back
+    # Yielding only OutputEvents doesn't trigger a loopback — LLM is called once.
     assert mock_llm._call_count == 1
 
 
@@ -1105,9 +1107,7 @@ async def test_plain_function_wrapped_as_loopback_tool():
 
     # Should be a FunctionTool
     assert isinstance(tool, FunctionTool)
-
-    # Should be loopback type
-    assert tool.tool_type == ToolType.LOOPBACK
+    assert tool.tool_type == ToolType.TOOL
 
     # Name and description should come from the function
     assert tool.name == "my_tool"
@@ -1194,10 +1194,8 @@ async def test_mixed_decorated_and_plain_functions(turn_env):
     resolved_tools, _ = _normalize_tools([decorated_tool, plain_tool], model_id=parse_model_id("gpt-4o"))
 
     assert len(resolved_tools) == 2
-
-    # Both should be loopback tools after resolution
-    assert resolved_tools[0].tool_type == ToolType.LOOPBACK
-    assert resolved_tools[1].tool_type == ToolType.LOOPBACK
+    assert resolved_tools[0].tool_type == ToolType.TOOL
+    assert resolved_tools[1].tool_type == ToolType.TOOL
 
     # Names should be correct
     assert resolved_tools[0].name == "decorated_tool"

--- a/tests/test_llm_agent_tools_decorators.py
+++ b/tests/test_llm_agent_tools_decorators.py
@@ -81,7 +81,7 @@ def test_loopback_tool_with_ctx_succeeds():
         return f"Weather in {city}"
 
     assert good_tool.name == "good_tool"
-    assert good_tool.tool_type.value == "tool"
+    assert good_tool.tool_type.value == "general"
     assert "city" in good_tool.parameters
     assert good_tool.parameters["city"].description == "City name"
 
@@ -107,7 +107,7 @@ def test_passthrough_tool_with_ctx_succeeds():
         yield AgentSendText(text=message)
 
     assert good_tool.name == "good_tool"
-    assert good_tool.tool_type.value == "tool"
+    assert good_tool.tool_type.value == "general"
     assert "message" in good_tool.parameters
 
 
@@ -249,7 +249,7 @@ def test_method_tool_binding():
 
     # Check it's still a FunctionTool
     assert bound_tool.name == "greet"
-    assert bound_tool.tool_type.value == "tool"
+    assert bound_tool.tool_type.value == "general"
     assert "name" in bound_tool.parameters
     # 'self' should NOT be in parameters
     assert "self" not in bound_tool.parameters
@@ -299,7 +299,7 @@ def test_method_passthrough_tool():
     bound_tool = filler.submit
 
     assert bound_tool.name == "submit"
-    assert bound_tool.tool_type.value == "tool"
+    assert bound_tool.tool_type.value == "general"
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_agent_tools_decorators.py
+++ b/tests/test_llm_agent_tools_decorators.py
@@ -81,7 +81,7 @@ def test_loopback_tool_with_ctx_succeeds():
         return f"Weather in {city}"
 
     assert good_tool.name == "good_tool"
-    assert good_tool.tool_type.value == "loopback"
+    assert good_tool.tool_type.value == "tool"
     assert "city" in good_tool.parameters
     assert good_tool.parameters["city"].description == "City name"
 
@@ -107,7 +107,7 @@ def test_passthrough_tool_with_ctx_succeeds():
         yield AgentSendText(text=message)
 
     assert good_tool.name == "good_tool"
-    assert good_tool.tool_type.value == "passthrough"
+    assert good_tool.tool_type.value == "tool"
     assert "message" in good_tool.parameters
 
 
@@ -249,7 +249,7 @@ def test_method_tool_binding():
 
     # Check it's still a FunctionTool
     assert bound_tool.name == "greet"
-    assert bound_tool.tool_type.value == "loopback"
+    assert bound_tool.tool_type.value == "tool"
     assert "name" in bound_tool.parameters
     # 'self' should NOT be in parameters
     assert "self" not in bound_tool.parameters
@@ -299,7 +299,7 @@ def test_method_passthrough_tool():
     bound_tool = filler.submit
 
     assert bound_tool.name == "submit"
-    assert bound_tool.tool_type.value == "passthrough"
+    assert bound_tool.tool_type.value == "tool"
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -389,7 +389,7 @@ async def test_end_call_has_function_tool_attributes(mock_ctx, anyio_backend):
     assert hasattr(func_tool, "func")
 
     assert func_tool.name == "end_call"
-    assert func_tool.tool_type == ToolType.TOOL
+    assert func_tool.tool_type == ToolType.GENERAL
     assert func_tool.is_background is False
 
     # Verify it's actually a FunctionTool instance (not duck-typed)
@@ -528,7 +528,7 @@ async def test_transfer_call_has_function_tool_attributes(mock_ctx, anyio_backen
     func_tool = transfer_call.as_function_tool()
     assert isinstance(func_tool, FunctionTool)
     assert func_tool.name == "transfer_call"
-    assert func_tool.tool_type == ToolType.TOOL
+    assert func_tool.tool_type == ToolType.GENERAL
     assert set(func_tool.parameters.keys()) == {"target_phone_number"}
     assert "message" not in func_tool.parameters
     assert func_tool.parameters["target_phone_number"].required is True

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -74,7 +74,7 @@ def tool_ctx_with_kb(kb: FakeKnowledgeBase):
 def test_knowledge_base_tool_default_metadata(anyio_backend):
     ft = knowledge_base.as_function_tool()
     assert ft.name == "knowledge_base"
-    assert ft.tool_type == ToolType.LOOPBACK
+    assert ft.tool_type == ToolType.GENERAL
     assert "knowledge base" in ft.description.lower()
     assert "query" in ft.parameters
 

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -389,7 +389,7 @@ async def test_end_call_has_function_tool_attributes(mock_ctx, anyio_backend):
     assert hasattr(func_tool, "func")
 
     assert func_tool.name == "end_call"
-    assert func_tool.tool_type == ToolType.PASSTHROUGH
+    assert func_tool.tool_type == ToolType.TOOL
     assert func_tool.is_background is False
 
     # Verify it's actually a FunctionTool instance (not duck-typed)
@@ -528,7 +528,7 @@ async def test_transfer_call_has_function_tool_attributes(mock_ctx, anyio_backen
     func_tool = transfer_call.as_function_tool()
     assert isinstance(func_tool, FunctionTool)
     assert func_tool.name == "transfer_call"
-    assert func_tool.tool_type == ToolType.PASSTHROUGH
+    assert func_tool.tool_type == ToolType.TOOL
     assert set(func_tool.parameters.keys()) == {"target_phone_number"}
     assert "message" not in func_tool.parameters
     assert func_tool.parameters["target_phone_number"].required is True


### PR DESCRIPTION
## What does this PR do?

[Slack convo](https://cartesia-ai.slack.com/archives/C08RSRJDQ2K/p1778193232630249)

We currently distinguish between `@loopback_tool` and `@passthrough_tool` in the type annotation of tools:
1) Loopback: the output of the tool call is passed back to the agent as input for the next step (also the default)
2) Passthrough: the output of the tool call is not passed back to the agent, but is instead returned directly to the user (e.g. `AgentSendText` goes straight to the harness)

There are a bunch of situations where we want to be able to have a tool that does both: either conditionally (depending on args) or interleaved.

This PR merges the annotations, giving us effectively just the one type. The decision to passthrough vs. loopback is now based on the type of the yielded value:
1) `OutputEvent`: yielded directly to the user (passthrough)
2) `str`: passed back to the agent (loopback)

This _does not_ change the exposed decorators. We can do that at a later time if we want, but for now this is just an internal change to simplify the implementation of tools.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Unit tests

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`
