### PR TITLE
Attach X-Cartesia-Error-Source header to HTTPExceptions from agent code

### DIFF
--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -194,13 +194,18 @@ class VoiceAgentApp:
                 metadata.update(result.metadata)
                 config = result.config
 
-            except HTTPException:
+            except HTTPException as e:
+                # Attach a X-Cartesia-Error-Source header to explicit HTTP errors
+                # from customer code.
+                if e.headers is None:
+                    e.headers = {}
+                e.headers["X-Cartesia-Error-Source"] = "agent-code"
                 raise
             except Exception as e:
                 logger.error(f"Error in pre_call_handler: {str(e)}")
                 # Mark this as customer-code-originated so downstream services
-                # (e.g. Inferno) can attribute the failure correctly rather than
-                # treating it as a Cartesia/SDK error.
+                # can attribute the failure correctly rather than treating it
+                # as a Cartesia/SDK error.
                 raise HTTPException(
                     status_code=500,
                     detail="Server error in call processing",

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -1416,7 +1416,7 @@ class TestCreateChatSessionErrorAttribution:
         assert response.status_code == 200
         assert "X-Cartesia-Error-Source" not in response.headers
 
-    def test_pre_call_handler_rejection_omits_header(self):
+    def test_pre_call_handler_rejection_sets_agent_code_header(self):
         from fastapi.testclient import TestClient
 
         async def reject(_request):
@@ -1425,7 +1425,7 @@ class TestCreateChatSessionErrorAttribution:
         client = TestClient(self._build_app(reject).fastapi_app)
         response = client.post("/chats", json=self._chats_body())
 
-        # Explicit rejection is a 403 from the SDK itself, not a customer-code
-        # exception, so it should not carry the agent-code attribution.
+        # Returning None is an explicit rejection by customer code, so the 403
+        # carries the agent-code attribution.
         assert response.status_code == 403
-        assert "X-Cartesia-Error-Source" not in response.headers
+        assert response.headers.get("X-Cartesia-Error-Source") == "agent-code"


### PR DESCRIPTION
## Summary

When customer code raises an explicit `HTTPException` in `pre_call_handler`, attach the `X-Cartesia-Error-Source: agent-code` header so downstream services can attribute the failure correctly rather than treating it as a Cartesia/SDK error.

This matches the behavior already applied to the generic exception branch, which wraps non-HTTP exceptions in an `HTTPException` carrying the same header.

## Changes

- Catch `HTTPException as e` in `pre_call_handler` error handling and inject the `X-Cartesia-Error-Source` header (initializing `e.headers` if `None`) before re-raising.
- Generalize the comment on the generic exception branch (drop the Inferno-specific reference).