### PR TITLE
[VA-892] Specify upper bound (exclusive) of 3.14 for Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cartesia-line"
 version = "0.2.11"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 authors = [
     {name = "Cartesia AI, Inc.", email = "support@cartesia.ai"}
 ]


### PR DESCRIPTION
## What does this PR do?

Specify upper bound (exclusive) of 3.14 for Python version as `uv sync` currently fails due to missing wheels.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How did you test this?

## Checklist
- [X] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have formatted my code with `make format`
