### PR TITLE
Add responses_store opt-out and stream phase=commentary live

### DIFF
--- a/line/llm_agent/config.py
+++ b/line/llm_agent/config.py
@@ -49,6 +49,15 @@ class LlmConfig:
     # Tool schema settings
     strict_tool_schemas: bool = _UNSET
 
+    # Responses API server-state opt-out. When True (default), the SDK sends
+    # ``store: true`` and chains turns via ``previous_response_id`` for
+    # efficient continuation. Set False for OpenAI organizations with Zero
+    # Data Retention enabled (server-side conversation storage rejected by
+    # the API) — the SDK then sends ``store: false`` and the full
+    # conversation as ``input`` each turn. Only used by the WebSocket and
+    # ``http_responses`` backends; the ``http`` backend ignores it.
+    responses_store: bool = _UNSET
+
     @classmethod
     def from_call_request(
         cls,
@@ -135,6 +144,7 @@ _FIELD_DEFAULTS: Dict[str, Any] = {
     "timeout": None,
     "extra": dict,  # callable → invoked each time
     "strict_tool_schemas": True,
+    "responses_store": True,
 }
 
 

--- a/line/llm_agent/config.py
+++ b/line/llm_agent/config.py
@@ -49,14 +49,14 @@ class LlmConfig:
     # Tool schema settings
     strict_tool_schemas: bool = _UNSET
 
-    # Responses API server-state opt-out. When True (default), the SDK sends
-    # ``store: true`` and chains turns via ``previous_response_id`` for
-    # efficient continuation. Set False for OpenAI organizations with Zero
-    # Data Retention enabled (server-side conversation storage rejected by
-    # the API) — the SDK then sends ``store: false`` and the full
-    # conversation as ``input`` each turn. Only used by the WebSocket and
-    # ``http_responses`` backends; the ``http`` backend ignores it.
-    responses_store: bool = _UNSET
+    # Zero Data Retention mode. Default False — the SDK sends ``store: true``
+    # to OpenAI's Responses API and chains turns via ``previous_response_id``
+    # for efficient continuation. Set True for OpenAI organizations with ZDR
+    # enabled (server-side conversation storage rejected by the API) — the
+    # SDK then sends ``store: false`` and the full conversation as ``input``
+    # on every turn. Only used by the WebSocket and ``http_responses``
+    # backends; the ``http`` backend ignores it.
+    zdr_enabled: bool = _UNSET
 
     @classmethod
     def from_call_request(
@@ -144,7 +144,7 @@ _FIELD_DEFAULTS: Dict[str, Any] = {
     "timeout": None,
     "extra": dict,  # callable → invoked each time
     "strict_tool_schemas": True,
-    "responses_store": True,
+    "zdr_enabled": False,
 }
 
 

--- a/line/llm_agent/http_responses_provider.py
+++ b/line/llm_agent/http_responses_provider.py
@@ -19,17 +19,27 @@ history, same ``previous_response_id`` continuation, same
 endpoint — useful when the ``wss://api.openai.com/v1/responses``
 endpoint is less reliable than HTTPS in practice.
 
-Phase handling
---------------
-The Responses API can emit two ``message`` items per response: one
-with ``phase: "commentary"`` (preamble before tool calls) and one with
-``phase: "final_answer"`` (the completed answer).  For a voice/TTS
-context, the commentary item's text is almost always undesirable to
-speak — and when it is similar/identical to the final answer it causes
-double-speak.  This provider tracks ``output_index → phase`` from
-``response.output_item.added`` events and suppresses
-``response.output_text.delta`` events for items marked
-``"commentary"``.
+Multiple message items per response
+-----------------------------------
+The Responses API can emit more than one ``message`` item in a single
+response — commonly a ``phase: "commentary"`` item (intermediate
+user-visible update, including preambles before tool calls) followed
+by a ``phase: "final_answer"`` item (the completed answer). For
+``gpt-5.4+`` reasoning models, the texts often duplicate; sometimes the
+second item is empty. Speaking everything would produce double-speak
+over TTS; suppressing commentary outright (as earlier versions did)
+silences turns where commentary is the entire reply or the preamble
+before a tool call.
+
+Strategy: phase-blind, "first textual message item wins". The first
+non-empty ``output_text.delta`` claims an ``output_index``; all deltas
+for that index stream as they arrive, and deltas from any later
+message item in the same response are dropped. Tool calls and
+single-message responses are unaffected. Phase is recorded only for
+log clarity.
+
+See the consumer repo's ``cartesia-examples/`` for standalone
+reproductions of the duplicate-text and preamble-before-tool patterns.
 """
 
 import asyncio
@@ -61,10 +71,11 @@ class _HttpResponseEventStream:
     """Reads Responses-API streaming events from ``litellm.aresponses`` and
     yields :class:`StreamChunk` objects.
 
-    Phase filtering: when an ``output_item.added`` event arrives with
-    ``item.type == "message"`` and ``item.phase == "commentary"``, all
-    subsequent ``output_text.delta`` events with that ``output_index``
-    are dropped.  Tool calls and final-answer text pass through.
+    First-message-wins filtering: the first ``output_text.delta`` claims
+    an ``output_index``; all subsequent deltas for that index stream as
+    they arrive. Deltas from any later message item in the same response
+    are dropped (see the module docstring for why). Tool calls pass
+    through unaffected.
 
     On terminal events the ``on_response_done`` callback is invoked
     with the response dict so the provider can update its history.
@@ -81,7 +92,14 @@ class _HttpResponseEventStream:
 
     async def __aiter__(self) -> AsyncIterator[StreamChunk]:
         tool_calls: Dict[str, ToolCall] = {}
-        commentary_indices: set[int] = set()
+        # output_index -> phase tag, kept for log clarity only. The streaming
+        # decision below is phase-blind — first textual message item in a
+        # response wins; subsequent textual items are dropped.
+        message_phases: Dict[int, str] = {}
+        # output_index whose deltas are being streamed this response. Set on
+        # the first non-empty delta of any message item.
+        streaming_index: Optional[int] = None
+        dropped_indices_logged: set[int] = set()
         received_content = False
 
         async for event in self._iter:
@@ -95,13 +113,8 @@ class _HttpResponseEventStream:
                 output_index = event.output_index
                 item_type = item.type
                 if item_type == "message":
-                    phase = getattr(item, "phase", None)
-                    if phase == "commentary":
-                        commentary_indices.add(int(output_index))
-                        logger.debug(
-                            "Responses HTTP: suppressing commentary message at output_index=%d",
-                            int(output_index),
-                        )
+                    phase = getattr(item, "phase", None) or "final_answer"
+                    message_phases[int(output_index)] = phase
                 elif item_type == "function_call":
                     call_id = item.call_id
                     name = item.name
@@ -109,13 +122,35 @@ class _HttpResponseEventStream:
                         tool_calls[call_id] = ToolCall(id=call_id, name=name, arguments="")
 
             elif event_type == "response.output_text.delta":
-                output_index = event.output_index
-                if int(output_index) in commentary_indices:
-                    continue
+                output_index = int(event.output_index)
                 delta = event.delta
-                if delta:
+                if not delta:
+                    continue
+                if streaming_index is None:
+                    streaming_index = output_index
+                    logger.debug(
+                        "Responses HTTP: streaming text from output_index={i} phase={p}",
+                        i=output_index,
+                        p=message_phases.get(output_index, "(unknown)"),
+                    )
+                if output_index == streaming_index:
                     received_content = True
                     yield StreamChunk(text=delta)
+                elif output_index not in dropped_indices_logged:
+                    # A second message item is producing text in this response —
+                    # log once per dropped index, then silently swallow its
+                    # remaining deltas. Avoids TTS double-speak (the model
+                    # often emits commentary + final_answer with identical
+                    # text) and respects "one reply per turn".
+                    dropped_indices_logged.add(output_index)
+                    logger.debug(
+                        "Responses HTTP: dropping text from output_index={i} phase={p} "
+                        "(already streaming output_index={s} phase={sp})",
+                        i=output_index,
+                        p=message_phases.get(output_index, "(unknown)"),
+                        s=streaming_index,
+                        sp=message_phases.get(streaming_index, "(unknown)"),
+                    )
 
             elif event_type == "response.function_call_arguments.delta":
                 # The Responses streaming protocol identifies the active
@@ -175,10 +210,10 @@ class _HttpResponseEventStream:
                 else:
                     details = response_dict.get("incomplete_details")
                     logger.warning(
-                        "Non-completed response from Responses API: status=%s, reason=%s, response_id=%s",
-                        status,
-                        details.get("reason", "") if isinstance(details, dict) else "",
-                        response_dict.get("id", ""),
+                        "Non-completed response from Responses API: status={s} reason={r} response_id={i}",
+                        s=status,
+                        r=details.get("reason", "") if isinstance(details, dict) else "",
+                        i=response_dict.get("id", ""),
                     )
 
                 yield StreamChunk(
@@ -343,8 +378,8 @@ class _HttpResponsesProvider:
                     self._history = []
                     attempt += 1
                     logger.debug(
-                        "Responses API lost previous_response_id (via %s); retrying current turn",
-                        type(exc).__name__,
+                        "Responses API lost previous_response_id (via {n}); retrying current turn",
+                        n=type(exc).__name__,
                     )
 
         return _AsyncIterableContext(_iter)

--- a/line/llm_agent/provider_utils.py
+++ b/line/llm_agent/provider_utils.py
@@ -152,7 +152,7 @@ def _build_responses_body(
     """
     body: Dict[str, Any] = {
         "model": model_id.model,
-        "store": cfg.responses_store,
+        "store": not cfg.zdr_enabled,
     }
     if input is not None:
         body["input"] = input
@@ -203,11 +203,11 @@ def _plan_responses_chat(
 
     desired_pairs = _expand_messages(non_system, assistant_text_type="output_text")
 
-    if not config.responses_store:
-        # ZDR-friendly stateless mode: every turn sends the full conversation
-        # as ``input`` (no ``previous_response_id`` chaining). Server keeps no
-        # state, so history-based divergence/continuation logic is skipped and
-        # the per-turn history update is a no-op.
+    if config.zdr_enabled:
+        # ZDR mode: every turn sends the full conversation as ``input`` (no
+        # ``previous_response_id`` chaining). Server keeps no state, so
+        # history-based divergence/continuation logic is skipped and the
+        # per-turn history update is a no-op.
         body = _build_responses_body(
             model_id=model_id,
             instructions=instructions,

--- a/line/llm_agent/provider_utils.py
+++ b/line/llm_agent/provider_utils.py
@@ -152,7 +152,7 @@ def _build_responses_body(
     """
     body: Dict[str, Any] = {
         "model": model_id.model,
-        "store": True,
+        "store": cfg.responses_store,
     }
     if input is not None:
         body["input"] = input
@@ -201,13 +201,33 @@ def _plan_responses_chat(
         responses_api=True,
     )
 
+    desired_pairs = _expand_messages(non_system, assistant_text_type="output_text")
+
+    if not config.responses_store:
+        # ZDR-friendly stateless mode: every turn sends the full conversation
+        # as ``input`` (no ``previous_response_id`` chaining). Server keeps no
+        # state, so history-based divergence/continuation logic is skipped and
+        # the per-turn history update is a no-op.
+        body = _build_responses_body(
+            model_id=model_id,
+            instructions=instructions,
+            tool_defs=tool_defs,
+            cfg=config,
+            input=[item for item, _ in desired_pairs],
+            previous_response_id=None,
+        )
+
+        def update(old_history: List[ConversationEntry], response: Dict[str, Any]) -> List[ConversationEntry]:
+            return []
+
+        return body, update
+
     context_id = _context_identity(
         instructions,
         tool_defs,
         temperature=config.temperature,
         max_tokens=config.max_tokens,
     )
-    desired_pairs = _expand_messages(non_system, assistant_text_type="output_text")
     desired_ids = [context_id] + [identity for _, identity in desired_pairs]
 
     if history and history[0][0] == context_id:

--- a/tests/test_http_responses_provider.py
+++ b/tests/test_http_responses_provider.py
@@ -52,12 +52,14 @@ async def _drive(events: List[Dict[str, Any]]) -> List[StreamChunk]:
     return chunks
 
 
-def test_commentary_message_is_suppressed_final_answer_passes_through():
-    """The duplication-fix regression test.
+def test_commentary_streams_and_subsequent_final_answer_is_dropped():
+    """Duplicate-text avoidance: commentary streams live, the duplicate
+    final_answer that follows is dropped to prevent TTS double-speak.
 
     Two message items in one response: commentary (output_index=0) and
-    final_answer (output_index=1) with the same text.  Only the
-    final_answer's deltas should reach the caller.
+    final_answer (output_index=1) with the same text. Only the commentary
+    deltas should reach the caller; final_answer deltas are silently dropped
+    because commentary already covered the turn's reply.
     """
     events = [
         # Commentary message item starts at output_index 0.
@@ -131,9 +133,147 @@ def test_commentary_message_is_suppressed_final_answer_passes_through():
     chunks = _run(_drive(events))
     text_chunks = [c.text for c in chunks if c.text is not None]
     assert text_chunks == ["Hello there!"], (
-        f"expected exactly one 'Hello there!' (commentary suppressed); got {text_chunks!r}"
+        f"expected the commentary text once (final_answer dropped as duplicate); got {text_chunks!r}"
     )
     assert chunks[-1].is_final is True
+
+
+def test_commentary_only_response_streams_live():
+    """When commentary is the ONLY output (no final_answer, no tool calls),
+    its deltas stream live as they arrive — no buffering. Real-world trigger:
+    gpt-5.4-mini tags some conversational read-back turns as commentary."""
+    events = [
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {"type": "message", "phase": "commentary", "id": "msg_0"},
+        },
+        {
+            "type": "response.output_text.delta",
+            "output_index": 0,
+            "item_id": "msg_0",
+            "content_index": 0,
+            "delta": "Your zip code is ",
+        },
+        {
+            "type": "response.output_text.delta",
+            "output_index": 0,
+            "item_id": "msg_0",
+            "content_index": 0,
+            "delta": "60007. Right?",
+        },
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "type": "message",
+                "phase": "commentary",
+                "id": "msg_0",
+                "content": [{"type": "output_text", "text": "Your zip code is 60007. Right?"}],
+            },
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_co",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "phase": "commentary",
+                        "content": [{"type": "output_text", "text": "Your zip code is 60007. Right?"}],
+                    },
+                ],
+            },
+        },
+    ]
+    chunks = _run(_drive(events))
+    text_chunks = [c.text for c in chunks if c.text]
+    # Two deltas in → two deltas out, in order. No buffering, no flush.
+    assert text_chunks == ["Your zip code is ", "60007. Right?"], (
+        f"expected commentary deltas to stream live; got {text_chunks!r}"
+    )
+    assert chunks[-1].is_final is True
+
+
+def test_commentary_streams_as_preamble_before_tool_call():
+    """When commentary precedes a tool call (the OpenAI-documented preamble-
+    before-tool pattern), the commentary text streams live so the user hears
+    the acknowledgment while the tool runs. Without this, the tool execution
+    is a silent dead-zone for voice agents."""
+    events = [
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {"type": "message", "phase": "commentary", "id": "msg_0"},
+        },
+        {
+            "type": "response.output_text.delta",
+            "output_index": 0,
+            "item_id": "msg_0",
+            "content_index": 0,
+            "delta": "Let me look that up for you...",
+        },
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "type": "message",
+                "phase": "commentary",
+                "id": "msg_0",
+                "content": [{"type": "output_text", "text": "Let me look that up for you..."}],
+            },
+        },
+        {
+            "type": "response.output_item.added",
+            "output_index": 1,
+            "item": {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "lookup",
+                "id": "fn_item_1",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "output_index": 1,
+            "item_id": "fn_item_1",
+            "delta": "{}",
+        },
+        {
+            "type": "response.output_item.done",
+            "output_index": 1,
+            "item": {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "lookup",
+                "id": "fn_item_1",
+                "arguments": "{}",
+            },
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_tc",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "phase": "commentary",
+                        "content": [{"type": "output_text", "text": "Let me look that up for you..."}],
+                    },
+                    {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{}"},
+                ],
+            },
+        },
+    ]
+    chunks = _run(_drive(events))
+    text_chunks = [c.text for c in chunks if c.text]
+    assert text_chunks == ["Let me look that up for you..."], (
+        f"expected commentary preamble to stream; got {text_chunks!r}"
+    )
+    assert chunks[-1].is_final is True
+    assert [tc.name for tc in chunks[-1].tool_calls] == ["lookup"]
 
 
 def test_text_passes_through_when_phase_is_missing():

--- a/tests/test_llm_agent_config.py
+++ b/tests/test_llm_agent_config.py
@@ -249,22 +249,22 @@ def test_user_defaults_with_extra_kwargs():
     assert config.max_tokens == 500
 
 
-def test_responses_store_defaults_to_true():
-    """The Responses-API ``store`` opt-out defaults to True (stateful)."""
+def test_zdr_enabled_defaults_to_false():
+    """ZDR mode defaults to False — stateful Responses API behavior preserved."""
     from line.llm_agent.config import _normalize_config
 
     config = _normalize_config(LlmConfig())
-    assert config.responses_store is True
+    assert config.zdr_enabled is False
 
 
-def test_responses_store_explicit_false_propagates_through_merge():
-    """Explicitly disabling server state survives normalization and merge."""
+def test_zdr_enabled_explicit_true_propagates_through_merge():
+    """Explicitly enabling ZDR survives normalization and merge."""
     from line.llm_agent.config import _merge_configs, _normalize_config
 
-    base = LlmConfig(responses_store=False)
+    base = LlmConfig(zdr_enabled=True)
     override = LlmConfig()
     merged = _merge_configs(base, override)
-    assert merged.responses_store is False
+    assert merged.zdr_enabled is True
 
     normalized = _normalize_config(base)
-    assert normalized.responses_store is False
+    assert normalized.zdr_enabled is True

--- a/tests/test_llm_agent_config.py
+++ b/tests/test_llm_agent_config.py
@@ -247,3 +247,24 @@ def test_user_defaults_with_extra_kwargs():
     assert config.introduction == "Welcome to our store!"
     assert config.temperature == 0.8
     assert config.max_tokens == 500
+
+
+def test_responses_store_defaults_to_true():
+    """The Responses-API ``store`` opt-out defaults to True (stateful)."""
+    from line.llm_agent.config import _normalize_config
+
+    config = _normalize_config(LlmConfig())
+    assert config.responses_store is True
+
+
+def test_responses_store_explicit_false_propagates_through_merge():
+    """Explicitly disabling server state survives normalization and merge."""
+    from line.llm_agent.config import _merge_configs, _normalize_config
+
+    base = LlmConfig(responses_store=False)
+    override = LlmConfig()
+    merged = _merge_configs(base, override)
+    assert merged.responses_store is False
+
+    normalized = _normalize_config(base)
+    assert normalized.responses_store is False

--- a/tests/test_websocket_provider.py
+++ b/tests/test_websocket_provider.py
@@ -175,19 +175,19 @@ def test_build_request_defaults_store_to_true():
     assert request["store"] is True
 
 
-def test_build_request_honors_responses_store_false():
+def test_build_request_honors_zdr_enabled_true():
     request = _build_request(
         model_id=parse_model_id("openai/gpt-5.2"),
         instructions=None,
         tool_defs=None,
-        cfg=_normalize_config(LlmConfig(responses_store=False)),
+        cfg=_normalize_config(LlmConfig(zdr_enabled=True)),
     )
     assert request["store"] is False
 
 
-def test_plan_chat_stateless_mode_sends_full_input_without_previous_response_id():
-    """When responses_store=False, ignore history and send the full conversation."""
-    config = _normalize_config(LlmConfig(responses_store=False))
+def test_plan_chat_zdr_mode_sends_full_input_without_previous_response_id():
+    """When zdr_enabled=True, ignore history and send the full conversation."""
+    config = _normalize_config(LlmConfig(zdr_enabled=True))
     context_id = _context_identity(None, None, temperature=config.temperature, max_tokens=config.max_tokens)
     history = [
         (context_id, "warmup"),

--- a/tests/test_websocket_provider.py
+++ b/tests/test_websocket_provider.py
@@ -165,6 +165,56 @@ def test_build_request_uses_bare_model_name():
     assert request["model"] == "gpt-5.2"
 
 
+def test_build_request_defaults_store_to_true():
+    request = _build_request(
+        model_id=parse_model_id("openai/gpt-5.2"),
+        instructions=None,
+        tool_defs=None,
+        cfg=_normalize_config(LlmConfig()),
+    )
+    assert request["store"] is True
+
+
+def test_build_request_honors_responses_store_false():
+    request = _build_request(
+        model_id=parse_model_id("openai/gpt-5.2"),
+        instructions=None,
+        tool_defs=None,
+        cfg=_normalize_config(LlmConfig(responses_store=False)),
+    )
+    assert request["store"] is False
+
+
+def test_plan_chat_stateless_mode_sends_full_input_without_previous_response_id():
+    """When responses_store=False, ignore history and send the full conversation."""
+    config = _normalize_config(LlmConfig(responses_store=False))
+    context_id = _context_identity(None, None, temperature=config.temperature, max_tokens=config.max_tokens)
+    history = [
+        (context_id, "warmup"),
+        (("user", "hello", "", ""), None),
+        (("assistant", "hi", "", ""), "resp_1"),
+    ]
+
+    request, update = _plan_chat(
+        history=history,
+        model_id=parse_model_id("openai/gpt-5.2"),
+        messages=[
+            Message(role="user", content="hello"),
+            Message(role="assistant", content="hi"),
+            Message(role="user", content="what's up?"),
+        ],
+        tools=None,
+        config=config,
+    )
+
+    assert request["store"] is False
+    assert "previous_response_id" not in request
+    # All three turns should be in input, not just the diverged tail
+    assert len(request["input"]) == 3
+    # Update should produce an empty history (server has no state to track)
+    assert update(history, {"status": "completed", "id": "resp_2", "output": []}) == []
+
+
 # ---------------------------------------------------------------------------
 # _extract_model_output_identities
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two changes to the HTTPS Responses provider, both motivated by a real production voice agent on `gpt-5.4-mini` with `reasoning=low` and tools.

## 1. `LlmConfig.responses_store` opt-out (commit 1)

`_build_responses_body` hardcoded `store: true` and chained turns via `previous_response_id`. OpenAI orgs with Zero Data Retention enabled reject `previous_response_id` with HTTP 400 on the second turn, which broke our agent.

Add a `responses_store: bool = True` field on `LlmConfig`. When `False`, the planner skips the continuation lookup, sends the full conversation as `input` every turn, sets `store: false`, and treats per-turn history updates as a no-op. Default behavior unchanged.

## 2. First textual message item wins (commit 2)

Today the provider drops every `output_text.delta` whose `output_index` belongs to a `phase: "commentary"` item. We hit two cases where that silences the voice agent:

- **`commentary`-only response** — on conversational read-back turns the model sometimes emits ONLY a commentary message (no `final_answer`, no tool). Dropping commentary leaves the turn silent.
- **`commentary` preamble before a tool call** — when prompted to acknowledge before calling a tool (per OpenAI's [prompt-guidance docs](https://developers.openai.com/api/docs/guides/prompt-guidance)), the model emits commentary + `function_call` with no `final_answer`. Dropping commentary kills the preamble; the user hears nothing while the tool runs.

The original anti-double-speak motivation is also real — the model frequently emits commentary + `final_answer` with byte-for-byte identical text, sometimes with an empty `final_answer`. For a voice consumer, all of those cases reduce to "one user-facing reply per turn".

Switch to a **phase-blind, first-textual-item-wins** rule: the first non-empty `output_text.delta` claims an `output_index`; all deltas for that index stream as they arrive, and deltas from any later message item in the same response are dropped. Tool calls and single-message responses are unaffected. This is strictly simpler than tracking phases for routing, and is robust to pathological orderings (multiple commentary items, `final_answer` before `commentary`, etc.) that phase-aware logic could leak through.

Phase tags are still recorded from `output_item.added` events and surfaced in debug logs so operators can see what phase the streamed text had and what phase any dropped text had — they just don't drive routing.

While I was there, I also fixed three pre-existing log call sites in this file that used printf-style `%d`/`%s` placeholders. The SDK uses loguru, which expects `{}` placeholders — under the previous calls the format strings leaked through verbatim (e.g. our prod logs showed lines like `output_index=%d` and `previous_response_id (via %s)`).

## Repros

Two standalone scripts (plus a README) live in this gist:
<https://gist.github.com/drago-balto/4ab97238aaec2e4325581ee7d6aea059>

- **`example_a_duplicate_text.py`** — short fact-game context that elicits both shapes of the duplicate-text case: `commentary` + `final_answer` with byte-for-byte identical text, and `commentary` + empty `final_answer`. Runs N attempts and tallies how often each shape lands.
- **`example_b_commentary_with_tool.py`** — order-lookup prompt with an explicit "acknowledge before calling the tool" instruction, eliciting `commentary` + `function_call` with no `final_answer`. Reproduces on ~every attempt.

Both call OpenAI's Responses API directly (`openai==2.40.0`, no `litellm`, no `cartesia-line`) with `gpt-5.4-mini`, `reasoning: {effort: "low"}`, `store: false`, `stream: true`. Set `OPENAI_API_KEY` and run with `uv run --with openai==2.40.0 --no-project python <script>.py`.

## Tests

The three `tests/test_http_responses_provider.py` tests for commentary handling are rewritten (renamed + assertions flipped) to encode the new semantics. Full suite passes locally (`tests/test_http_responses_provider.py`, `tests/test_websocket_provider.py`, `tests/test_llm_agent_config.py`): 36/36.
