### PR TITLE
Bump version to 0.2.11

### DIFF
--- a/example_integrations/browserbase/pyproject.toml
+++ b/example_integrations/browserbase/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Voice agent that fills web forms using Stagehand browser automation (Line SDK)"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
     "stagehand>=3.0.0",
     "google-genai>=1.26.0",
     "loguru>=0.7.0",

--- a/example_integrations/cerebras/pyproject.toml
+++ b/example_integrations/cerebras/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "An interviewer agent using Cerebras via LiteLLM with Line SDK v0.2"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
     "python-dotenv>=1.0.0",
     "loguru>=0.7.0",
     "pydantic>=2.0.0",

--- a/example_integrations/exa/pyproject.toml
+++ b/example_integrations/exa/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A web research voice agent using Exa API and Cartesia Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
     "exa-py>=1.0.0",
     "loguru>=0.7.0",
     "python-dotenv>=1.0.0",

--- a/example_integrations/tavily/pyproject.toml
+++ b/example_integrations/tavily/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A web research voice agent using Tavily API and Cartesia Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
     "tavily-python>=0.7.23",
     "loguru>=0.7.3",
     "python-dotenv>=1.2.2",

--- a/examples/basic_chat/pyproject.toml
+++ b/examples/basic_chat/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Basic chat example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
     "loguru>=0.7.0",
 ]
 

--- a/examples/chat_supervisor/pyproject.toml
+++ b/examples/chat_supervisor/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Chat/Supervisor example: A fast Haiku agent that consults Opus for complex questions"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
 ]
 
 [tool.setuptools]

--- a/examples/echo/pyproject.toml
+++ b/examples/echo/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Handoff echo example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
     "loguru>=0.7.0",
 ]
 

--- a/examples/form_filler/pyproject.toml
+++ b/examples/form_filler/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Voice agent that helps patients schedule doctor appointments and complete intake forms."
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
     "loguru>=0.7.0",
 ]
 

--- a/examples/guardrails_wrapper/pyproject.toml
+++ b/examples/guardrails_wrapper/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Guardrails wrapper example - LLM agent with preprocessing/postprocessing for content filtering"
 requires-python = ">=3.10"
 dependencies = [
-   "cartesia-line==0.2.10",
+   "cartesia-line==0.2.11",
 ]
 
 [tool.setuptools]

--- a/examples/sales_with_leads/pyproject.toml
+++ b/examples/sales_with_leads/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Sales agent with stateful leads extraction and company research"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
     "loguru>=0.7.0",
 ]
 

--- a/examples/transfer_agent/pyproject.toml
+++ b/examples/transfer_agent/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Multi-agent handoff example demonstrating agent-to-agent transfers using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
 ]
 
 [tool.setuptools]

--- a/examples/transfer_phone_call/pyproject.toml
+++ b/examples/transfer_phone_call/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Phone transfer example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.10",
+    "cartesia-line==0.2.11",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cartesia-line"
-version = "0.2.11a0"
+version = "0.2.11"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What does this PR do?

  - Add Knowledge Base querying support (#222)
  - Move to Python 3.10, drop 3.9 (#223)
  - Merge loopback/passthrough tools (#225)
  - Remove local uv source override from basic_chat example (#226)
  - Revert basic_chat tool from knowledge_base to web_search (#227)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: Version bump

## Testing
N/A

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`
