### PR TITLE
Fix reasoning_effort=none for gpt-5-mini and related models (VA-921)

### DIFF
--- a/line/llm_agent/config.py
+++ b/line/llm_agent/config.py
@@ -32,7 +32,7 @@ class LlmConfig:
     top_p: Optional[float] = _UNSET
     stop: Optional[List[str]] = _UNSET
     seed: Optional[int] = _UNSET
-    reasoning_effort: Optional[Literal["none", "low", "medium", "high"]] = _UNSET
+    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high"]] = _UNSET
 
     # Penalties
     presence_penalty: Optional[float] = _UNSET

--- a/line/llm_agent/http_provider.py
+++ b/line/llm_agent/http_provider.py
@@ -16,13 +16,7 @@ from typing import Any, AsyncIterator, Dict, List, NamedTuple, Optional, Protoco
 from litellm import acompletion
 
 from line.llm_agent.config import LlmConfig
-from line.llm_agent.provider import (
-    Message,
-    ParsedModelId,
-    StreamChunk,
-    ToolCall,
-    _coerce_reasoning_effort,
-)
+from line.llm_agent.provider import Message, ParsedModelId, StreamChunk, ToolCall
 from line.llm_agent.schema_converter import tools_to_litellm
 from line.llm_agent.tools.utils import FunctionTool
 
@@ -39,7 +33,7 @@ class _HttpProvider:
 
     Handles streaming responses and tool calls for all LiteLLM-supported models.
 
-    Config normalization and reasoning-effort detection are handled by the
+    Config normalization and reasoning-effort resolution are handled by the
     ``LlmProvider`` facade — this class receives fully-resolved configs and
     tools on every call.
     """
@@ -48,13 +42,9 @@ class _HttpProvider:
         self,
         model_id: ParsedModelId,
         api_key: Optional[str] = None,
-        supports_reasoning_effort: bool = False,
-        default_reasoning_effort: Optional[str] = "low",
     ):
         self._model_id = model_id
         self._api_key = api_key
-        self._supports_reasoning_effort = supports_reasoning_effort
-        self._default_reasoning_effort = default_reasoning_effort
 
     def chat(
         self,
@@ -105,13 +95,8 @@ class _HttpProvider:
             llm_kwargs["presence_penalty"] = config.presence_penalty
         if config.frequency_penalty is not None:
             llm_kwargs["frequency_penalty"] = config.frequency_penalty
-        if self._supports_reasoning_effort:
-            effort = _coerce_reasoning_effort(
-                self._model_id,
-                config.reasoning_effort or self._default_reasoning_effort,
-            )
-            if effort is not None:
-                llm_kwargs["reasoning_effort"] = effort
+        if config.reasoning_effort is not None:
+            llm_kwargs["reasoning_effort"] = config.reasoning_effort
 
         if config.extra:
             llm_kwargs.update(config.extra)

--- a/line/llm_agent/http_provider.py
+++ b/line/llm_agent/http_provider.py
@@ -16,7 +16,13 @@ from typing import Any, AsyncIterator, Dict, List, NamedTuple, Optional, Protoco
 from litellm import acompletion
 
 from line.llm_agent.config import LlmConfig
-from line.llm_agent.provider import Message, ParsedModelId, StreamChunk, ToolCall
+from line.llm_agent.provider import (
+    Message,
+    ParsedModelId,
+    StreamChunk,
+    ToolCall,
+    _coerce_reasoning_effort,
+)
 from line.llm_agent.schema_converter import tools_to_litellm
 from line.llm_agent.tools.utils import FunctionTool
 
@@ -100,7 +106,12 @@ class _HttpProvider:
         if config.frequency_penalty is not None:
             llm_kwargs["frequency_penalty"] = config.frequency_penalty
         if self._supports_reasoning_effort:
-            llm_kwargs["reasoning_effort"] = config.reasoning_effort or self._default_reasoning_effort
+            effort = _coerce_reasoning_effort(
+                self._model_id,
+                config.reasoning_effort or self._default_reasoning_effort,
+            )
+            if effort is not None:
+                llm_kwargs["reasoning_effort"] = effort
 
         if config.extra:
             llm_kwargs.update(config.extra)

--- a/line/llm_agent/http_responses_provider.py
+++ b/line/llm_agent/http_responses_provider.py
@@ -260,11 +260,9 @@ class _HttpResponsesProvider:
         self,
         model_id: ParsedModelId,
         api_key: Optional[str] = None,
-        default_reasoning_effort: Optional[str] = "low",
     ):
         self._model_id = model_id
         self._api_key = api_key or ""
-        self._default_reasoning_effort = default_reasoning_effort
         self._history: List[ConversationEntry] = []
         self._lock: Optional[asyncio.Lock] = None
 
@@ -298,7 +296,6 @@ class _HttpResponsesProvider:
                         body, update = _plan_responses_chat(
                             history=self._history,
                             model_id=self._model_id,
-                            default_reasoning_effort=self._default_reasoning_effort,
                             messages=messages,
                             tools=tools,
                             config=config,

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -98,7 +98,11 @@ class LlmAgent:
 
         # Resolve the base config to insert default values for any _UNSET sentinels.
         effective_config = _normalize_config(config or LlmConfig())
-        if effective_config.reasoning_effort is not None and not model_config.supports_reasoning_effort:
+        if (
+            effective_config.reasoning_effort is not None
+            and effective_config.reasoning_effort != "none"
+            and not model_config.supports_reasoning_effort
+        ):
             raise ValueError(
                 f"Model {str(model_id)} does not support reasoning_effort. "
                 "Remove reasoning_effort from your LlmConfig or use a model that supports it."

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -294,7 +294,6 @@ class LlmProvider:
         self._backend_override = backend
         normalized_config = _normalize_config(config or LlmConfig())
         mcfg = _get_model_config(model_id, backend=backend, config=normalized_config)
-        self._model_config = mcfg
         self._config = _resolve_config_reasoning_effort(model_id, mcfg, normalized_config)
 
         if mcfg.backend == "realtime":
@@ -348,7 +347,6 @@ class LlmProvider:
         effective_tools, web_search_options = _normalize_tools(
             _merge_tools(self._tools, tools), model_id=self._model_id
         )
-        _get_model_config(self._model_id, backend=self._backend_override, config=effective_config)
 
         if web_search_options is not None:
             kwargs = {**kwargs, "web_search_options": web_search_options}
@@ -356,16 +354,17 @@ class LlmProvider:
         return self._backend.chat(normalized, effective_tools, config=effective_config, **kwargs)
 
     def _effective_config(self, config: Optional[LlmConfig]) -> LlmConfig:
-        """Merge a per-call config override onto the base config and resolve it.
+        """Merge a per-call config override onto the base config, validate it
+        against the model/backend, and resolve it.
 
         ``self._config`` is already resolved at init time, so resolution is
         only re-applied when an override may have reintroduced a raw value.
         """
