### PR TITLE
[VA-864] Emit end_call reason + built-in voicemail tool (VA-866)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,20 +121,21 @@ async def get_agent(env: AgentEnv, call_request: CallRequest):
 Ready-to-use tools for common actions:
 
 ```python
-from line.llm_agent import LlmAgent, LlmConfig, end_call, knowledge_base, send_dtmf, transfer_call, web_search
+from line.llm_agent import LlmAgent, LlmConfig, end_call, knowledge_base, send_dtmf, transfer_call, voicemail, web_search
 
 agent = LlmAgent(
     model="gemini/gemini-2.5-flash-preview-09-2025",
-    tools=[end_call, send_dtmf, transfer_call, web_search, knowledge_base],
+    tools=[end_call, send_dtmf, transfer_call, voicemail, web_search, knowledge_base],
     config=LlmConfig(...),
 )
 ```
 
 | Tool | What it does |
 |------|--------------|
-| `end_call` | Ends the call |
+| `end_call` | Ends the call (records `end_reason="agent_ended"`) |
 | `send_dtmf` | Presses phone buttons (0-9, *, #) |
 | `transfer_call` | Transfers to a phone number (E.164 format) |
+| `voicemail` | Call when you reach a voicemail: optionally leaves a message, then ends the call with `end_reason="voicemail_detected"`. Configure with `voicemail(message="…")` |
 | `web_search` | Searches the web (native LLM search or DuckDuckGo fallback) |
 | `knowledge_base` | Looks up information from the agent's knowledge base via natural-language query. Call `knowledge_base(filters={...}, top_k=10)` to pre-filter retrievals or override `top_k` |
 

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ agent = LlmAgent(
 
 | Tool | What it does |
 |------|--------------|
-| `end_call` | Ends the call (records `end_reason="agent_ended"`) |
+| `end_call` | Ends the call |
 | `send_dtmf` | Presses phone buttons (0-9, *, #) |
 | `transfer_call` | Transfers to a phone number (E.164 format) |
-| `voicemail` | Call when you reach a voicemail: optionally leaves a message, then ends the call with `end_reason="voicemail_detected"`. Configure with `voicemail(message="…")` |
+| `voicemail` | Call when you reach a voicemail: optionally leaves a message, then hangs up the call. Configure with `voicemail(message="…")` |
 | `web_search` | Searches the web (native LLM search or DuckDuckGo fallback) |
 | `knowledge_base` | Looks up information from the agent's knowledge base via natural-language query. Call `knowledge_base(filters={...}, top_k=10)` to pre-filter retrievals or override `top_k` |
 

--- a/line/__init__.py
+++ b/line/__init__.py
@@ -30,6 +30,7 @@ from line.events import (
     CallStarted,
     # Custom events
     CustomHistoryEntry,
+    EndCallReason,
     HistoryEvent,
     InputEvent,
     LogMessage,
@@ -71,6 +72,7 @@ __all__ = [
     "AgentSendText",
     "AgentSendDtmf",
     "AgentEndCall",
+    "EndCallReason",
     "AgentTransferCall",
     "AgentToolCalled",
     "AgentToolReturned",

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field
 
 ########################################################
-#  Copied and adapted from Bifrost agent_types.py
+#  Wire message types for the Cartesia voice-agent websocket protocol.
 ########################################################
 
 # Input messages to be sent over the websocket to the user code
@@ -108,6 +108,9 @@ class TransferOutput(BaseModel):
 
 class EndCallOutput(BaseModel):
     type: Literal["end_call"] = "end_call"
+    # Free-form on the wire so the harness never rejects an unknown reason from a
+    # newer SDK; the canonical vocabulary is line.events.EndCallReason.
+    reason: Optional[str] = None
     responding_to: Optional[str] = None
     interruptible: bool = True
 

--- a/line/events.py
+++ b/line/events.py
@@ -42,8 +42,15 @@ class AgentToolReturned(BaseModel):
     responding_to: Optional[str] = None
 
 
+# Supported end_reason values in the Cartesia API. "agent_ended" is the default
+# normal hangup (from end_call); "voicemail_detected" is set by the voicemail tool.
+# The reason field below stays a plain str so an unexpected value never raises.
+EndCallReason = Literal["agent_ended", "voicemail_detected"]
+
+
 class AgentEndCall(BaseModel):
     type: Literal["end_call"] = "end_call"
+    reason: str = "agent_ended"
     responding_to: Optional[str] = None
     interruptible: bool = True
 

--- a/line/llm_agent/__init__.py
+++ b/line/llm_agent/__init__.py
@@ -31,6 +31,7 @@ from line.llm_agent.tools.system import (
     mcp_tool,
     send_dtmf,
     transfer_call,
+    voicemail,
     web_search,
 )
 
@@ -66,6 +67,7 @@ __all__ = [
     "end_call",
     "send_dtmf",
     "transfer_call",
+    "voicemail",
     "web_search",
     "agent_as_handoff",
     "mcp_tool",

--- a/line/llm_agent/tools/__init__.py
+++ b/line/llm_agent/tools/__init__.py
@@ -20,6 +20,7 @@ from line.llm_agent.tools.system import (
     knowledge_base,
     send_dtmf,
     transfer_call,
+    voicemail,
     web_search,
 )
 
@@ -47,6 +48,7 @@ __all__ = [
     "end_call",
     "send_dtmf",
     "transfer_call",
+    "voicemail",
     "agent_as_handoff",
     "knowledge_base",
     # Utility types

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -210,7 +210,9 @@ is possible."""
             ctx: ToolEnv,
             reason: Annotated[str, "The reason for ending the call"],
         ):
-            yield AgentEndCall(interruptible=self.interruptible)
+            # end_call always reports a normal agent hangup; the voicemail tool is
+            # the only path to reason="voicemail_detected".
+            yield AgentEndCall(reason="agent_ended", interruptible=self.interruptible)
 
         return construct_function_tool(
             _end_call_impl,
@@ -321,6 +323,94 @@ class TransferCallTool:
 #   transfer_call                                              # Use default behavior
 #   transfer_call(interruptible=False)                          # Disable interruptibility
 transfer_call = TransferCallTool()
+
+
+class VoicemailTool:
+    """
+    voicemail tool: the LLM calls this when it detects it has reached a voicemail /
+    answering machine. An optional fixed message and interruptibility are set at
+    construction (``VoicemailTool(...)`` / ``voicemail(...)``), not by the LLM.
+
+    The detection cues live in the tool's description (below), so the agent's system
+    prompt doesn't need to carry voicemail-handling instructions. When invoked the tool
+    speaks the configured message (if any) and then ends the call with
+    ``reason="voicemail_detected"``, which the Cartesia API records as the call's
+    ``end_reason``.
+
+    Behavior modes (all from this one tool):
+      - voicemail(message="...")  -> speak the message (uninterruptible), then end.
+      - voicemail                 -> silently end the call (no message).
+      - dynamic message           -> let the LLM speak in its turn, then call voicemail() to end.
+    """
+
+    DEFAULT_DESCRIPTION = """End the call because you've reached a voicemail or answering machine.
+
+Use when the greeting is a machine, e.g.:
+- "please leave a message", "at the tone", "you've reached the voicemail of…"
+- a beep, or a one-sided recorded greeting with no back-and-forth
+
+Do NOT use this if a real person is talking with you. You may leave a brief message
+first; this tool ends the call."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        interruptible: bool = False,
+        description: Optional[str] = None,
+    ):
+        # interruptible defaults to False: on a voicemail there's no human to interrupt
+        # and we want the message left in full.
+        self.message = message
+        self.interruptible = interruptible
+        self.description = description if description else self.DEFAULT_DESCRIPTION
+        self._function_tool = self._create_function_tool()
+
+    @property
+    def name(self) -> str:
+        """Return the tool name."""
+        return "voicemail"
+
+    def _create_function_tool(self) -> FunctionTool:
+        """Create the underlying FunctionTool with the configured message and interruptibility."""
+
+        async def _voicemail_impl(ctx: ToolEnv):
+            # Keep "voicemail_detected" in sync with EndCallReason in line/events.py.
+            if self.message:
+                yield AgentSendText(text=self.message, interruptible=self.interruptible)
+            yield AgentEndCall(reason="voicemail_detected", interruptible=self.interruptible)
+
+        return construct_function_tool(
+            _voicemail_impl,
+            name="voicemail",
+            description=self.description,
+            tool_type=ToolType.GENERAL,
+        )
+
+    def as_function_tool(self) -> FunctionTool:
+        """Return the underlying FunctionTool for use in tool resolution."""
+        return self._function_tool
+
+    def __call__(
+        self,
+        message: Optional[str] = None,
+        interruptible: bool = False,
+        description: Optional[str] = None,
+    ) -> "VoicemailTool":
+        """Create a configured VoicemailTool instance.
+
+        Args:
+            message: Optional message spoken (uninterruptible by default) before the call ends.
+            interruptible: Whether the message/end are interruptible.
+            description: Override the default LLM-facing description (when to invoke).
+        """
+        return VoicemailTool(message=message, interruptible=interruptible, description=description)
+
+
+# Default instance - can be used directly or called to configure
+# Examples:
+#   voicemail                                          # Silently end on voicemail
+#   voicemail(message="Hi, please call us back…")      # Leave a message, then end
+voicemail = VoicemailTool()
 
 
 @dataclass
@@ -727,6 +817,7 @@ __all__ = [
     "DtmfButton",
     "EndCallTool",
     "TransferCallTool",
+    "VoicemailTool",
     "UpdateCallConfig",
     "WebSearchTool",
     "web_search",
@@ -734,5 +825,6 @@ __all__ = [
     "end_call",
     "send_dtmf",
     "transfer_call",
+    "voicemail",
     "agent_as_handoff",
 ]

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -210,8 +210,7 @@ is possible."""
             ctx: ToolEnv,
             reason: Annotated[str, "The reason for ending the call"],
         ):
-            # end_call always reports a normal agent hangup; the voicemail tool is
-            # the only path to reason="voicemail_detected".
+            # end_call always reports a normal agent hangup reason.
             yield AgentEndCall(reason="agent_ended", interruptible=self.interruptible)
 
         return construct_function_tool(

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -199,8 +199,8 @@ class VoiceAgentApp:
             except Exception as e:
                 logger.error(f"Error in pre_call_handler: {str(e)}")
                 # Mark this as customer-code-originated so downstream services
-                # (e.g. Inferno) can attribute the failure correctly rather than
-                # treating it as a Cartesia/SDK error.
+                # can attribute the failure correctly rather than treating it as
+                # a Cartesia/SDK error.
                 raise HTTPException(
                     status_code=500,
                     detail="Server error in call processing",
@@ -672,8 +672,12 @@ class ConversationRunner:
             logger.info(f"<- 🤖🔔 Agent DTMF sent: {event.button}")
             return DTMFOutput(button=event.button, responding_to=event.responding_to)
         if isinstance(event, AgentEndCall):
-            logger.info(f"<- 📞 End call (interruptible={event.interruptible})")
-            return EndCallOutput(responding_to=event.responding_to, interruptible=event.interruptible)
+            logger.info(f"<- 📞 End call (reason={event.reason}, interruptible={event.interruptible})")
+            return EndCallOutput(
+                reason=event.reason,
+                responding_to=event.responding_to,
+                interruptible=event.interruptible,
+            )
         if isinstance(event, AgentTransferCall):
             logger.info(
                 f"<- 📱 Transfer to: {event.target_phone_number} (interruptible={event.interruptible})"

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -16,10 +16,12 @@ from line.llm_agent.tools.system import (
     EndCallTool,
     KnowledgeBaseTool,
     TransferCallTool,
+    VoicemailTool,
     end_call,
     knowledge_base,
     send_dtmf,
     transfer_call,
+    voicemail,
 )
 from line.llm_agent.tools.utils import ToolType
 
@@ -350,13 +352,15 @@ async def test_end_call_default_description(mock_ctx, anyio_backend):
 
 
 async def test_end_call_yields_agent_end_call(mock_ctx, anyio_backend):
-    """Test that end_call yields AgentEndCall event."""
+    """end_call always reports a normal agent hangup (reason=agent_ended)."""
     func_tool = end_call.as_function_tool()
-    # LLM must provide a reason when calling end_call
+    # The LLM supplies a free-form reason, but end_call hardcodes agent_ended;
+    # voicemail_detected only comes from the voicemail tool.
     events = await collect_events(func_tool.func(mock_ctx, reason="user said goodbye"))
 
     assert len(events) == 1
     assert isinstance(events[0], AgentEndCall)
+    assert events[0].reason == "agent_ended"
 
 
 async def test_end_call_requires_reason_parameter(mock_ctx, anyio_backend):
@@ -580,3 +584,48 @@ async def test_normalize_tools_rejects_duplicate_names(anyio_backend):
             [knowledge_base, knowledge_base(filters={"x": "y"})],
             parse_model_id("openai/gpt-4o"),
         )
+
+
+# ============================================================
+# Tests: voicemail
+# ============================================================
+
+
+async def test_voicemail_with_message(mock_ctx, anyio_backend):
+    """voicemail(message=...) speaks the message (uninterruptible) then ends the call."""
+    tool = voicemail(message="Hi, please call us back.")
+    events = await collect_events(tool.as_function_tool().func(mock_ctx))
+
+    assert len(events) == 2
+    assert isinstance(events[0], AgentSendText)
+    assert events[0].text == "Hi, please call us back."
+    assert events[0].interruptible is False
+    assert isinstance(events[1], AgentEndCall)
+    assert events[1].reason == "voicemail_detected"
+    assert events[1].interruptible is False
+
+
+async def test_voicemail_no_message_silent_end(mock_ctx, anyio_backend):
+    """Bare voicemail silently ends the call with reason=voicemail_detected."""
+    events = await collect_events(voicemail.as_function_tool().func(mock_ctx))
+
+    assert len(events) == 1
+    assert isinstance(events[0], AgentEndCall)
+    assert events[0].reason == "voicemail_detected"
+
+
+async def test_voicemail_name_and_takes_no_llm_args(mock_ctx, anyio_backend):
+    """The tool is named 'voicemail' and exposes no LLM-facing parameters."""
+    func_tool = voicemail.as_function_tool()
+    assert voicemail.name == "voicemail"
+    assert func_tool.name == "voicemail"
+    assert func_tool.parameters == {}
+
+
+async def test_voicemail_custom_description(mock_ctx, anyio_backend):
+    """A custom description overrides the default; default carries detection cues."""
+    assert "voicemail" in VoicemailTool().description.lower()
+    tool = voicemail(description="Reached an answering machine — leave a message and hang up.")
+    assert (
+        tool.as_function_tool().description == "Reached an answering machine — leave a message and hang up."
+    )

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -1165,6 +1165,18 @@ class TestEndCallAndTransferCallMapping:
         assert isinstance(result, EndCallOutput)
         assert result.interruptible is True
 
+    def test_end_call_reason_forwarded(self):
+        """AgentEndCall(reason=...) forwards the reason to EndCallOutput."""
+        result = self._map(AgentEndCall(reason="voicemail_detected"))
+        assert isinstance(result, EndCallOutput)
+        assert result.reason == "voicemail_detected"
+
+    def test_end_call_reason_defaults_to_agent_ended(self):
+        """AgentEndCall() defaults the reason to agent_ended."""
+        result = self._map(AgentEndCall())
+        assert isinstance(result, EndCallOutput)
+        assert result.reason == "agent_ended"
+
     def test_transfer_call_interruptible_false(self):
         """AgentTransferCall(interruptible=False) maps to TransferOutput(interruptible=False)."""
         result = self._map(AgentTransferCall(target_phone_number="+14155551234", interruptible=False))


### PR DESCRIPTION
## Changes
Adds a structured `end_reason` to calls and a built-in `voicemail` tool. `end_call` records `agent_ended`; the `voicemail` tool records `voicemail_detected`, optionally leaving a message before hanging up. Documented in the README built-in tools table.

## Testing
- `uv run pytest tests/test_llm_agent_tools_system.py tests/test_voice_agent_app.py` — reason forwarding/default + voicemail tool (message / silent-end / no-args / description).
- Full suite: `uv run pytest` (467 passed).
