### PR TITLE
Remove local uv source override from basic_chat example

### DIFF
--- a/examples/basic_chat/pyproject.toml
+++ b/examples/basic_chat/pyproject.toml
@@ -10,6 +10,3 @@ dependencies = [
 
 [tool.setuptools]
 py-modules = ["main"]
-
-[tool.uv.sources]
-cartesia-line = { path = "../../", editable=true }


### PR DESCRIPTION
## Summary
- Removes `[tool.uv.sources]` block that pinned `cartesia-line` to a local editable path (`../../`), which does not resolve in production builds.

## Test plan
- [x] `uv sync` from a clean checkout of `examples/basic_chat` resolves `cartesia-line==0.2.10` from PyPI.
- [x] Production build pipeline succeeds.