### PR TITLE
Revert basic_chat tool from knowledge_base back to web_search

### DIFF
--- a/examples/basic_chat/main.py
+++ b/examples/basic_chat/main.py
@@ -2,7 +2,7 @@ import os
 
 from loguru import logger
 
-from line.llm_agent import LlmAgent, LlmConfig, knowledge_base
+from line.llm_agent import LlmAgent, LlmConfig, web_search
 from line.voice_agent_app import AgentEnv, CallRequest, VoiceAgentApp
 
 #  ANTHROPIC_API_KEY=your-key uv python main.py
@@ -64,7 +64,7 @@ async def get_agent(env: AgentEnv, call_request: CallRequest):
     return LlmAgent(
         model="anthropic/claude-haiku-4-5-20251001",
         api_key=os.getenv("ANTHROPIC_API_KEY"),
-        tools=[knowledge_base],
+        tools=[web_search],
         config=LlmConfig.from_call_request(
             call_request, fallback_system_prompt=SYSTEM_PROMPT, fallback_introduction=INTRODUCTION
         ),


### PR DESCRIPTION
## Summary
- Reverts the `basic_chat` example's tool back to `web_search`. The KB tool change from #222 should not live in the starter template.

## Test plan
- [x] `uv run python examples/basic_chat/main.py` starts without import errors.
- [x] Agent responds to a query that exercises `web_search`.