### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cartesia Line SDK
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cartesia-ai/line)
+
 Build intelligent, low-latency voice agents with Line.
 
 Line brings voice to your text agents with Cartesia's state-of-the-art speech models. We handle audio orchestration, deployment, and observability so you can focus on your agent's reasoning.


### PR DESCRIPTION
## What does this PR do?
Adds a [DeepWiki](https://deepwiki.com/cartesia-ai/line) badge to the top of the README, just below the title.

### Why add this badge?

- **AI-powered codebase Q&A** — DeepWiki auto-generates interactive documentation that anyone can query in natural language. Users and contributors can ask questions about Line's architecture, APIs, and usage patterns without needing to read through every file.
- **Lower barrier to entry** — New contributors can quickly understand the codebase structure, conventions, and key concepts by chatting with DeepWiki, reducing onboarding time.
- **Zero maintenance** — DeepWiki indexes the repo automatically and stays up-to-date with changes. No docs to write or keep in sync.
- **Reduces support burden** — Common "how does X work?" questions can be self-served via DeepWiki, freeing maintainers to focus on development.
- **Widely adopted** — Many popular open-source projects use DeepWiki badges for discoverability.

## Type of change
- [x] Documentation

## Testing
Verified the badge renders correctly in the markdown preview and links to the correct DeepWiki page.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

Link to Devin session: https://app.devin.ai/sessions/af40cce7c51a494bba6b6787bb4411a4
Requested by: @zeuslawyer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only markdown with an external documentation link; no code or security impact.
> 
> **Overview**
> Adds an **[Ask DeepWiki](https://deepwiki.com/cartesia-ai/line)** badge directly under the README title, linking readers to DeepWiki’s AI-generated docs for this repo.
> 
> No runtime, API, or dependency changes—documentation discoverability only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85fbcc282e8a80f5464a66c36900e707694c2e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->