+        merged = _merge_configs(self._config, config) if config else self._config
+        mcfg = _get_model_config(self._model_id, backend=self._backend_override, config=merged)
         if config is None:
-            return self._config
-        return _resolve_config_reasoning_effort(
-            self._model_id, self._model_config, _merge_configs(self._config, config)
-        )
+            return merged
+        return _resolve_config_reasoning_effort(self._model_id, mcfg, merged)
 
     def _set_tools(self, tools: Optional[List[Any]]) -> None:
         """Replace the provider's default tool specs."""
@@ -380,7 +379,6 @@ class LlmProvider:
         effective_tools, web_search_options = _normalize_tools(
             _merge_tools(self._tools, tools), model_id=self._model_id
         )
-        _get_model_config(self._model_id, backend=self._backend_override, config=effective_config)
         await self._backend.warmup(
             config=effective_config,
             tools=effective_tools,
@@ -401,38 +399,12 @@ class _ModelConfig:
 
     backend: str  # "realtime" | "websocket" | "http_responses" | "http"
     supports_reasoning_effort: bool
+    # Semantic default applied when the user leaves reasoning_effort unset;
+    # coerced to the model's wire-safe equivalent at resolution time.
     default_reasoning_effort: Optional[str]
 
 
 _VALID_BACKENDS = frozenset({"http", "http_responses", "realtime", "websocket"})
-
-
-def _default_reasoning_effort_for_model(model_id: ParsedModelId) -> Optional[str]:
-    """Return the lowest-effort default for a reasoning-capable model.
-
-    Some OpenAI models (e.g. ``gpt-5-mini``) reject ``reasoning_effort="none"``
-    and only accept ``minimal``/``low``/… — see LiteLLM's
-    ``supports_none_reasoning_effort``. Anthropic models omit the parameter.
-    """
-    if model_id.provider == "anthropic":
-        return None
-
-    from litellm import get_model_info
-
-    try:
-        info = get_model_info(model=str(model_id))
-    except Exception:
-        return "none"
-
-    if info.get("supports_none_reasoning_effort") is True:
-        return "none"
-    if info.get("supports_none_reasoning_effort") is False:
-        if info.get("supports_minimal_reasoning_effort") is True:
-            return "minimal"
-        return None
-    if info.get("supports_reasoning"):
-        return "none"
-    return None
 
 
 def _coerce_reasoning_effort(model_id: ParsedModelId, effort: Optional[str]) -> Optional[str]:
@@ -561,12 +533,12 @@ def _get_model_config(
 
     elif litellm_support:
         supports = "reasoning_effort" in litellm_support
-        default = _default_reasoning_effort_for_model(model_id) if supports else None
-
         mcfg = _ModelConfig(
             backend="http",
             supports_reasoning_effort=supports,
-            default_reasoning_effort=default,
+            # Reasoning is disabled by default for voice latency; resolution
+            # coerces "none" to each model's wire-safe equivalent.
+            default_reasoning_effort="none" if supports else None,
         )
 
     else:

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -398,6 +398,66 @@ class _ModelConfig:
 _VALID_BACKENDS = frozenset({"http", "http_responses", "realtime", "websocket"})
 
 
+def _default_reasoning_effort_for_model(model_id: ParsedModelId) -> Optional[str]:
+    """Return the lowest-effort default for a reasoning-capable model.
+
+    Some OpenAI models (e.g. ``gpt-5-mini``) reject ``reasoning_effort="none"``
+    and only accept ``minimal``/``low``/… — see LiteLLM's
+    ``supports_none_reasoning_effort``. Anthropic models omit the parameter.
+    """
+    if model_id.provider == "anthropic":
+        return None
+
+    from litellm import get_model_info
+
+    try:
+        info = get_model_info(model=str(model_id))
+    except Exception:
+        return "none"
+
+    if info.get("supports_none_reasoning_effort") is True:
+        return "none"
+    if info.get("supports_none_reasoning_effort") is False:
+        if info.get("supports_minimal_reasoning_effort") is True:
+            return "minimal"
+        return None
+    if info.get("supports_reasoning"):
+        return "none"
+    return None
+
+
+def _coerce_reasoning_effort(model_id: ParsedModelId, effort: Optional[str]) -> Optional[str]:
+    """Map ``reasoning_effort`` to a wire-safe value, or ``None`` to omit it.
+
+    ``"none"`` in :class:`LlmConfig` means "disable reasoning", but several models
+    reject that literal (``gpt-5-mini`` uses ``minimal``). Non-reasoning models
+    should omit the parameter when the user requests ``"none"``.
+    """
+    if effort is None:
+        return None
+    if effort != "none":
+        return effort
+    if model_id.provider == "anthropic":
+        return None
+
+    from litellm import get_model_info
+
+    try:
+        info = get_model_info(model=str(model_id))
+    except Exception:
+        return effort
+
+    if info.get("supports_none_reasoning_effort") is False:
+        if info.get("supports_minimal_reasoning_effort") is True:
+            return "minimal"
+        return None
+    if info.get("supports_none_reasoning_effort") is True:
+        return "none"
+    if info.get("supports_reasoning"):
+        return "none"
+    return None
+
+
 def _get_model_config(
     model_id: ParsedModelId,
     *,
@@ -469,15 +529,7 @@ def _get_model_config(
 
     elif litellm_support:
         supports = "reasoning_effort" in litellm_support
-        default: Optional[str] = None
-        if supports:
-            # Anthropic: omit the param entirely to skip the thinking block. Across
-            # litellm versions the "none" string is handled inconsistently — older
-            # versions raise, newer versions accept it. None (no param) is the only
-            # deterministic skip; "low" would enable a 1024-token thinking budget.
-            # Other providers (OpenAI reasoning models, etc.): "none" is the
-            # well-defined "no reasoning" value.
-            default = None if model_id.provider == "anthropic" else "none"
+        default = _default_reasoning_effort_for_model(model_id) if supports else None
 
         mcfg = _ModelConfig(
             backend="http",

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -11,7 +11,7 @@ Model naming:
 """
 
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import (
     Any,
     AsyncIterable,
@@ -251,10 +251,10 @@ class LlmProvider:
     for ``gpt-5.2`` / ``gpt-5.4-*`` models) based on the model name and the
     optional ``backend`` override, and delegates all calls to it.
 
-    Handles config normalization and reasoning-effort detection so that
-    backends receive normalized configs and pre-computed flags.  This class
-    is a public SDK surface — callers may pass raw ``LlmConfig`` and tool
-    specs which are normalized internally.
+    Handles config normalization and reasoning-effort resolution so that
+    backends receive fully-resolved configs.  This class is a public SDK
+    surface — callers may pass raw ``LlmConfig`` and tool specs which are
+    normalized internally.
 
     Args:
         model: Model name (e.g. ``"gpt-4o"``, ``"gpt-4o-realtime-preview"``).
@@ -291,10 +291,11 @@ class LlmProvider:
 
         self._model_id = model_id
         self._tools = list(tools or [])
-        normalized_config = _normalize_config(config or LlmConfig())
-        self._config = normalized_config
         self._backend_override = backend
+        normalized_config = _normalize_config(config or LlmConfig())
         mcfg = _get_model_config(model_id, backend=backend, config=normalized_config)
+        self._model_config = mcfg
+        self._config = _resolve_config_reasoning_effort(model_id, mcfg, normalized_config)
 
         if mcfg.backend == "realtime":
             from line.llm_agent.realtime_provider import _RealtimeProvider
@@ -313,7 +314,6 @@ class LlmProvider:
             self._backend = _WebSocketProvider(
                 model_id=model_id,
                 api_key=api_key,
-                default_reasoning_effort=mcfg.default_reasoning_effort,
             )
         elif mcfg.backend == "http_responses":
             from line.llm_agent.http_responses_provider import _HttpResponsesProvider
@@ -323,7 +323,6 @@ class LlmProvider:
             self._backend = _HttpResponsesProvider(
                 model_id=model_id,
                 api_key=api_key,
-                default_reasoning_effort=mcfg.default_reasoning_effort,
             )
         else:
             from line.llm_agent.http_provider import _HttpProvider
@@ -332,8 +331,6 @@ class LlmProvider:
             self._backend = _HttpProvider(
                 model_id=model_id,
                 api_key=api_key,
-                supports_reasoning_effort=mcfg.supports_reasoning_effort,
-                default_reasoning_effort=mcfg.default_reasoning_effort,
             )
 
     def chat(
@@ -347,7 +344,7 @@ class LlmProvider:
         if normalized is None:
             return _empty_stream()
 
-        effective_config = _merge_configs(self._config, config) if config else self._config
+        effective_config = self._effective_config(config)
         effective_tools, web_search_options = _normalize_tools(
             _merge_tools(self._tools, tools), model_id=self._model_id
         )
@@ -358,6 +355,18 @@ class LlmProvider:
 
         return self._backend.chat(normalized, effective_tools, config=effective_config, **kwargs)
 
+    def _effective_config(self, config: Optional[LlmConfig]) -> LlmConfig:
+        """Merge a per-call config override onto the base config and resolve it.
+
+        ``self._config`` is already resolved at init time, so resolution is
+        only re-applied when an override may have reintroduced a raw value.
+        """
+        if config is None:
+            return self._config
+        return _resolve_config_reasoning_effort(
+            self._model_id, self._model_config, _merge_configs(self._config, config)
+        )
+
     def _set_tools(self, tools: Optional[List[Any]]) -> None:
         """Replace the provider's default tool specs."""
         self._tools = list(tools or [])
@@ -367,7 +376,7 @@ class LlmProvider:
         config: Optional[LlmConfig] = None,
         tools: Optional[List[Any]] = None,
     ) -> None:
-        effective_config = _merge_configs(self._config, config) if config else self._config
+        effective_config = self._effective_config(config)
         effective_tools, web_search_options = _normalize_tools(
             _merge_tools(self._tools, tools), model_id=self._model_id
         )
@@ -456,6 +465,29 @@ def _coerce_reasoning_effort(model_id: ParsedModelId, effort: Optional[str]) -> 
     if info.get("supports_reasoning"):
         return "none"
     return None
+
+
+def _resolve_config_reasoning_effort(
+    model_id: ParsedModelId,
+    model_config: "_ModelConfig",
+    config: LlmConfig,
+) -> LlmConfig:
+    """Return *config* with ``reasoning_effort`` resolved to the wire value.
+
+    Applies the model's support gate (unsupported → ``None``), the per-model
+    default when unset, and wire-safety coercion (e.g. ``"none"`` →
+    ``"minimal"`` for models that reject the literal).  ``None`` means "omit
+    the parameter".  *config* must already be normalized.
+    """
+    if not model_config.supports_reasoning_effort:
+        resolved = None
+    else:
+        resolved = _coerce_reasoning_effort(
+            model_id, config.reasoning_effort or model_config.default_reasoning_effort
+        )
+    if resolved == config.reasoning_effort:
+        return config
+    return replace(config, reasoning_effort=resolved)
 
 
 def _get_model_config(

--- a/line/llm_agent/provider_utils.py
+++ b/line/llm_agent/provider_utils.py
@@ -26,6 +26,7 @@ from line.llm_agent.provider import (
     ParsedModelId,
     StreamChunk,
     ToolCall,
+    _coerce_reasoning_effort,
     _extract_instructions_and_messages,
 )
 from line.llm_agent.schema_converter import build_openai_tool_defs
@@ -163,7 +164,10 @@ def _build_responses_body(
         body["instructions"] = instructions
     if tool_defs is not None:
         body["tools"] = tool_defs
-    reasoning_effort = cfg.reasoning_effort or default_reasoning_effort
+    reasoning_effort = _coerce_reasoning_effort(
+        model_id,
+        cfg.reasoning_effort or default_reasoning_effort,
+    )
     if reasoning_effort is not None:
         body["reasoning"] = {"effort": reasoning_effort}
     if cfg.temperature is not None:

--- a/line/llm_agent/provider_utils.py
+++ b/line/llm_agent/provider_utils.py
@@ -26,7 +26,6 @@ from line.llm_agent.provider import (
     ParsedModelId,
     StreamChunk,
     ToolCall,
-    _coerce_reasoning_effort,
     _extract_instructions_and_messages,
 )
 from line.llm_agent.schema_converter import build_openai_tool_defs
@@ -139,7 +138,6 @@ def _expand_messages(
 def _build_responses_body(
     *,
     model_id: ParsedModelId,
-    default_reasoning_effort: Optional[str],
     instructions: Optional[str],
     tool_defs: Optional[List[Dict[str, Any]]],
     cfg: LlmConfig,
@@ -164,12 +162,8 @@ def _build_responses_body(
         body["instructions"] = instructions
     if tool_defs is not None:
         body["tools"] = tool_defs
-    reasoning_effort = _coerce_reasoning_effort(
-        model_id,
-        cfg.reasoning_effort or default_reasoning_effort,
-    )
-    if reasoning_effort is not None:
-        body["reasoning"] = {"effort": reasoning_effort}
+    if cfg.reasoning_effort is not None:
+        body["reasoning"] = {"effort": cfg.reasoning_effort}
     if cfg.temperature is not None:
         body["temperature"] = cfg.temperature
     if cfg.max_tokens is not None:
@@ -183,7 +177,6 @@ def _plan_responses_chat(
     *,
     history: List[ConversationEntry],
     model_id: ParsedModelId,
-    default_reasoning_effort: Optional[str],
     messages: List[Message],
     tools: Optional[List[FunctionTool]],
     config: LlmConfig,
@@ -244,7 +237,6 @@ def _plan_responses_chat(
     input_pairs = desired_pairs[max(0, continuation_idx - 1) :]
     body = _build_responses_body(
         model_id=model_id,
-        default_reasoning_effort=default_reasoning_effort,
         instructions=instructions,
         tool_defs=tool_defs,
         cfg=config,

--- a/line/llm_agent/websocket_provider.py
+++ b/line/llm_agent/websocket_provider.py
@@ -82,10 +82,8 @@ class _WebSocketProvider:
         self,
         model_id: ParsedModelId,
         api_key: Optional[str] = None,
-        default_reasoning_effort: Optional[str] = "none",
     ):
         self._model_id = model_id
-        self._default_reasoning_effort = default_reasoning_effort
         self._api_key = api_key or ""
         self._ws: Optional[WebSocketClientProtocol] = None
         self._history: List[ConversationEntry] = []
@@ -169,7 +167,6 @@ class _WebSocketProvider:
 
             request = _build_request(
                 model_id=self._model_id,
-                default_reasoning_effort=self._default_reasoning_effort,
                 instructions=instructions,
                 tool_defs=tool_defs,
                 cfg=config,
@@ -215,7 +212,6 @@ class _WebSocketProvider:
             request, update_history = _plan_chat(
                 history=self._history,
                 model_id=self._model_id,
-                default_reasoning_effort=self._default_reasoning_effort,
                 messages=messages,
                 tools=tools,
                 config=config,
@@ -244,7 +240,6 @@ def _plan_chat(
     *,
     history: List[ConversationEntry],
     model_id: ParsedModelId,
-    default_reasoning_effort: Optional[str],
     messages: List[Message],
     tools: Optional[List[FunctionTool]],
     config: LlmConfig,
@@ -258,7 +253,6 @@ def _plan_chat(
     body, update = _plan_responses_chat(
         history=history,
         model_id=model_id,
-        default_reasoning_effort=default_reasoning_effort,
         messages=messages,
         tools=tools,
         config=config,
@@ -271,7 +265,6 @@ def _plan_chat(
 def _build_request(
     *,
     model_id: ParsedModelId,
-    default_reasoning_effort: Optional[str],
     instructions: Optional[str],
     tool_defs: Optional[List[Dict[str, Any]]],
     cfg: LlmConfig,
@@ -286,7 +279,6 @@ def _build_request(
     """
     body = _build_responses_body(
         model_id=model_id,
-        default_reasoning_effort=default_reasoning_effort,
         instructions=instructions,
         tool_defs=tool_defs,
         cfg=cfg,

--- a/tests/real_api_test_provider.py
+++ b/tests/real_api_test_provider.py
@@ -728,23 +728,31 @@ Always include menu_item_id and quantity.""",
 
 async def test_reasoning_disabled_by_default(model: str, api_key: str, backend: Optional[str] = None):
     """Verify the codebase's default reasoning_effort actually suppresses thinking on the wire."""
-    from line.llm_agent.provider import _get_model_config, parse_model_id
+    from line.llm_agent.config import LlmConfig, _normalize_config
+    from line.llm_agent.provider import (
+        _get_model_config,
+        _resolve_config_reasoning_effort,
+        parse_model_id,
+    )
 
     print("\n" + "=" * 60)
     print(f"Testing reasoning disabled by default for {model} (backend={backend})")
     print("=" * 60)
 
-    mcfg = _get_model_config(parse_model_id(model))
+    model_id = parse_model_id(model)
+    mcfg = _get_model_config(model_id)
+    resolved = _resolve_config_reasoning_effort(model_id, mcfg, _normalize_config(LlmConfig()))
     print(f"  supports_reasoning_effort: {mcfg.supports_reasoning_effort}")
     print(f"  default_reasoning_effort:  {mcfg.default_reasoning_effort!r}")
+    print(f"  resolved reasoning_effort: {resolved.reasoning_effort!r}")
 
     llm_kwargs: dict = {
         "model": model,
         "api_key": api_key,
         "messages": [{"role": "user", "content": "What is 2+2? Just give the number."}],
     }
-    if mcfg.supports_reasoning_effort and mcfg.default_reasoning_effort is not None:
-        llm_kwargs["reasoning_effort"] = mcfg.default_reasoning_effort
+    if resolved.reasoning_effort is not None:
+        llm_kwargs["reasoning_effort"] = resolved.reasoning_effort
 
     response = await litellm.acompletion(**llm_kwargs)
     msg = response.choices[0].message

--- a/tests/real_api_test_websocket_provider.py
+++ b/tests/real_api_test_websocket_provider.py
@@ -106,7 +106,7 @@ async def _run_expect_rejection(name, api_key, config, *, model_id):
 
     Returns None on expected rejection, or an error string on failure.
     """
-    provider = _WebSocketProvider(model_id=model_id, api_key=api_key, default_reasoning_effort=None)
+    provider = _WebSocketProvider(model_id=model_id, api_key=api_key)
     try:
         text = await _collect_text(provider, _MIN_MESSAGE, config=config)
         if text:
@@ -125,11 +125,7 @@ async def _run_expect_rejection(name, api_key, config, *, model_id):
 
 async def _run_expect_success(name, api_key, config, *, model_id, **kwargs):
     """Run a chat that should succeed. Returns None on success, or an error string."""
-    provider = _WebSocketProvider(
-        model_id=model_id,
-        api_key=api_key,
-        default_reasoning_effort=kwargs.get("default_reasoning_effort"),
-    )
+    provider = _WebSocketProvider(model_id=model_id, api_key=api_key)
     try:
         if kwargs.get("expect_tool_call"):
             got_tool = await _collect_tool_calls(
@@ -347,7 +343,7 @@ async def test_response_not_found_retry(api_key: str, model_id: ParsedModelId):
     """Force a ``previous_response_not_found`` by corrupting history; verify retry recovers."""
     print_header(f"Response Not Found Retry Test ({model_id.model})")
 
-    provider = _WebSocketProvider(model_id=model_id, api_key=api_key, default_reasoning_effort=None)
+    provider = _WebSocketProvider(model_id=model_id, api_key=api_key)
     config = LlmConfig(system_prompt="You are a helpful assistant. Be brief.")
 
     try:
@@ -562,7 +558,6 @@ async def test_websocket_model_config(api_key: str, model_id: ParsedModelId):
         api_key,
         _normalize_config(LlmConfig(system_prompt="Be brief.", reasoning_effort="low")),
         model_id=model_id,
-        default_reasoning_effort="low",
     )
     if err:
         print(f"FAIL: {err}")

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -241,6 +241,25 @@ async def test_init_rejects_unsupported_reasoning_effort(monkeypatch, anyio_back
         )
 
 
+async def test_init_allows_reasoning_none_on_non_reasoning_model(monkeypatch, anyio_backend):
+    """reasoning_effort='none' means 'no reasoning' and must not fail init."""
+    monkeypatch.setattr(
+        "line.llm_agent.llm_agent._get_model_config",
+        lambda model_id, *, backend=None: _ModelConfig(
+            backend="http",
+            supports_reasoning_effort=False,
+            default_reasoning_effort=None,
+        ),
+    )
+
+    agent = LlmAgent(
+        model="gpt-4o-mini",
+        api_key="test-key",
+        config=LlmConfig(reasoning_effort="none"),
+    )
+    assert str(agent._model_id) == "openai/gpt-4o-mini"
+
+
 async def test_call_started_warmup_uses_effective_tools(turn_env):
     responses = []
     agent, mock_llm = create_agent_with_mock(responses)

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -525,22 +525,44 @@ def test_coerce_reasoning_none_for_non_reasoning_model():
     assert _coerce_reasoning_effort(model_id, "none") is None
 
 
-def test_http_provider_coerces_reasoning_effort_for_gpt5_mini():
-    provider = _HttpProvider(
-        model_id=parse_model_id("openai/gpt-5-mini"),
-        supports_reasoning_effort=True,
-        default_reasoning_effort="minimal",
+def test_llm_provider_coerces_init_reasoning_effort_for_gpt5_mini():
+    """The LlmProvider facade coerces 'none' before it reaches the backend."""
+    provider = LlmProvider(
+        model="openai/gpt-5-mini",
+        api_key="test-key",
+        config=LlmConfig(reasoning_effort="none"),
     )
-    stream = provider.chat([], config=_normalize_config(LlmConfig(reasoning_effort="none")))
+    stream = provider.chat([Message(role="user", content="hi")])
     assert stream._kwargs["reasoning_effort"] == "minimal"
 
 
-def test_http_provider_omits_reasoning_effort_for_non_reasoning_model():
-    provider = _HttpProvider(
-        model_id=parse_model_id("openai/gpt-4o-mini"),
-        supports_reasoning_effort=False,
+def test_llm_provider_coerces_per_call_reasoning_effort_for_gpt5_mini():
+    """Per-call config overrides are also coerced by the facade."""
+    provider = LlmProvider(model="openai/gpt-5-mini", api_key="test-key")
+    stream = provider.chat(
+        [Message(role="user", content="hi")],
+        config=LlmConfig(reasoning_effort="none"),
     )
-    stream = provider.chat([], config=_normalize_config(LlmConfig(reasoning_effort="none")))
+    assert stream._kwargs["reasoning_effort"] == "minimal"
+
+
+def test_llm_provider_omits_reasoning_effort_for_non_reasoning_model():
+    provider = LlmProvider(
+        model="openai/gpt-4o-mini",
+        api_key="test-key",
+        config=LlmConfig(reasoning_effort="none"),
+    )
+    stream = provider.chat([Message(role="user", content="hi")])
+    assert "reasoning_effort" not in stream._kwargs
+
+
+def test_http_provider_sends_reasoning_effort_verbatim():
+    """Backends perform no resolution — they send the facade-resolved value as-is."""
+    provider = _HttpProvider(model_id=parse_model_id("openai/gpt-5-mini"))
+    stream = provider.chat([], config=_normalize_config(LlmConfig(reasoning_effort="minimal")))
+    assert stream._kwargs["reasoning_effort"] == "minimal"
+
+    stream = provider.chat([], config=_normalize_config(LlmConfig()))
     assert "reasoning_effort" not in stream._kwargs
 
 

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -11,6 +11,7 @@ from line.llm_agent.provider import (
     Message,
     ParsedModelId,
     ToolCall,
+    _coerce_reasoning_effort,
     _extract_instructions_and_messages,
     _get_model_config,
     _is_realtime_model,
@@ -499,6 +500,48 @@ class TestGetModelConfig:
         assert cfg.backend == "http"
         assert cfg.supports_reasoning_effort is True
         assert cfg.default_reasoning_effort is None
+
+    def test_gpt5_mini_reasoning_default_is_minimal(self):
+        """gpt-5-mini rejects reasoning_effort='none'; use minimal instead."""
+        cfg = _get_model_config(parse_model_id("openai/gpt-5-mini"))
+        assert cfg.backend == "http"
+        assert cfg.supports_reasoning_effort is True
+        assert cfg.default_reasoning_effort == "minimal"
+
+    def test_gpt52_reasoning_default_stays_none(self):
+        cfg = _get_model_config(parse_model_id("openai/gpt-5.2"))
+        assert cfg.supports_reasoning_effort is True
+        assert cfg.default_reasoning_effort == "none"
+
+
+def test_coerce_reasoning_none_for_gpt5_mini():
+    model_id = parse_model_id("openai/gpt-5-mini")
+    assert _coerce_reasoning_effort(model_id, "none") == "minimal"
+    assert _coerce_reasoning_effort(model_id, "low") == "low"
+
+
+def test_coerce_reasoning_none_for_non_reasoning_model():
+    model_id = parse_model_id("openai/gpt-4o-mini")
+    assert _coerce_reasoning_effort(model_id, "none") is None
+
+
+def test_http_provider_coerces_reasoning_effort_for_gpt5_mini():
+    provider = _HttpProvider(
+        model_id=parse_model_id("openai/gpt-5-mini"),
+        supports_reasoning_effort=True,
+        default_reasoning_effort="minimal",
+    )
+    stream = provider.chat([], config=_normalize_config(LlmConfig(reasoning_effort="none")))
+    assert stream._kwargs["reasoning_effort"] == "minimal"
+
+
+def test_http_provider_omits_reasoning_effort_for_non_reasoning_model():
+    provider = _HttpProvider(
+        model_id=parse_model_id("openai/gpt-4o-mini"),
+        supports_reasoning_effort=False,
+    )
+    stream = provider.chat([], config=_normalize_config(LlmConfig(reasoning_effort="none")))
+    assert "reasoning_effort" not in stream._kwargs
 
 
 def test_is_websocket_model_matches_gpt52_variants():

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -494,24 +494,18 @@ class TestGetModelConfig:
         assert cfg.supports_reasoning_effort is False
         assert cfg.default_reasoning_effort is None
 
-    def test_anthropic_model_reasoning_default_is_none(self):
-        """Anthropic models use None (not 'low') to skip the thinking block."""
-        cfg = _get_model_config(parse_model_id("anthropic/claude-sonnet-4-20250514"))
-        assert cfg.backend == "http"
-        assert cfg.supports_reasoning_effort is True
-        assert cfg.default_reasoning_effort is None
-
-    def test_gpt5_mini_reasoning_default_is_minimal(self):
-        """gpt-5-mini rejects reasoning_effort='none'; use minimal instead."""
-        cfg = _get_model_config(parse_model_id("openai/gpt-5-mini"))
-        assert cfg.backend == "http"
-        assert cfg.supports_reasoning_effort is True
-        assert cfg.default_reasoning_effort == "minimal"
-
-    def test_gpt52_reasoning_default_stays_none(self):
-        cfg = _get_model_config(parse_model_id("openai/gpt-5.2"))
-        assert cfg.supports_reasoning_effort is True
-        assert cfg.default_reasoning_effort == "none"
+    def test_http_reasoning_models_default_to_none(self):
+        """HTTP reasoning models get the semantic 'none' default; resolution
+        coerces it to each model's wire-safe equivalent."""
+        for model in (
+            "anthropic/claude-sonnet-4-20250514",
+            "openai/gpt-5-mini",
+            "openai/gpt-5.2",
+        ):
+            cfg = _get_model_config(parse_model_id(model))
+            assert cfg.backend == "http"
+            assert cfg.supports_reasoning_effort is True
+            assert cfg.default_reasoning_effort == "none"
 
 
 def test_coerce_reasoning_none_for_gpt5_mini():
@@ -523,6 +517,20 @@ def test_coerce_reasoning_none_for_gpt5_mini():
 def test_coerce_reasoning_none_for_non_reasoning_model():
     model_id = parse_model_id("openai/gpt-4o-mini")
     assert _coerce_reasoning_effort(model_id, "none") is None
+
+
+def test_llm_provider_resolves_default_reasoning_effort_for_gpt5_mini():
+    """With reasoning_effort unset, the 'none' default resolves to 'minimal'."""
+    provider = LlmProvider(model="openai/gpt-5-mini", api_key="test-key")
+    stream = provider.chat([Message(role="user", content="hi")])
+    assert stream._kwargs["reasoning_effort"] == "minimal"
+
+
+def test_llm_provider_omits_default_reasoning_effort_for_anthropic():
+    """With reasoning_effort unset, Anthropic models omit the parameter."""
+    provider = LlmProvider(model="anthropic/claude-sonnet-4-20250514", api_key="test-key")
+    stream = provider.chat([Message(role="user", content="hi")])
+    assert "reasoning_effort" not in stream._kwargs
 
 
 def test_llm_provider_coerces_init_reasoning_effort_for_gpt5_mini():

--- a/tests/test_websocket_provider.py
+++ b/tests/test_websocket_provider.py
@@ -31,7 +31,6 @@ def test_plan_chat_update_preserves_text_then_tool_call_outputs():
     _, update = _plan_chat(
         history=history,
         model_id=parse_model_id("openai/gpt-5.2"),
-        default_reasoning_effort="none",
         messages=[Message(role="user", content="Weather?")],
         tools=None,
         config=config,
@@ -79,7 +78,6 @@ def test_plan_chat_continuation_from_checkpoint():
     request, _ = _plan_chat(
         history=history,
         model_id=parse_model_id("openai/gpt-5.2"),
-        default_reasoning_effort="none",
         messages=[
             Message(role="user", content="hello"),
             Message(role="assistant", content="hi"),
@@ -109,7 +107,6 @@ def test_plan_chat_divergence_rolls_back_to_checkpoint():
     request, _ = _plan_chat(
         history=history,
         model_id=parse_model_id("openai/gpt-5.2"),
-        default_reasoning_effort="none",
         messages=[
             Message(role="user", content="hello"),
             Message(role="assistant", content="truncated"),  # diverges
@@ -132,7 +129,6 @@ def test_plan_chat_update_builds_correct_history():
     _, update = _plan_chat(
         history=[],
         model_id=parse_model_id("openai/gpt-5.2"),
-        default_reasoning_effort="none",
         messages=[Message(role="user", content="hi")],
         tools=None,
         config=config,
@@ -162,10 +158,9 @@ def test_plan_chat_update_builds_correct_history():
 def test_build_request_uses_bare_model_name():
     request = _build_request(
         model_id=parse_model_id("openai/gpt-5.2"),
-        default_reasoning_effort="none",
         instructions=None,
         tool_defs=None,
-        cfg=LlmConfig(),
+        cfg=_normalize_config(LlmConfig()),
     )
     assert request["model"] == "gpt-5.2"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes VA-921: `LlmAgent` failures when using models like `gpt-5-mini`, `gpt-4.1-mini`, and `gpt-4o-mini` with the default or explicit `reasoning_effort="none"`.

OpenAI's `gpt-5-mini` accepts `minimal`/`low`/`medium`/`high` but **rejects** the literal `"none"` value (returns HTTP 400). The SDK was defaulting all OpenAI reasoning-capable models to `"none"`, which broke agents on these models.

This PR uses LiteLLM's `get_model_info()` metadata (`supports_none_reasoning_effort`, `supports_minimal_reasoning_effort`) to:

- Default to `"minimal"` when `"none"` is unsupported (e.g. `gpt-5-mini`)
- Keep `"none"` for models that support it (e.g. `gpt-5.2`)
- Coerce explicit `reasoning_effort="none"` to a wire-safe value at request time (HTTP + Responses API paths)
- Treat `reasoning_effort="none"` as a no-op during `LlmAgent` init for non-reasoning models (`gpt-4.1-mini`, `gpt-4o-mini`)

## Type of change
- [x] Bug fix

## Testing

- Added unit tests in `tests/test_llm_agent_provider.py` and `tests/test_llm_agent_llm_agent.py`
- Ran: `uv run python -m pytest tests/test_llm_agent_provider.py tests/test_llm_agent_llm_agent.py tests/test_websocket_provider.py tests/test_http_responses_provider.py` (148 passed)
- Verified defaults via script: `gpt-5-mini` → `minimal`, `gpt-5.2` → `none`, `gpt-4o-mini`/`gpt-4.1-mini` → omit

## Checklist
- [x] I have read the contributing guidelines
- [x] I have added tests that prove my fix is effective
- [x] Lint passes (`ruff check` on changed files)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cartesia-ai.slack.com/archives/C08RSRJDQ2K/p1780499535121649?thread_ts=1780499535.121649&cid=C08RSRJDQ2K)

<div><a href="https://cursor.com/agents/bc-c59810cf-a82d-5e81-945a-a785ff7446d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c59810cf-a82d-5e81-945a-a785ff7446d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

