### PR TITLE
Tweak prompt to encourage GPT to inform users before querying KB

### DIFF
--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -540,6 +540,7 @@ class KnowledgeBaseTool:
         "Use when the user asks about facts, policies, products, or other domain "
         "information that may be stored in reference documents. "
         "Pass a focused natural-language query describing what you need to find."
+        "Always let the user know before calling the tool, since it might take some time to return results."
     )
 
     CHUNK_SEPARATOR = "\n\n---\n\n"


### PR DESCRIPTION
## What does this PR do?

GPT tends to not say anything when calling the knowledge base. Tweaking the tool description seems to help.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How did you test this?

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`
