### PR TITLE
Create alpha release 0.2.11a0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cartesia-line"
-version = "0.2.10"
+version = "0.2.11a0"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What does this PR do?

- Knowledge Base querying support (#222, 20310af) — new knowledge_base built-in tool with backgroundable execution and long-timeout warning; documented in README.
- Merged loopback/passthrough tools into a unified "general" tool type (#225, c23c8cd).
- Dropped Python 3.9, moved minimum to Python 3.10 (#223, ac9a898) — VA-456, since 3.9 hits end-of-support 2025-10.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: Version bump

## Testing
Version bump

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`
