### PR TITLE
[VA-941] Add built-in voicemail detection tool for outbound agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ agent = LlmAgent(
 
 | Tool | What it does |
 |------|--------------|
-| `end_call` | Ends the call (records `end_reason="agent_ended"`) |
+| `end_call` | Ends the call |
 | `send_dtmf` | Presses phone buttons (0-9, *, #) |
 | `transfer_call` | Transfers to a phone number (E.164 format) |
-| `voicemail` | Call when you reach a voicemail: optionally leaves a message, then ends the call with `end_reason="voicemail_detected"`. Configure with `voicemail(message="…")` |
+| `voicemail` | Call when you reach a voicemail: optionally leaves a message, then hangs up the call. Configure with `voicemail(message="…")` |
 | `web_search` | Searches the web (native LLM search or DuckDuckGo fallback) |
 | `knowledge_base` | Looks up information from the agent's knowledge base via natural-language query. Call `knowledge_base(filters={...}, top_k=10)` to pre-filter retrievals or override `top_k` |
 | `http_server_tool` | Creates an HTTP tool from JSON schemas (see below) |

--- a/README.md
+++ b/README.md
@@ -172,23 +172,26 @@ voicemail(description="…")                 # override the LLM-facing "when to 
 
 **Automatic removal once the conversation starts.** Voicemail is only worth
 checking at the very start of a call, so the agent **drops the `voicemail` tool
-after `voicemail_tool_active_turns` user turns** (default `2`) — once the
-conversation is "deemed started" the LLM can no longer trigger a voicemail
-hangup mid-call. The default of `2` covers a greeting that arrives over a couple
-of turns (e.g. split by VAD); set it higher for heavily fragmented greetings, or
-`None` to keep the tool for the whole call:
+after its `active_turns`** (default `2`) — once the conversation is "deemed
+started" the LLM can no longer trigger a voicemail hangup mid-call. The default
+of `2` covers a greeting that arrives over a couple of turns (e.g. split by VAD);
+set it higher for heavily fragmented greetings, or `None` to keep the tool for
+the whole call:
 
 ```python
 agent = LlmAgent(
     model="anthropic/claude-haiku-4-5-20251001",
     api_key=os.getenv("ANTHROPIC_API_KEY"),
-    tools=[voicemail(message="Hi, please call us back."), end_call],
+    # active_turns lives on the tool. Default is 2; None keeps it for the whole call.
+    tools=[voicemail(message="Hi, please call us back.", active_turns=2), end_call],
     config=LlmConfig(system_prompt=SYSTEM_PROMPT, introduction=""),
-    voicemail_tool_active_turns=2,  # default; None keeps the tool for the whole call
 )
 ```
 
-The removal is a no-op for agents that don't include the `voicemail` tool.
+`active_turns` is a general feature of the built-in class tools (`end_call`,
+`transfer_call`, `voicemail`, `knowledge_base`): any of them can be set to drop
+after N user turns. It defaults to `None` (kept for the whole call) for every
+tool except `voicemail`, which defaults to `2`.
 
 ### HTTP Tools — Connect to HTTP APIs Without Code
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,58 @@ agent = LlmAgent(
 | `end_call` | Ends the call |
 | `send_dtmf` | Presses phone buttons (0-9, *, #) |
 | `transfer_call` | Transfers to a phone number (E.164 format) |
-| `voicemail` | Call when you reach a voicemail: optionally leaves a message, then hangs up the call. Configure with `voicemail(message="…")` |
+| `voicemail` | Ends the call when you reach a voicemail: optionally leaves a message first, then hangs up with `end_reason="voicemail_detected"`. Configure with `voicemail(message="…")`. See [Voicemail detection](#voicemail-detection-outbound-calls). |
 | `web_search` | Searches the web (native LLM search or DuckDuckGo fallback) |
 | `knowledge_base` | Looks up information from the agent's knowledge base via natural-language query. Call `knowledge_base(filters={...}, top_k=10)` to pre-filter retrievals or override `top_k` |
 | `http_server_tool` | Creates an HTTP tool from JSON schemas (see below) |
+
+### Voicemail Detection (outbound calls)
+
+On an outbound call you usually want the agent to hear the callee's opening line
+before speaking, so set `introduction=""` — the agent stays silent on
+`CallStarted` and only responds after the first `UserTurnEnded`. Give it the
+`voicemail` tool and it will hang up (after an optional message) when the LLM
+recognizes a machine greeting, recording `end_reason="voicemail_detected"`:
+
+```python
+from line.llm_agent import LlmAgent, LlmConfig, end_call, voicemail
+
+agent = LlmAgent(
+    model="anthropic/claude-haiku-4-5-20251001",
+    api_key=os.getenv("ANTHROPIC_API_KEY"),
+    tools=[voicemail(message="Hi, please call us back when you can."), end_call],
+    config=LlmConfig(system_prompt=SYSTEM_PROMPT, introduction=""),  # outbound: wait for the callee
+)
+```
+
+Behavior modes (all from the one tool):
+
+```python
+voicemail                                  # silently end the call on a voicemail
+voicemail(message="Sorry we missed you.")  # speak the message (uninterruptible), then end
+voicemail(interruptible=True)              # allow the message/hangup to be interrupted
+voicemail(description="…")                 # override the LLM-facing "when to call this" text
+```
+
+**Automatic removal once the conversation starts.** Voicemail is only worth
+checking at the very start of a call, so the agent **drops the `voicemail` tool
+after `voicemail_tool_active_turns` user turns** (default `2`) — once the
+conversation is "deemed started" the LLM can no longer trigger a voicemail
+hangup mid-call. The default of `2` covers a greeting that arrives over a couple
+of turns (e.g. split by VAD); set it higher for heavily fragmented greetings, or
+`None` to keep the tool for the whole call:
+
+```python
+agent = LlmAgent(
+    model="anthropic/claude-haiku-4-5-20251001",
+    api_key=os.getenv("ANTHROPIC_API_KEY"),
+    tools=[voicemail(message="Hi, please call us back."), end_call],
+    config=LlmConfig(system_prompt=SYSTEM_PROMPT, introduction=""),
+    voicemail_tool_active_turns=2,  # default; None keeps the tool for the whole call
+)
+```
+
+The removal is a no-op for agents that don't include the `voicemail` tool.
 
 ### HTTP Tools — Connect to HTTP APIs Without Code
 

--- a/README.md
+++ b/README.md
@@ -123,20 +123,21 @@ async def get_agent(env: AgentEnv, call_request: CallRequest):
 Ready-to-use tools for common actions:
 
 ```python
-from line.llm_agent import LlmAgent, LlmConfig, end_call, knowledge_base, send_dtmf, transfer_call, web_search
+from line.llm_agent import LlmAgent, LlmConfig, end_call, knowledge_base, send_dtmf, transfer_call, voicemail, web_search
 
 agent = LlmAgent(
     model="gemini/gemini-2.5-flash-preview-09-2025",
-    tools=[end_call, send_dtmf, transfer_call, web_search, knowledge_base],
+    tools=[end_call, send_dtmf, transfer_call, voicemail, web_search, knowledge_base],
     config=LlmConfig(...),
 )
 ```
 
 | Tool | What it does |
 |------|--------------|
-| `end_call` | Ends the call |
+| `end_call` | Ends the call (records `end_reason="agent_ended"`) |
 | `send_dtmf` | Presses phone buttons (0-9, *, #) |
 | `transfer_call` | Transfers to a phone number (E.164 format) |
+| `voicemail` | Call when you reach a voicemail: optionally leaves a message, then ends the call with `end_reason="voicemail_detected"`. Configure with `voicemail(message="…")` |
 | `web_search` | Searches the web (native LLM search or DuckDuckGo fallback) |
 | `knowledge_base` | Looks up information from the agent's knowledge base via natural-language query. Call `knowledge_base(filters={...}, top_k=10)` to pre-filter retrievals or override `top_k` |
 | `http_server_tool` | Creates an HTTP tool from JSON schemas (see below) |

--- a/examples/basic_chat/AGENTS.md
+++ b/examples/basic_chat/AGENTS.md
@@ -159,7 +159,7 @@ agent = LlmAgent(
 | `end_call` | passthrough | End call gracefully (`end_reason="agent_ended"`) |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
-| `voicemail` | passthrough | End on a voicemail greeting: optional message, then hang up with `end_reason="voicemail_detected"`. Auto-removed after `voicemail_tool_active_turns` (default 2). |
+| `voicemail` | passthrough | End on a voicemail greeting: optional message, then hang up with `end_reason="voicemail_detected"`. Auto-removed after its `active_turns` (default 2). |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/examples/basic_chat/AGENTS.md
+++ b/examples/basic_chat/AGENTS.md
@@ -156,9 +156,10 @@ agent = LlmAgent(
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `end_call` | passthrough | End call gracefully |
+| `end_call` | passthrough | End call gracefully (`end_reason="agent_ended"`) |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
+| `voicemail` | passthrough | End on a voicemail greeting: optional message, then hang up with `end_reason="voicemail_detected"`. Auto-removed after `voicemail_tool_active_turns` (default 2). |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/line/__init__.py
+++ b/line/__init__.py
@@ -30,6 +30,7 @@ from line.events import (
     CallStarted,
     # Custom events
     CustomHistoryEntry,
+    EndCallReason,
     HistoryEvent,
     InputEvent,
     LogMessage,
@@ -71,6 +72,7 @@ __all__ = [
     "AgentSendText",
     "AgentSendDtmf",
     "AgentEndCall",
+    "EndCallReason",
     "AgentTransferCall",
     "AgentToolCalled",
     "AgentToolReturned",

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field
 
 ########################################################
-#  Copied and adapted from Bifrost agent_types.py
+#  Wire message types for the Cartesia voice-agent websocket protocol.
 ########################################################
 
 # Input messages to be sent over the websocket to the user code
@@ -108,6 +108,9 @@ class TransferOutput(BaseModel):
 
 class EndCallOutput(BaseModel):
     type: Literal["end_call"] = "end_call"
+    # Free-form on the wire so the harness never rejects an unknown reason from a
+    # newer SDK; the canonical vocabulary is line.events.EndCallReason.
+    reason: Optional[str] = None
     responding_to: Optional[str] = None
     interruptible: bool = True
 

--- a/line/events.py
+++ b/line/events.py
@@ -42,8 +42,15 @@ class AgentToolReturned(BaseModel):
     responding_to: Optional[str] = None
 
 
+# Supported end_reason values in the Cartesia API. "agent_ended" is the default
+# normal hangup (from end_call); "voicemail_detected" is set by the voicemail tool.
+# The reason field below stays a plain str so an unexpected value never raises.
+EndCallReason = Literal["agent_ended", "voicemail_detected"]
+
+
 class AgentEndCall(BaseModel):
     type: Literal["end_call"] = "end_call"
+    reason: str = "agent_ended"
     responding_to: Optional[str] = None
     interruptible: bool = True
 

--- a/line/llm_agent/__init__.py
+++ b/line/llm_agent/__init__.py
@@ -38,6 +38,7 @@ from line.llm_agent.tools.system import (
 
 # Function tool definitions and types
 from line.llm_agent.tools.utils import (
+    ClassTool,
     FunctionTool,
     HandoffToolFn,
     LoopbackToolFn,
@@ -81,6 +82,7 @@ __all__ = [
     "HandoffToolFn",
     # Tool definitions
     "FunctionTool",
+    "ClassTool",
     "ParameterInfo",
     "ToolType",
 ]

--- a/line/llm_agent/__init__.py
+++ b/line/llm_agent/__init__.py
@@ -32,6 +32,7 @@ from line.llm_agent.tools.system import (
     mcp_tool,
     send_dtmf,
     transfer_call,
+    voicemail,
     web_search,
 )
 
@@ -67,6 +68,7 @@ __all__ = [
     "end_call",
     "send_dtmf",
     "transfer_call",
+    "voicemail",
     "web_search",
     "agent_as_handoff",
     "mcp_tool",

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -52,7 +52,7 @@ from line.llm_agent.provider import (
     _get_model_config,
     parse_model_id,
 )
-from line.llm_agent.tools.system import EndCallTool, TransferCallTool, WebSearchTool
+from line.llm_agent.tools.system import EndCallTool, TransferCallTool, VoicemailTool, WebSearchTool
 from line.llm_agent.tools.utils import (
     FunctionTool,
     ToolEnv,
@@ -68,7 +68,14 @@ _OUTPUT_EVENT_TYPES: Tuple[type, ...] = get_args(OutputEvent)
 
 # Type alias for tools that can be passed to LlmAgent.
 # Plain callables are automatically wrapped via the @tool decorator.
-ToolSpec = Union[FunctionTool, WebSearchTool, EndCallTool, TransferCallTool, Callable]
+ToolSpec = Union[FunctionTool, WebSearchTool, EndCallTool, TransferCallTool, VoicemailTool, Callable]
+
+
+def _is_voicemail_tool(tool: Any) -> bool:
+    """Return True if *tool* is the built-in voicemail tool (instance or FunctionTool)."""
+    if isinstance(tool, VoicemailTool):
+        return True
+    return getattr(tool, "name", None) == "voicemail"
 
 
 class LlmAgent:
@@ -89,7 +96,18 @@ class LlmAgent:
         config: Optional[LlmConfig] = None,
         max_tool_iterations: int = 10,
         backend: Optional[str] = None,
+        voicemail_tool_active_turns: Optional[int] = 1,
     ):
+        """
+        Args:
+            voicemail_tool_active_turns: How many completed user turns the built-in
+                ``voicemail`` tool stays available before the agent drops it from its
+                options. Voicemail is only worth detecting at the start of a call, so
+                once the conversation is "deemed started" the tool is removed and the
+                LM can no longer hang up mid-conversation. Defaults to ``1`` (available
+                only for the opening turn). ``None`` keeps it for the whole call. No-op
+                when no voicemail tool is in ``tools``.
+        """
         if not api_key:
             raise ValueError("Missing API key in LLmAgent initialization")
 
@@ -123,6 +141,12 @@ class LlmAgent:
             tools=self._tools,
             backend=backend,
         )
+
+        # Drop the built-in voicemail tool once the conversation is "deemed
+        # started" (after `voicemail_tool_active_turns` completed turns).
+        self._voicemail_tool_active_turns = voicemail_tool_active_turns
+        self._user_turns_seen = 0
+        self._voicemail_tool_removed = False
 
         self._introduction_sent = False
         self.history = History()
@@ -246,6 +270,13 @@ class LlmAgent:
             await self.cleanup()
             yield LogMetric(name="agent_turn_ms", value=(time.perf_counter() - turn_start_time) * 1000)
             return
+
+        # A non-handoff, non-lifecycle event drives an agent response turn. Count
+        # it and drop the voicemail tool once the conversation is "deemed started".
+        self._user_turns_seen += 1
+        self._maybe_remove_voicemail_tool()
+        # Recompute in case the voicemail tool was just removed.
+        effective_tools = _merge_tools(self._tools, tools)
 
         async for output in self._generate_response(
             env, event, effective_tools, effective_config, context=context, history=history
@@ -689,6 +720,32 @@ class LlmAgent:
         await self._get_background_event_queue().wait()
         await self._llm.aclose()
 
+    def _maybe_remove_voicemail_tool(self) -> None:
+        """Drop the built-in voicemail tool once enough user turns have elapsed.
+
+        The voicemail tool is only useful at the very start of a call (the
+        greeting). Once the conversation is "deemed started" — after
+        ``voicemail_tool_active_turns`` completed user turns — we remove it so the
+        main LM can't accidentally hang up mid-conversation. No-op when no
+        voicemail tool is configured or when removal is disabled (``None``).
+        """
+        if (
+            self._voicemail_tool_removed
+            or self._voicemail_tool_active_turns is None
+            or self._user_turns_seen <= self._voicemail_tool_active_turns
+        ):
+            return
+
+        remaining = [t for t in self._tools if not _is_voicemail_tool(t)]
+        if len(remaining) != len(self._tools):
+            logger.info(
+                f"Removing voicemail tool after {self._voicemail_tool_active_turns} user turn(s) "
+                "(conversation deemed started)"
+            )
+            self.set_tools(remaining)
+        # Set the flag regardless so we only ever attempt removal once.
+        self._voicemail_tool_removed = True
+
     # ------------------------------------------------------------------
     # Validation helpers
     # ------------------------------------------------------------------
@@ -713,12 +770,14 @@ class LlmAgent:
                 raise TypeError(f"tools must be a list, got {type(tools).__name__}")
             for i, tool in enumerate(tools):
                 if not (
-                    isinstance(tool, (FunctionTool, WebSearchTool, EndCallTool, TransferCallTool))
+                    isinstance(
+                        tool, (FunctionTool, WebSearchTool, EndCallTool, TransferCallTool, VoicemailTool)
+                    )
                     or callable(tool)
                 ):
                     raise TypeError(
                         f"tools[{i}] must be a FunctionTool, WebSearchTool, EndCallTool, "
-                        f"TransferCallTool, or callable, got {type(tool).__name__}"
+                        f"TransferCallTool, VoicemailTool, or callable, got {type(tool).__name__}"
                     )
 
     @staticmethod

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -243,6 +243,10 @@ class LlmAgent:
 
         # Handle CallStarted
         if isinstance(event, CallStarted):
+            # Reset per-call turn state so tool-removal windows (active_turns) start
+            # fresh — a reused LlmAgent instance otherwise carries the count over and
+            # would drop windowed tools on the next call's opening turn.
+            self._user_turns_seen = 0
             warmup_task = asyncio.create_task(
                 self._llm.warmup(config=effective_config, tools=effective_tools)
             )

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -52,8 +52,9 @@ from line.llm_agent.provider import (
     _get_model_config,
     parse_model_id,
 )
-from line.llm_agent.tools.system import EndCallTool, TransferCallTool, VoicemailTool, WebSearchTool
+from line.llm_agent.tools.system import WebSearchTool
 from line.llm_agent.tools.utils import (
+    ClassTool,
     FunctionTool,
     ToolEnv,
     ToolType,
@@ -68,14 +69,7 @@ _OUTPUT_EVENT_TYPES: Tuple[type, ...] = get_args(OutputEvent)
 
 # Type alias for tools that can be passed to LlmAgent.
 # Plain callables are automatically wrapped via the @tool decorator.
-ToolSpec = Union[FunctionTool, WebSearchTool, EndCallTool, TransferCallTool, VoicemailTool, Callable]
-
-
-def _is_voicemail_tool(tool: Any) -> bool:
-    """Return True if *tool* is the built-in voicemail tool (instance or FunctionTool)."""
-    if isinstance(tool, VoicemailTool):
-        return True
-    return getattr(tool, "name", None) == "voicemail"
+ToolSpec = Union[FunctionTool, WebSearchTool, ClassTool, Callable]
 
 
 class LlmAgent:
@@ -96,18 +90,13 @@ class LlmAgent:
         config: Optional[LlmConfig] = None,
         max_tool_iterations: int = 10,
         backend: Optional[str] = None,
-        voicemail_tool_active_turns: Optional[int] = 2,
     ):
         """
-        Args:
-            voicemail_tool_active_turns: How many completed user turns the built-in
-                ``voicemail`` tool stays available before the agent drops it from its
-                options. Voicemail is only worth detecting at the start of a call, so
-                once the conversation is "deemed started" the tool is removed and the
-                LM can no longer hang up mid-conversation. Defaults to ``2`` — enough to
-                cover a greeting that arrives over a couple of turns (e.g. when VAD splits
-                it) while still retiring the tool early. ``None`` keeps it for the whole
-                call. No-op when no voicemail tool is in ``tools``.
+        A tool may opt into turn-limited availability via its ``active_turns``
+        (e.g. ``voicemail(active_turns=2)``): the agent drops it from its options
+        after that many user turns, so the LM can no longer call it once the
+        conversation is "deemed started". The built-in ``voicemail`` tool defaults
+        to ``active_turns=2``; pass ``None`` to keep a tool for the whole call.
         """
         if not api_key:
             raise ValueError("Missing API key in LLmAgent initialization")
@@ -143,9 +132,8 @@ class LlmAgent:
             backend=backend,
         )
 
-        # Drop the built-in voicemail tool once the conversation is "deemed
-        # started" (after `voicemail_tool_active_turns` completed turns).
-        self._voicemail_tool_active_turns = voicemail_tool_active_turns
+        # Counts user-driven response turns so tools with a finite `active_turns`
+        # can be dropped once the conversation is "deemed started".
         self._user_turns_seen = 0
 
         self._introduction_sent = False
@@ -272,18 +260,14 @@ class LlmAgent:
             return
 
         # A non-handoff, non-lifecycle event drives an agent response turn. Count
-        # it and, once the conversation is "deemed started", strip the voicemail
-        # tool from this turn's tools so the LM can't hang up mid-conversation.
+        # it, then drop any tool whose `active_turns` window has closed so the LM
+        # can no longer call it once the conversation is "deemed started".
         self._user_turns_seen += 1
+        self._strip_windowed_tools()
         effective_tools = _merge_tools(self._tools, tools)
-        if self._voicemail_window_closed():
-            # Remove it from the provider's stored defaults (so it isn't merged
-            # back in) AND from this turn's effective set (so a per-call `tools`
-            # override can't reintroduce it). Re-checked every turn, so there is no
-            # sticky flag that could wrongly block a later re-added tool.
-            if any(_is_voicemail_tool(t) for t in self._tools):
-                self.set_tools([t for t in self._tools if not _is_voicemail_tool(t)])
-            effective_tools = [t for t in effective_tools if not _is_voicemail_tool(t)]
+        # Also strip from this turn's effective set so a per-call `tools` override
+        # can't reintroduce a windowed tool. Re-checked every turn (no sticky flag).
+        effective_tools = [t for t in effective_tools if not self._tool_window_closed(t)]
 
         async for output in self._generate_response(
             env, event, effective_tools, effective_config, context=context, history=history
@@ -727,19 +711,26 @@ class LlmAgent:
         await self._get_background_event_queue().wait()
         await self._llm.aclose()
 
-    def _voicemail_window_closed(self) -> bool:
-        """Whether the voicemail tool should no longer be available.
+    def _tool_window_closed(self, tool: Any) -> bool:
+        """Whether *tool*'s ``active_turns`` window has elapsed.
 
-        True once more than ``voicemail_tool_active_turns`` user turns have been
-        seen. The voicemail tool is only useful at the start of a call (the
-        greeting); after that the conversation is "deemed started" and we strip
-        the tool so the main LM can't hang up mid-conversation. Always ``False``
-        when removal is disabled (``None``).
+        A tool (e.g. ``voicemail(active_turns=2)``) is dropped once more user turns
+        have been seen than its ``active_turns``. Tools without an ``active_turns``
+        (plain FunctionTools, callables, or ``active_turns=None``) are never dropped.
         """
-        return (
-            self._voicemail_tool_active_turns is not None
-            and self._user_turns_seen > self._voicemail_tool_active_turns
-        )
+        active_turns = getattr(tool, "active_turns", None)
+        return active_turns is not None and self._user_turns_seen > active_turns
+
+    def _strip_windowed_tools(self) -> None:
+        """Permanently drop any tool whose ``active_turns`` window has closed.
+
+        Updates ``self._tools`` (and the provider's stored defaults via
+        ``set_tools``) so a windowed tool isn't merged back in. Re-checked every
+        turn; removal is monotonic since the turn count only grows.
+        """
+        remaining = [t for t in self._tools if not self._tool_window_closed(t)]
+        if len(remaining) != len(self._tools):
+            self.set_tools(remaining)
 
     # ------------------------------------------------------------------
     # Validation helpers
@@ -765,14 +756,12 @@ class LlmAgent:
                 raise TypeError(f"tools must be a list, got {type(tools).__name__}")
             for i, tool in enumerate(tools):
                 if not (
-                    isinstance(
-                        tool, (FunctionTool, WebSearchTool, EndCallTool, TransferCallTool, VoicemailTool)
-                    )
-                    or callable(tool)
+                    isinstance(tool, (FunctionTool, WebSearchTool, ClassTool)) or callable(tool)
                 ):
                     raise TypeError(
-                        f"tools[{i}] must be a FunctionTool, WebSearchTool, EndCallTool, "
-                        f"TransferCallTool, VoicemailTool, or callable, got {type(tool).__name__}"
+                        f"tools[{i}] must be a FunctionTool, WebSearchTool, a built-in ClassTool "
+                        f"(end_call/transfer_call/voicemail/knowledge_base), or callable, "
+                        f"got {type(tool).__name__}"
                     )
 
     @staticmethod

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -124,11 +124,15 @@ class LlmAgent:
         self._tools: List[ToolSpec] = list(tools or [])
         effective_tools, web_search_options = _normalize_tools(self._tools, model_id=model_id)
 
+        # The provider is intentionally NOT seeded with the agent's tools: the
+        # agent passes the fully-resolved tool list to every chat()/warmup(), so a
+        # stored copy would be redundant — and would re-merge tools the agent has
+        # dropped for the turn (e.g. a windowed-out voicemail tool).
         self._llm = LlmProvider(
             model=str(model_id),
             api_key=api_key,
             config=effective_config,
-            tools=self._tools,
+            tools=[],
             backend=backend,
         )
 
@@ -156,9 +160,12 @@ class LlmAgent:
         return self._background_event_queue
 
     def set_tools(self, tools: List[ToolSpec]) -> None:
-        """Replace the agent's tools with a new list."""
+        """Replace the agent's tools with a new list.
+
+        Only updates the agent's own list; the resolved tools are passed to the
+        provider per call, so there's no provider-side copy to keep in sync.
+        """
         self._tools = tools
-        self._llm._set_tools(tools)
 
     def set_config(self, config: LlmConfig) -> None:
         """Replace the agent's config."""
@@ -261,13 +268,11 @@ class LlmAgent:
 
         # A non-handoff, non-lifecycle event drives an agent response turn. Count
         # it, then drop any tool whose `active_turns` window has closed so the LM
-        # can no longer call it once the conversation is "deemed started".
+        # can no longer call it once the conversation is "deemed started". This is
+        # the single source of truth — the provider isn't seeded with tools, so the
+        # filtered list here is exactly what's sent (no per-turn mutation needed).
         self._user_turns_seen += 1
-        self._strip_windowed_tools()
-        effective_tools = _merge_tools(self._tools, tools)
-        # Also strip from this turn's effective set so a per-call `tools` override
-        # can't reintroduce a windowed tool. Re-checked every turn (no sticky flag).
-        effective_tools = [t for t in effective_tools if not self._tool_window_closed(t)]
+        effective_tools = [t for t in _merge_tools(self._tools, tools) if not self._tool_window_closed(t)]
 
         async for output in self._generate_response(
             env, event, effective_tools, effective_config, context=context, history=history
@@ -720,17 +725,6 @@ class LlmAgent:
         """
         active_turns = getattr(tool, "active_turns", None)
         return active_turns is not None and self._user_turns_seen > active_turns
-
-    def _strip_windowed_tools(self) -> None:
-        """Permanently drop any tool whose ``active_turns`` window has closed.
-
-        Updates ``self._tools`` (and the provider's stored defaults via
-        ``set_tools``) so a windowed tool isn't merged back in. Re-checked every
-        turn; removal is monotonic since the turn count only grows.
-        """
-        remaining = [t for t in self._tools if not self._tool_window_closed(t)]
-        if len(remaining) != len(self._tools):
-            self.set_tools(remaining)
 
     # ------------------------------------------------------------------
     # Validation helpers

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -96,7 +96,7 @@ class LlmAgent:
         config: Optional[LlmConfig] = None,
         max_tool_iterations: int = 10,
         backend: Optional[str] = None,
-        voicemail_tool_active_turns: Optional[int] = 1,
+        voicemail_tool_active_turns: Optional[int] = 2,
     ):
         """
         Args:
@@ -104,9 +104,10 @@ class LlmAgent:
                 ``voicemail`` tool stays available before the agent drops it from its
                 options. Voicemail is only worth detecting at the start of a call, so
                 once the conversation is "deemed started" the tool is removed and the
-                LM can no longer hang up mid-conversation. Defaults to ``1`` (available
-                only for the opening turn). ``None`` keeps it for the whole call. No-op
-                when no voicemail tool is in ``tools``.
+                LM can no longer hang up mid-conversation. Defaults to ``2`` — enough to
+                cover a greeting that arrives over a couple of turns (e.g. when VAD splits
+                it) while still retiring the tool early. ``None`` keeps it for the whole
+                call. No-op when no voicemail tool is in ``tools``.
         """
         if not api_key:
             raise ValueError("Missing API key in LLmAgent initialization")
@@ -146,7 +147,6 @@ class LlmAgent:
         # started" (after `voicemail_tool_active_turns` completed turns).
         self._voicemail_tool_active_turns = voicemail_tool_active_turns
         self._user_turns_seen = 0
-        self._voicemail_tool_removed = False
 
         self._introduction_sent = False
         self.history = History()
@@ -272,11 +272,18 @@ class LlmAgent:
             return
 
         # A non-handoff, non-lifecycle event drives an agent response turn. Count
-        # it and drop the voicemail tool once the conversation is "deemed started".
+        # it and, once the conversation is "deemed started", strip the voicemail
+        # tool from this turn's tools so the LM can't hang up mid-conversation.
         self._user_turns_seen += 1
-        self._maybe_remove_voicemail_tool()
-        # Recompute in case the voicemail tool was just removed.
         effective_tools = _merge_tools(self._tools, tools)
+        if self._voicemail_window_closed():
+            # Remove it from the provider's stored defaults (so it isn't merged
+            # back in) AND from this turn's effective set (so a per-call `tools`
+            # override can't reintroduce it). Re-checked every turn, so there is no
+            # sticky flag that could wrongly block a later re-added tool.
+            if any(_is_voicemail_tool(t) for t in self._tools):
+                self.set_tools([t for t in self._tools if not _is_voicemail_tool(t)])
+            effective_tools = [t for t in effective_tools if not _is_voicemail_tool(t)]
 
         async for output in self._generate_response(
             env, event, effective_tools, effective_config, context=context, history=history
@@ -720,31 +727,19 @@ class LlmAgent:
         await self._get_background_event_queue().wait()
         await self._llm.aclose()
 
-    def _maybe_remove_voicemail_tool(self) -> None:
-        """Drop the built-in voicemail tool once enough user turns have elapsed.
+    def _voicemail_window_closed(self) -> bool:
+        """Whether the voicemail tool should no longer be available.
 
-        The voicemail tool is only useful at the very start of a call (the
-        greeting). Once the conversation is "deemed started" — after
-        ``voicemail_tool_active_turns`` completed user turns — we remove it so the
-        main LM can't accidentally hang up mid-conversation. No-op when no
-        voicemail tool is configured or when removal is disabled (``None``).
+        True once more than ``voicemail_tool_active_turns`` user turns have been
+        seen. The voicemail tool is only useful at the start of a call (the
+        greeting); after that the conversation is "deemed started" and we strip
+        the tool so the main LM can't hang up mid-conversation. Always ``False``
+        when removal is disabled (``None``).
         """
-        if (
-            self._voicemail_tool_removed
-            or self._voicemail_tool_active_turns is None
-            or self._user_turns_seen <= self._voicemail_tool_active_turns
-        ):
-            return
-
-        remaining = [t for t in self._tools if not _is_voicemail_tool(t)]
-        if len(remaining) != len(self._tools):
-            logger.info(
-                f"Removing voicemail tool after {self._voicemail_tool_active_turns} user turn(s) "
-                "(conversation deemed started)"
-            )
-            self.set_tools(remaining)
-        # Set the flag regardless so we only ever attempt removal once.
-        self._voicemail_tool_removed = True
+        return (
+            self._voicemail_tool_active_turns is not None
+            and self._user_turns_seen > self._voicemail_tool_active_turns
+        )
 
     # ------------------------------------------------------------------
     # Validation helpers

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -755,9 +755,7 @@ class LlmAgent:
             if not isinstance(tools, list):
                 raise TypeError(f"tools must be a list, got {type(tools).__name__}")
             for i, tool in enumerate(tools):
-                if not (
-                    isinstance(tool, (FunctionTool, WebSearchTool, ClassTool)) or callable(tool)
-                ):
+                if not (isinstance(tool, (FunctionTool, WebSearchTool, ClassTool)) or callable(tool)):
                     raise TypeError(
                         f"tools[{i}] must be a FunctionTool, WebSearchTool, a built-in ClassTool "
                         f"(end_call/transfer_call/voicemail/knowledge_base), or callable, "

--- a/line/llm_agent/tools/__init__.py
+++ b/line/llm_agent/tools/__init__.py
@@ -20,6 +20,7 @@ from line.llm_agent.tools.system import (
     knowledge_base,
     send_dtmf,
     transfer_call,
+    voicemail,
     web_search,
 )
 
@@ -47,6 +48,7 @@ __all__ = [
     "end_call",
     "send_dtmf",
     "transfer_call",
+    "voicemail",
     "agent_as_handoff",
     "knowledge_base",
     # Utility types

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -233,12 +233,14 @@ is possible."""
             # end_call always reports a normal agent hangup reason.
             yield AgentEndCall(reason="agent_ended", interruptible=self.interruptible)
 
-        return construct_function_tool(
+        ft = construct_function_tool(
             _end_call_impl,
             name="end_call",
             description=self.description,
             tool_type=ToolType.GENERAL,
         )
+        ft.active_turns = self.active_turns
+        return ft
 
     def as_function_tool(self) -> FunctionTool:
         """Return the underlying FunctionTool for use in tool resolution."""
@@ -352,9 +354,13 @@ class TransferCallTool:
 
     def _create_function_tool(self) -> FunctionTool:
         """Create the underlying FunctionTool for the configured mode."""
-        if self.target_phone_number is not None:
-            return self._create_fixed_number_tool()
-        return self._create_dynamic_number_tool()
+        ft = (
+            self._create_fixed_number_tool()
+            if self.target_phone_number is not None
+            else self._create_dynamic_number_tool()
+        )
+        ft.active_turns = self.active_turns
+        return ft
 
     def _create_fixed_number_tool(self) -> FunctionTool:
         """Pinned destination: no LLM-facing parameter; transfer to the preset number."""
@@ -520,12 +526,14 @@ first; this tool ends the call."""
                 yield AgentSendText(text=self.message, interruptible=self.interruptible)
             yield AgentEndCall(reason="voicemail_detected", interruptible=self.interruptible)
 
-        return construct_function_tool(
+        ft = construct_function_tool(
             _voicemail_impl,
             name="voicemail",
             description=self.description,
             tool_type=ToolType.GENERAL,
         )
+        ft.active_turns = self.active_turns
+        return ft
 
     def as_function_tool(self) -> FunctionTool:
         """Return the underlying FunctionTool for use in tool resolution."""
@@ -837,13 +845,15 @@ class KnowledgeBaseTool:
                 return "No relevant information found in the knowledge base."
             return separator.join(chunks)
 
-        return construct_function_tool(
+        ft = construct_function_tool(
             _knowledge_base_impl,
             name="knowledge_base",
             description=self._description,
             tool_type=ToolType.GENERAL,
             is_background=self._is_background,
         )
+        ft.active_turns = self.active_turns
+        return ft
 
     def as_function_tool(self) -> FunctionTool:
         return self._function_tool

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -216,8 +216,7 @@ is possible."""
             ctx: ToolEnv,
             reason: Annotated[str, "The reason for ending the call"],
         ):
-            # end_call always reports a normal agent hangup; the voicemail tool is
-            # the only path to reason="voicemail_detected".
+            # end_call always reports a normal agent hangup reason.
             yield AgentEndCall(reason="agent_ended", interruptible=self.interruptible)
 
         return construct_function_tool(

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -216,7 +216,9 @@ is possible."""
             ctx: ToolEnv,
             reason: Annotated[str, "The reason for ending the call"],
         ):
-            yield AgentEndCall(interruptible=self.interruptible)
+            # end_call always reports a normal agent hangup; the voicemail tool is
+            # the only path to reason="voicemail_detected".
+            yield AgentEndCall(reason="agent_ended", interruptible=self.interruptible)
 
         return construct_function_tool(
             _end_call_impl,
@@ -327,6 +329,94 @@ class TransferCallTool:
 #   transfer_call                                              # Use default behavior
 #   transfer_call(interruptible=False)                          # Disable interruptibility
 transfer_call = TransferCallTool()
+
+
+class VoicemailTool:
+    """
+    voicemail tool: the LLM calls this when it detects it has reached a voicemail /
+    answering machine. An optional fixed message and interruptibility are set at
+    construction (``VoicemailTool(...)`` / ``voicemail(...)``), not by the LLM.
+
+    The detection cues live in the tool's description (below), so the agent's system
+    prompt doesn't need to carry voicemail-handling instructions. When invoked the tool
+    speaks the configured message (if any) and then ends the call with
+    ``reason="voicemail_detected"``, which the Cartesia API records as the call's
+    ``end_reason``.
+
+    Behavior modes (all from this one tool):
+      - voicemail(message="...")  -> speak the message (uninterruptible), then end.
+      - voicemail                 -> silently end the call (no message).
+      - dynamic message           -> let the LLM speak in its turn, then call voicemail() to end.
+    """
+
+    DEFAULT_DESCRIPTION = """End the call because you've reached a voicemail or answering machine.
+
+Use when the greeting is a machine, e.g.:
+- "please leave a message", "at the tone", "you've reached the voicemail of…"
+- a beep, or a one-sided recorded greeting with no back-and-forth
+
+Do NOT use this if a real person is talking with you. You may leave a brief message
+first; this tool ends the call."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        interruptible: bool = False,
+        description: Optional[str] = None,
+    ):
+        # interruptible defaults to False: on a voicemail there's no human to interrupt
+        # and we want the message left in full.
+        self.message = message
+        self.interruptible = interruptible
+        self.description = description if description else self.DEFAULT_DESCRIPTION
+        self._function_tool = self._create_function_tool()
+
+    @property
+    def name(self) -> str:
+        """Return the tool name."""
+        return "voicemail"
+
+    def _create_function_tool(self) -> FunctionTool:
+        """Create the underlying FunctionTool with the configured message and interruptibility."""
+
+        async def _voicemail_impl(ctx: ToolEnv):
+            # Keep "voicemail_detected" in sync with EndCallReason in line/events.py.
+            if self.message:
+                yield AgentSendText(text=self.message, interruptible=self.interruptible)
+            yield AgentEndCall(reason="voicemail_detected", interruptible=self.interruptible)
+
+        return construct_function_tool(
+            _voicemail_impl,
+            name="voicemail",
+            description=self.description,
+            tool_type=ToolType.GENERAL,
+        )
+
+    def as_function_tool(self) -> FunctionTool:
+        """Return the underlying FunctionTool for use in tool resolution."""
+        return self._function_tool
+
+    def __call__(
+        self,
+        message: Optional[str] = None,
+        interruptible: bool = False,
+        description: Optional[str] = None,
+    ) -> "VoicemailTool":
+        """Create a configured VoicemailTool instance.
+
+        Args:
+            message: Optional message spoken (uninterruptible by default) before the call ends.
+            interruptible: Whether the message/end are interruptible.
+            description: Override the default LLM-facing description (when to invoke).
+        """
+        return VoicemailTool(message=message, interruptible=interruptible, description=description)
+
+
+# Default instance - can be used directly or called to configure
+# Examples:
+#   voicemail                                          # Silently end on voicemail
+#   voicemail(message="Hi, please call us back…")      # Leave a message, then end
+voicemail = VoicemailTool()
 
 
 @dataclass
@@ -963,6 +1053,7 @@ __all__ = [
     "DtmfButton",
     "EndCallTool",
     "TransferCallTool",
+    "VoicemailTool",
     "UpdateCallConfig",
     "WebSearchTool",
     "web_search",
@@ -970,6 +1061,7 @@ __all__ = [
     "end_call",
     "send_dtmf",
     "transfer_call",
+    "voicemail",
     "agent_as_handoff",
     "http_server_tool",
 ]

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -534,11 +534,15 @@ first; this tool ends the call."""
     def __call__(
         self,
         message: Optional[str] = None,
-        interruptible: bool = False,
+        interruptible: Optional[bool] = None,
         description: Optional[str] = None,
         active_turns: Any = _INHERIT,
     ) -> "VoicemailTool":
         """Create a configured VoicemailTool instance.
+
+        Unset arguments inherit from this instance, so re-configuring a tool
+        doesn't silently reset prior settings (e.g.
+        ``voicemail(message="…")(active_turns=5)`` keeps the message).
 
         Args:
             message: Optional message spoken (uninterruptible by default) before the call ends.
@@ -548,9 +552,9 @@ first; this tool ends the call."""
                 (default 2; ``None`` = whole call). Omit to inherit the current value.
         """
         return VoicemailTool(
-            message=message,
-            interruptible=interruptible,
-            description=description,
+            message=message if message is not None else self.message,
+            interruptible=interruptible if interruptible is not None else self.interruptible,
+            description=description if description is not None else self.description,
             active_turns=self.active_turns if active_turns is _INHERIT else active_turns,
         )
 

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -34,6 +34,11 @@ DtmfButton = Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "#"]
 # Logger for system tools
 logger = logging.getLogger(__name__)
 
+# Sentinel for chainable ``__call__`` configs: distinguishes "argument omitted
+# (inherit the current value)" from "explicitly passed None". Needed for
+# ``active_turns``, where ``None`` is a real value meaning "never auto-remove".
+_INHERIT: Any = object()
+
 
 @dataclass
 class UpdateCallConfig:
@@ -204,9 +209,13 @@ is possible."""
         self,
         description: Optional[str] = None,
         interruptible: bool = True,
+        active_turns: Optional[int] = None,
     ):
         self.description = description if description else self.DEFAULT_DESCRIPTION
         self.interruptible = interruptible
+        # How many user turns this tool stays available before LlmAgent drops it.
+        # None (default) = available for the whole call.
+        self.active_turns = active_turns
         self._function_tool = self._create_function_tool()
 
     @property
@@ -239,6 +248,7 @@ is possible."""
         self,
         description: Optional[str] = None,
         interruptible: Optional[bool] = None,
+        active_turns: Any = _INHERIT,
     ) -> "EndCallTool":
         """Create a configured EndCallTool instance.
 
@@ -249,12 +259,15 @@ is possible."""
             description: Description that replaces the default. Use this to customize
                 when the LLM should end the call.
             interruptible: Whether the end_call tool is interruptible.
+            active_turns: User turns the tool stays available before the agent drops it
+                (``None`` = whole call). Omit to inherit the current value.
         Returns:
             A new EndCallTool instance with the specified configuration.
         """
         return EndCallTool(
             description=description if description is not None else self.description,
             interruptible=interruptible if interruptible is not None else self.interruptible,
+            active_turns=self.active_turns if active_turns is _INHERIT else active_turns,
         )
 
 
@@ -304,6 +317,7 @@ class TransferCallTool:
         target_phone_number: Optional[str] = None,
         message: Optional[str] = None,
         interruptible: bool = True,
+        active_turns: Optional[int] = None,
     ):
         # When pinned, validate/normalize once at construction so a bad config
         # fails fast rather than at call time.
@@ -312,6 +326,8 @@ class TransferCallTool:
         )
         self.message = message
         self.interruptible = interruptible
+        # User turns this tool stays available before LlmAgent drops it (None = whole call).
+        self.active_turns = active_turns
         self._function_tool = self._create_function_tool()
 
     @property
@@ -410,6 +426,7 @@ class TransferCallTool:
         target_phone_number: Optional[str] = None,
         message: Optional[str] = None,
         interruptible: Optional[bool] = None,
+        active_turns: Any = _INHERIT,
     ) -> "TransferCallTool":
         """Create a configured TransferCallTool instance.
 
@@ -423,6 +440,8 @@ class TransferCallTool:
                 the number is hidden from the LLM and validated at construction.
             message: Optional message spoken before transfer.
             interruptible: Whether the transfer_call tool is interruptible.
+            active_turns: User turns the tool stays available before the agent drops it
+                (``None`` = whole call). Omit to inherit the current value.
         """
         return TransferCallTool(
             target_phone_number=(
@@ -430,6 +449,7 @@ class TransferCallTool:
             ),
             message=message if message is not None else self.message,
             interruptible=interruptible if interruptible is not None else self.interruptible,
+            active_turns=self.active_turns if active_turns is _INHERIT else active_turns,
         )
 
 
@@ -473,12 +493,17 @@ first; this tool ends the call."""
         message: Optional[str] = None,
         interruptible: bool = False,
         description: Optional[str] = None,
+        active_turns: Optional[int] = 2,
     ):
         # interruptible defaults to False: on a voicemail there's no human to interrupt
         # and we want the message left in full.
         self.message = message
         self.interruptible = interruptible
         self.description = description if description else self.DEFAULT_DESCRIPTION
+        # Voicemail is only worth checking at the start of a call, so the agent drops
+        # this tool after `active_turns` user turns (default 2, covering a greeting that
+        # arrives over a couple of turns). None keeps it for the whole call.
+        self.active_turns = active_turns
         self._function_tool = self._create_function_tool()
 
     @property
@@ -511,6 +536,7 @@ first; this tool ends the call."""
         message: Optional[str] = None,
         interruptible: bool = False,
         description: Optional[str] = None,
+        active_turns: Any = _INHERIT,
     ) -> "VoicemailTool":
         """Create a configured VoicemailTool instance.
 
@@ -518,8 +544,15 @@ first; this tool ends the call."""
             message: Optional message spoken (uninterruptible by default) before the call ends.
             interruptible: Whether the message/end are interruptible.
             description: Override the default LLM-facing description (when to invoke).
+            active_turns: User turns the tool stays available before the agent drops it
+                (default 2; ``None`` = whole call). Omit to inherit the current value.
         """
-        return VoicemailTool(message=message, interruptible=interruptible, description=description)
+        return VoicemailTool(
+            message=message,
+            interruptible=interruptible,
+            description=description,
+            active_turns=self.active_turns if active_turns is _INHERIT else active_turns,
+        )
 
 
 # Default instance - can be used directly or called to configure
@@ -758,12 +791,15 @@ class KnowledgeBaseTool:
         description: Optional[str] = None,
         timeout_s: Optional[float] = None,
         is_background: bool = False,
+        active_turns: Optional[int] = None,
     ):
         self._filters = filters
         self._top_k = top_k
         self._description = description if description else self.DEFAULT_DESCRIPTION
         self._timeout_s = timeout_s
         self._is_background = is_background
+        # User turns this tool stays available before LlmAgent drops it (None = whole call).
+        self.active_turns = active_turns
         _warn_if_long_timeout(timeout_s, source="KnowledgeBaseTool")
         self._function_tool = self._create_function_tool()
 
@@ -815,6 +851,7 @@ class KnowledgeBaseTool:
         description: Optional[str] = None,
         timeout_s: Optional[float] = None,
         is_background: Optional[bool] = None,
+        active_turns: Any = _INHERIT,
     ) -> "KnowledgeBaseTool":
         return KnowledgeBaseTool(
             filters=filters if filters is not None else self._filters,
@@ -822,6 +859,7 @@ class KnowledgeBaseTool:
             description=description if description is not None else self._description,
             timeout_s=timeout_s if timeout_s is not None else self._timeout_s,
             is_background=is_background if is_background is not None else self._is_background,
+            active_turns=self.active_turns if active_turns is _INHERIT else active_turns,
         )
 
 

--- a/line/llm_agent/tools/utils.py
+++ b/line/llm_agent/tools/utils.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
         EndCallTool,
         KnowledgeBaseTool,
         TransferCallTool,
+        VoicemailTool,
         WebSearchTool,
     )
 
@@ -159,6 +160,7 @@ ToolSpec = Union[
     "EndCallTool",
     "TransferCallTool",
     "KnowledgeBaseTool",
+    "VoicemailTool",
     Callable,
 ]
 
@@ -354,6 +356,7 @@ def _normalize_tools(
         EndCallTool,
         KnowledgeBaseTool,
         TransferCallTool,
+        VoicemailTool,
         WebSearchTool,
     )
 
@@ -363,7 +366,7 @@ def _normalize_tools(
     for tool in tool_specs:
         if isinstance(tool, FunctionTool):
             function_tools.append(tool)
-        elif isinstance(tool, (EndCallTool, TransferCallTool, KnowledgeBaseTool)):
+        elif isinstance(tool, (EndCallTool, TransferCallTool, KnowledgeBaseTool, VoicemailTool)):
             function_tools.append(tool.as_function_tool())
         elif isinstance(tool, WebSearchTool):
             web_search_tool = tool

--- a/line/llm_agent/tools/utils.py
+++ b/line/llm_agent/tools/utils.py
@@ -144,6 +144,10 @@ class FunctionTool:
     parameters: Dict[str, "ParameterInfo"]
     tool_type: ToolType = ToolType.GENERAL
     is_background: bool = False
+    # User turns the tool stays available before LlmAgent drops it (None = whole
+    # call). Carried over from a ClassTool's `active_turns` by `as_function_tool()`
+    # so turn-limited removal still applies when a resolved FunctionTool is passed.
+    active_turns: Optional[int] = None
 
 
 @runtime_checkable

--- a/line/llm_agent/tools/utils.py
+++ b/line/llm_agent/tools/utils.py
@@ -47,6 +47,7 @@ from typing import (
     get_args,
     get_origin,
     get_type_hints,
+    runtime_checkable,
 )
 
 from line.agent import TurnEnv
@@ -55,13 +56,7 @@ from line.knowledge_base import KnowledgeBase
 
 if TYPE_CHECKING:
     from line.llm_agent.provider import ParsedModelId
-    from line.llm_agent.tools.system import (
-        EndCallTool,
-        KnowledgeBaseTool,
-        TransferCallTool,
-        VoicemailTool,
-        WebSearchTool,
-    )
+    from line.llm_agent.tools.system import WebSearchTool
 
 # -------------------------
 # Tool Type Enum
@@ -151,16 +146,34 @@ class FunctionTool:
     is_background: bool = False
 
 
+@runtime_checkable
+class ClassTool(Protocol):
+    """Shared interface for the built-in class-based tools (``end_call``,
+    ``transfer_call``, ``voicemail``, ``knowledge_base``).
+
+    Each is configured by calling it (e.g. ``voicemail(message=…)``), resolves to a
+    :class:`FunctionTool` via :meth:`as_function_tool`, and may opt into
+    turn-limited availability via ``active_turns`` — the number of user turns the
+    tool stays in the agent's options before it is dropped (``None`` = whole call).
+    A runtime-checkable Protocol (composition over inheritance), so ``isinstance``
+    recognizes any tool exposing this shape.
+    """
+
+    active_turns: Optional[int]
+
+    @property
+    def name(self) -> str: ...
+
+    def as_function_tool(self) -> "FunctionTool": ...
+
+
 # Type alias for tools that can be passed to LlmAgent/LlmProvider.
 # Plain callables are automatically wrapped as loopback tools.
-# Uses string literal because WebSearchTool/EndCallTool are TYPE_CHECKING-only imports.
+# WebSearchTool stays separate — it maps to native web-search options, not a FunctionTool.
 ToolSpec = Union[
     FunctionTool,
     "WebSearchTool",
-    "EndCallTool",
-    "TransferCallTool",
-    "KnowledgeBaseTool",
-    "VoicemailTool",
+    ClassTool,
     Callable,
 ]
 
@@ -352,13 +365,7 @@ def _normalize_tools(
         FunctionTool in the first list.
     """
     from line.llm_agent.tools.decorators import loopback_tool
-    from line.llm_agent.tools.system import (
-        EndCallTool,
-        KnowledgeBaseTool,
-        TransferCallTool,
-        VoicemailTool,
-        WebSearchTool,
-    )
+    from line.llm_agent.tools.system import WebSearchTool
 
     function_tools: List[FunctionTool] = []
     web_search_tool: Optional[Any] = None
@@ -366,17 +373,18 @@ def _normalize_tools(
     for tool in tool_specs:
         if isinstance(tool, FunctionTool):
             function_tools.append(tool)
-        elif isinstance(tool, (EndCallTool, TransferCallTool, KnowledgeBaseTool, VoicemailTool)):
-            function_tools.append(tool.as_function_tool())
         elif isinstance(tool, WebSearchTool):
             web_search_tool = tool
+        elif isinstance(tool, ClassTool):
+            # Built-in class tools (end_call, transfer_call, voicemail, knowledge_base).
+            # Checked before `callable` since they are callable (configurable via __call__).
+            function_tools.append(tool.as_function_tool())
         elif callable(tool):
             function_tools.append(loopback_tool(tool))
         else:
             raise TypeError(
                 f"Unsupported tool type: {type(tool).__name__}. "
-                f"Expected FunctionTool, EndCallTool, TransferCallTool, "
-                f"KnowledgeBaseTool, WebSearchTool, or callable."
+                f"Expected FunctionTool, WebSearchTool, a built-in ClassTool, or callable."
             )
 
     web_search_options: Optional[Dict[str, Any]] = None
@@ -437,6 +445,7 @@ __all__ = [
     "PassthroughToolFn",
     "HandoffToolFn",
     "FunctionTool",
+    "ClassTool",
     "ParameterInfo",
     # constructor
     "construct_function_tool",

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -677,8 +677,12 @@ class ConversationRunner:
             logger.info(f"<- 🤖🔔 Agent DTMF sent: {event.button}")
             return DTMFOutput(button=event.button, responding_to=event.responding_to)
         if isinstance(event, AgentEndCall):
-            logger.info(f"<- 📞 End call (interruptible={event.interruptible})")
-            return EndCallOutput(responding_to=event.responding_to, interruptible=event.interruptible)
+            logger.info(f"<- 📞 End call (reason={event.reason}, interruptible={event.interruptible})")
+            return EndCallOutput(
+                reason=event.reason,
+                responding_to=event.responding_to,
+                interruptible=event.interruptible,
+            )
         if isinstance(event, AgentTransferCall):
             logger.info(
                 f"<- 📱 Transfer to: {event.target_phone_number} (interruptible={event.interruptible})"

--- a/tests/real_api_test_voicemail_tool.py
+++ b/tests/real_api_test_voicemail_tool.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Live-API evaluation of the built-in voicemail tool (Approach 1).
+
+Runs a real LlmAgent (with the ``voicemail`` tool) over labeled multi-turn
+scenarios and reports a confusion matrix. The priority metric is **human-safety**:
+the agent must never hang up on a real person (zero false positives).
+
+This is a live test — it makes real LLM calls and is intentionally NOT collected
+by a bare ``pytest`` run (filename starts with ``real_api_test_``). Run it either
+way:
+
+    # as a script (prints the matrix, exits non-zero on a false positive)
+    ANTHROPIC_API_KEY=... uv run python tests/real_api_test_voicemail_tool.py
+
+    # under pytest (skips when no key is set)
+    ANTHROPIC_API_KEY=... uv run pytest tests/real_api_test_voicemail_tool.py -s
+
+Environment:
+    VOICEMAIL_EVAL_MODEL  main model (default anthropic/claude-haiku-4-5-20251001)
+    ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY  matched to the model
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+import os
+import sys
+from typing import List, Literal, Optional
+
+from line.agent import AgentEnv, TurnEnv
+from line.events import AgentEndCall, AgentSendText, AgentTextSent, UserTextSent, UserTurnEnded
+from line.llm_agent import LlmAgent, LlmConfig, end_call, voicemail
+
+MODEL = os.getenv("VOICEMAIL_EVAL_MODEL", "anthropic/claude-haiku-4-5-20251001")
+SYSTEM_PROMPT = (
+    "You are an outbound voice agent making a brief courtesy call about a customer's recent order. "
+    "Wait for the other party to speak first. If you've reached a live person, greet them and keep it short. "
+    "If you've reached a voicemail or answering machine, use the voicemail tool."
+)
+VOICEMAIL_MESSAGE = "Hi, this is a courtesy call about your recent order. Please call us back. Thanks!"
+
+
+@dataclass
+class Scenario:
+    label: Literal["voicemail", "human"]
+    category: str
+    turns: List[str]
+
+
+# Human-weighted, adversarial. The point is to measure false positives with
+# enough samples to trust the result, since hanging up on a person is the
+# catastrophic error. "voicemail_classic" greetings are unambiguous and used for
+# the recall floor assertion.
+SCENARIOS: List[Scenario] = [
+    # --- voicemail ---
+    Scenario(
+        "voicemail",
+        "voicemail_classic",
+        ["Hi, you've reached the voicemail of Alex Carter. Please leave a message after the tone."],
+    ),
+    Scenario(
+        "voicemail",
+        "voicemail_classic",
+        ["The person you are trying to reach is not available. At the tone, please record your message."],
+    ),
+    Scenario(
+        "voicemail",
+        "voicemail_classic",
+        ["You've reached the Google subscriber. Please record your message after the tone."],
+    ),
+    Scenario(
+        "voicemail",
+        "voicemail_business",
+        ["Thank you for calling Brightwave Solutions. Our office is closed. Please leave a message."],
+    ),
+    Scenario("voicemail", "voicemail_subtle", ["Hey, it's Dana. You know what to do."]),
+    Scenario(
+        "voicemail",
+        "voicemail_subtle",
+        ["Hi, this is Mike. I can't get to my phone right now. Catch you later."],
+    ),
+    Scenario("voicemail", "voicemail_terse", ["Leave a message."]),
+    # --- human (multi-turn, adversarial) ---
+    Scenario("human", "human_short", ["Hello?", "Yeah, this is me. What's up?"]),
+    Scenario("human", "human_short", ["Yeah, hello?", "Who's this?"]),
+    Scenario(
+        "human", "human_name", ["Hello, this is Sarah speaking.", "Yes, that's me — what's this about?"]
+    ),
+    Scenario("human", "human_name", ["Good afternoon, Daniel here.", "Who's calling?"]),
+    Scenario("human", "human_name", ["Hi, you've got Marcus.", "Yeah? What's up?"]),
+    Scenario(
+        "human",
+        "human_message_word",
+        ["Oh hey, I got your voicemail earlier — what's up?", "Right, the order. Go on."],
+    ),
+    Scenario(
+        "human",
+        "human_message_word",
+        ["Sorry, my voicemail's full, good thing you caught me.", "What did you need?"],
+    ),
+    Scenario(
+        "human",
+        "human_message_word",
+        ["Hey, did you leave me a message? I saw a missed call.", "Okay, what's it about?"],
+    ),
+    Scenario("human", "human_screening", ["Who's calling please?", "And what's this regarding?"]),
+    Scenario("human", "human_screening", ["Is this a sales call?", "Fine, what is it?"]),
+    Scenario("human", "human_busy", ["Hang on— okay, sorry, hi. You there?", "Go ahead."]),
+    Scenario("human", "human_busy", ["Sorry, I'm driving, you're on speaker. Who's this?", "Okay, quickly?"]),
+    Scenario(
+        "human",
+        "human_business",
+        ["Good morning, Brightwave Solutions, this is Jordan, how can I help?", "Sure, one moment."],
+    ),
+    Scenario("human", "human_business", ["Front desk, this is Lena.", "Who did you need?"]),
+    Scenario(
+        "human", "human_callback", ["Hi, I got a missed call from this number?", "Oh, okay, what's it about?"]
+    ),
+    Scenario(
+        "human",
+        "human_confused",
+        ["Hello? Who is this now?", "Speak up, I can't hear you.", "Oh. Okay, go on."],
+    ),
+    Scenario(
+        "human", "human_skeptical", ["Yeah?... who's this exactly?", "Uh huh. And why are you calling?"]
+    ),
+]
+
+
+@dataclass
+class Matrix:
+    tp: int = 0
+    fn: int = 0
+    fp: int = 0
+    tn: int = 0
+    fp_examples: List[str] = field(default_factory=list)
+
+    @property
+    def precision(self) -> float:
+        d = self.tp + self.fp
+        return self.tp / d if d else 1.0
+
+    @property
+    def recall(self) -> float:
+        d = self.tp + self.fn
+        return self.tp / d if d else 0.0
+
+    @property
+    def accuracy(self) -> float:
+        t = self.tp + self.fn + self.fp + self.tn
+        return (self.tp + self.tn) / t if t else 0.0
+
+
+def _resolve_api_key(model: str) -> Optional[str]:
+    if model.startswith("anthropic"):
+        return os.getenv("ANTHROPIC_API_KEY")
+    if model.startswith("gemini"):
+        return os.getenv("GEMINI_API_KEY")
+    return os.getenv("OPENAI_API_KEY")
+
+
+async def _detected_voicemail(model: str, api_key: str, scenario: Scenario) -> bool:
+    """Run a scenario through a fresh agent; True if it hung up as voicemail."""
+    agent = LlmAgent(
+        model=model,
+        api_key=api_key,
+        tools=[voicemail(message=VOICEMAIL_MESSAGE), end_call],
+        config=LlmConfig(system_prompt=SYSTEM_PROMPT, introduction=""),
+        voicemail_tool_active_turns=1,
+    )
+    env = TurnEnv(agent_env=AgentEnv())
+    history: list = []
+    detected = False
+    try:
+        for text in scenario.turns:
+            history.append(UserTextSent(content=text))
+            event = UserTurnEnded(content=[UserTextSent(content=text)], history=list(history))
+            agent_text: List[str] = []
+            async for output in agent.process(env, event):
+                if isinstance(output, AgentEndCall) and output.reason == "voicemail_detected":
+                    detected = True
+                elif isinstance(output, AgentSendText):
+                    agent_text.append(output.text)
+            if agent_text:
+                history.append(AgentTextSent(content=" ".join(agent_text)))
+            if detected:
+                break
+    finally:
+        await agent.cleanup()
+    return detected
+
+
+async def run_eval(model: str, api_key: str) -> Matrix:
+    m = Matrix()
+    print(f"\nVoicemail-tool eval — model={model}, {len(SCENARIOS)} scenarios\n")
+    print(f"{'truth':<10} {'predicted':<10} category")
+    print("-" * 44)
+    for s in SCENARIOS:
+        detected = await _detected_voicemail(model, api_key, s)
+        actual_vm = s.label == "voicemail"
+        if actual_vm and detected:
+            m.tp += 1
+        elif actual_vm and not detected:
+            m.fn += 1
+        elif not actual_vm and detected:
+            m.fp += 1
+            m.fp_examples.append(f"{s.category}: {s.turns[0]!r}")
+        else:
+            m.tn += 1
+        pred = "voicemail" if detected else "human"
+        flag = "  ⚠ FALSE POSITIVE" if (not actual_vm and detected) else ""
+        print(f"{s.label:<10} {pred:<10} {s.category}{flag}")
+
+    humans = m.tn + m.fp
+    print("\nconfusion matrix          predicted")
+    print("                       voicemail   human")
+    print(f"  actual voicemail   {m.tp:>9}   {m.fn:>5}")
+    print(f"  actual human       {m.fp:>9}   {m.tn:>5}")
+    print(f"\naccuracy {m.accuracy:.0%}  precision {m.precision:.0%}  recall {m.recall:.0%}")
+    print(f"human-safety: {m.tn}/{humans} humans preserved" + (f"  ⚠ {m.fp} WRONGLY HUNG UP" if m.fp else ""))
+    for ex in m.fp_examples:
+        print(f"  FP → {ex}")
+    return m
+
+
+async def _main_async() -> int:
+    api_key = _resolve_api_key(MODEL)
+    if not api_key:
+        print(f"No API key for model {MODEL!r}. Set ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY.")
+        return 2
+    m = await run_eval(MODEL, api_key)
+    # Hard guarantee: never hang up on a human.
+    if m.fp:
+        print(f"\nFAIL: {m.fp} false positive(s) — the agent hung up on a real person.")
+        return 1
+    print("\nPASS: zero false positives (no human was hung up on).")
+    return 0
+
+
+def test_voicemail_tool_confusion_matrix():
+    """Pytest entry: skips without an API key; asserts zero false positives."""
+    import pytest
+
+    api_key = _resolve_api_key(MODEL)
+    if not api_key:
+        pytest.skip(f"no API key for live voicemail eval (model={MODEL})")
+    matrix = asyncio.run(run_eval(MODEL, api_key))
+    # The non-negotiable: never hang up on a human.
+    assert matrix.fp == 0, f"hung up on {matrix.fp} human(s): {matrix.fp_examples}"
+    # Sanity floor: unambiguous classic greetings should be caught.
+    assert matrix.recall > 0.0, "detected no voicemails at all — check the tool/prompt"
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main_async()))

--- a/tests/real_api_test_voicemail_tool.py
+++ b/tests/real_api_test_voicemail_tool.py
@@ -8,7 +8,7 @@ Two phases (both make real LLM calls):
    up on a real person → zero false positives).
 
 2. **Latency sweep** — runs longer human conversations at several
-   ``voicemail_tool_active_turns`` limits (1, 2, 5, None) and reports the average
+   ``voicemail(active_turns=…)`` limits (1, 2, 5, None) and reports the average
    per-turn latency for each, to show how keeping the tool available on more
    turns adds per-turn overhead (an extra tool sits in the LLM's schema on every
    turn the tool is still present).
@@ -254,9 +254,9 @@ async def _run_conversation(
     agent = LlmAgent(
         model=model,
         api_key=api_key,
-        tools=[voicemail(message=VOICEMAIL_MESSAGE), end_call],
+        # active_turns lives on the tool now.
+        tools=[voicemail(message=VOICEMAIL_MESSAGE, active_turns=active_turns), end_call],
         config=LlmConfig(system_prompt=SYSTEM_PROMPT, introduction=""),
-        voicemail_tool_active_turns=active_turns,
     )
     env = TurnEnv(agent_env=AgentEnv())
     history: list = []
@@ -286,7 +286,7 @@ async def _run_conversation(
 async def run_detection_eval(model: str, api_key: str) -> Matrix:
     """Phase 1: confusion matrix over the labeled detection scenarios (limit=1)."""
     m = Matrix()
-    print(f"\n[1] Detection — model={model}, {len(SCENARIOS)} scenarios (voicemail_tool_active_turns=1)\n")
+    print(f"\n[1] Detection — model={model}, {len(SCENARIOS)} scenarios (voicemail active_turns=1)\n")
     print(f"{'truth':<10} {'predicted':<10} category")
     print("-" * 44)
     for s in SCENARIOS:

--- a/tests/real_api_test_voicemail_tool.py
+++ b/tests/real_api_test_voicemail_tool.py
@@ -1,18 +1,25 @@
 #!/usr/bin/env python3
 """Live-API evaluation of the built-in voicemail tool (Approach 1).
 
-Runs a real LlmAgent (with the ``voicemail`` tool) over labeled multi-turn
-scenarios and reports a confusion matrix. The priority metric is **human-safety**:
-the agent must never hang up on a real person (zero false positives).
+Two phases (both make real LLM calls):
 
-This is a live test — it makes real LLM calls and is intentionally NOT collected
-by a bare ``pytest`` run (filename starts with ``real_api_test_``). Run it either
-way:
+1. **Detection** — runs labeled scenarios through an agent with the voicemail
+   tool and reports a confusion matrix. Priority metric: human-safety (never hang
+   up on a real person → zero false positives).
 
-    # as a script (prints the matrix, exits non-zero on a false positive)
+2. **Latency sweep** — runs longer human conversations at several
+   ``voicemail_tool_active_turns`` limits (1, 2, 5, None) and reports the average
+   per-turn latency for each, to show how keeping the tool available on more
+   turns adds per-turn overhead (an extra tool sits in the LLM's schema on every
+   turn the tool is still present).
+
+This is a live test (real LLM calls) and is intentionally NOT collected by a bare
+``pytest`` run (filename starts with ``real_api_test_``). Run it either way:
+
+    # full run (detection + latency sweep), prints everything
     ANTHROPIC_API_KEY=... uv run python tests/real_api_test_voicemail_tool.py
 
-    # under pytest (skips when no key is set)
+    # pytest: detection only (asserts zero false positives), skips without a key
     ANTHROPIC_API_KEY=... uv run pytest tests/real_api_test_voicemail_tool.py -s
 
 Environment:
@@ -25,6 +32,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 import os
 import sys
+import time
 from typing import List, Literal, Optional
 
 import litellm
@@ -34,6 +42,9 @@ from line.events import AgentEndCall, AgentSendText, AgentTextSent, UserTextSent
 from line.llm_agent import LlmAgent, LlmConfig, end_call, voicemail
 
 MODEL = os.getenv("VOICEMAIL_EVAL_MODEL", "anthropic/claude-haiku-4-5-20251001")
+# Tool-active-turn limits compared in the latency sweep.
+TURN_LIMITS: List[Optional[int]] = [1, 2, 5, None]
+
 SYSTEM_PROMPT = (
     "You are an outbound voice agent making a brief courtesy call about a customer's recent order. "
     "Wait for the other party to speak first. If you've reached a live person, greet them and keep it short. "
@@ -49,10 +60,8 @@ class Scenario:
     turns: List[str]
 
 
-# Human-weighted, adversarial. The point is to measure false positives with
-# enough samples to trust the result, since hanging up on a person is the
-# catastrophic error. "voicemail_classic" greetings are unambiguous and used for
-# the recall floor assertion.
+# Detection set — human-weighted and adversarial so the false-positive rate is
+# trustworthy. "voicemail_classic" greetings are unambiguous.
 SCENARIOS: List[Scenario] = [
     # --- voicemail ---
     Scenario(
@@ -128,6 +137,62 @@ SCENARIOS: List[Scenario] = [
     ),
 ]
 
+# Latency set — longer (8-turn) live human conversations, used only for the
+# sweep. They must exceed the largest finite limit (5) so the 5-vs-None
+# difference is observable. These are the callee's (human) turns.
+LATENCY_SCENARIOS: List[List[str]] = [
+    [
+        "Hello?",
+        "Yeah, this is Sarah.",
+        "Oh, about my order? Sure.",
+        "Right, the one I placed last week.",
+        "It hasn't arrived yet, actually.",
+        "Okay, so when should I expect it?",
+        "Got it, that works.",
+        "Thanks for calling, bye.",
+    ],
+    [
+        "Who's this?",
+        "Uh huh, and what's this about?",
+        "My order, okay. Make it quick.",
+        "It was supposed to come Tuesday.",
+        "So it's delayed again?",
+        "Fine, just keep me posted then.",
+        "Yeah, this number's fine.",
+        "Okay. Bye.",
+    ],
+    [
+        "Oh, hi there!",
+        "Yes, this is the right number.",
+        "The order, yes, I've been wondering about it.",
+        "I ordered the blue one, not the red.",
+        "Right, so can you fix that?",
+        "Wonderful, thank you so much.",
+        "And how long will that take?",
+        "Perfect, appreciate it!",
+    ],
+    [
+        "Hello? Who is this?",
+        "Speak up please, I can't hear well.",
+        "My... order? What order?",
+        "Oh, the package. Yes, yes.",
+        "It came already, I think.",
+        "No, wait, maybe not.",
+        "Can you check for me, dear?",
+        "Alright, thank you.",
+    ],
+    [
+        "Hang on— okay, hi.",
+        "Sorry, who's calling?",
+        "Right, the order, go ahead.",
+        "Can you hold a sec? ... okay, back.",
+        "So what about it?",
+        "It's late? Ugh.",
+        "Okay, just let me know.",
+        "Thanks, bye.",
+    ],
+]
+
 
 @dataclass
 class Matrix:
@@ -161,44 +226,62 @@ def _resolve_api_key(model: str) -> Optional[str]:
     return os.getenv("OPENAI_API_KEY")
 
 
-async def _detected_voicemail(model: str, api_key: str, scenario: Scenario) -> bool:
-    """Run a scenario through a fresh agent; True if it hung up as voicemail."""
+def _avg(xs: List[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _tool_present_on_turn(turn_index_1based: int, active_turns: Optional[int]) -> bool:
+    """Whether the voicemail tool is still in the schema on a given (1-based) turn."""
+    return active_turns is None or turn_index_1based <= active_turns
+
+
+async def _run_conversation(
+    model: str, api_key: str, turns: List[str], active_turns: Optional[int]
+) -> tuple[bool, List[float]]:
+    """Drive a conversation through a fresh agent.
+
+    Returns (detected_voicemail, per_turn_latency_ms).
+    """
     agent = LlmAgent(
         model=model,
         api_key=api_key,
         tools=[voicemail(message=VOICEMAIL_MESSAGE), end_call],
         config=LlmConfig(system_prompt=SYSTEM_PROMPT, introduction=""),
-        voicemail_tool_active_turns=1,
+        voicemail_tool_active_turns=active_turns,
     )
     env = TurnEnv(agent_env=AgentEnv())
     history: list = []
     detected = False
+    latencies: List[float] = []
     try:
-        for text in scenario.turns:
+        for text in turns:
             history.append(UserTextSent(content=text))
             event = UserTurnEnded(content=[UserTextSent(content=text)], history=list(history))
+            start = time.perf_counter()
             agent_text: List[str] = []
             async for output in agent.process(env, event):
                 if isinstance(output, AgentEndCall) and output.reason == "voicemail_detected":
                     detected = True
                 elif isinstance(output, AgentSendText):
                     agent_text.append(output.text)
+            latencies.append((time.perf_counter() - start) * 1000)
             if agent_text:
                 history.append(AgentTextSent(content=" ".join(agent_text)))
             if detected:
                 break
     finally:
         await agent.cleanup()
-    return detected
+    return detected, latencies
 
 
-async def run_eval(model: str, api_key: str) -> Matrix:
+async def run_detection_eval(model: str, api_key: str) -> Matrix:
+    """Phase 1: confusion matrix over the labeled detection scenarios (limit=1)."""
     m = Matrix()
-    print(f"\nVoicemail-tool eval — model={model}, {len(SCENARIOS)} scenarios\n")
+    print(f"\n[1] Detection — model={model}, {len(SCENARIOS)} scenarios (voicemail_tool_active_turns=1)\n")
     print(f"{'truth':<10} {'predicted':<10} category")
     print("-" * 44)
     for s in SCENARIOS:
-        detected = await _detected_voicemail(model, api_key, s)
+        detected, _ = await _run_conversation(model, api_key, s.turns, active_turns=1)
         actual_vm = s.label == "voicemail"
         if actual_vm and detected:
             m.tp += 1
@@ -225,24 +308,54 @@ async def run_eval(model: str, api_key: str) -> Matrix:
     return m
 
 
-async def _eval_then_cleanup(model: str, api_key: str) -> Matrix:
-    """Run the eval and close litellm's cached async HTTP clients before the
-    event loop tears down — otherwise their SSL transports raise
-    "Event loop is closed" after the run finishes."""
-    try:
-        return await run_eval(model, api_key)
-    finally:
-        with suppress(Exception):
-            await litellm.close_litellm_async_clients()
+async def run_latency_sweep(model: str, api_key: str) -> None:
+    """Phase 2: average per-turn latency at each tool-active-turn limit."""
+    n_turns = sum(len(t) for t in LATENCY_SCENARIOS)
+    print(
+        f"\n[2] Latency sweep — {len(LATENCY_SCENARIOS)} human conversations, "
+        f"{n_turns} turns each limit, model={model}\n"
+    )
+    print(f"  {'active_turns':<13} {'avg ms/turn':>12} {'tool-present':>14} {'tool-absent':>13}")
+    print("  " + "-" * 54)
+
+    present_pool: List[float] = []
+    absent_pool: List[float] = []
+    for limit in TURN_LIMITS:
+        per_turn: List[tuple[int, float]] = []
+        for turns in LATENCY_SCENARIOS:
+            _, lats = await _run_conversation(model, api_key, turns, limit)
+            per_turn.extend((i, ms) for i, ms in enumerate(lats, start=1))
+        present = [ms for i, ms in per_turn if _tool_present_on_turn(i, limit)]
+        absent = [ms for i, ms in per_turn if not _tool_present_on_turn(i, limit)]
+        present_pool += present
+        absent_pool += absent
+        all_ms = [ms for _, ms in per_turn]
+        label = "None" if limit is None else str(limit)
+        present_str = f"{_avg(present):.0f}ms" if present else "—"
+        absent_str = f"{_avg(absent):.0f}ms" if absent else "—"
+        print(f"  {label:<13} {_avg(all_ms):>10.0f}ms {present_str:>14} {absent_str:>13}")
+
+    dp, da = _avg(present_pool), _avg(absent_pool)
+    print(
+        f"\n  Pooled across limits — tool present: {dp:.0f}ms/turn   tool absent: {da:.0f}ms/turn   "
+        f"per-turn cost of keeping the tool: {dp - da:+.0f}ms"
+    )
 
 
-async def _main_async() -> int:
+async def _run_all() -> int:
     api_key = _resolve_api_key(MODEL)
     if not api_key:
         print(f"No API key for model {MODEL!r}. Set ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY.")
         return 2
-    m = await _eval_then_cleanup(MODEL, api_key)
-    # Hard guarantee: never hang up on a human.
+    try:
+        m = await run_detection_eval(MODEL, api_key)
+        await run_latency_sweep(MODEL, api_key)
+    finally:
+        # Close litellm's cached async HTTP clients inside the loop, else their
+        # SSL transports raise "Event loop is closed" after the run.
+        with suppress(Exception):
+            await litellm.close_litellm_async_clients()
+
     if m.fp:
         print(f"\nFAIL: {m.fp} false positive(s) — the agent hung up on a real person.")
         return 1
@@ -251,13 +364,21 @@ async def _main_async() -> int:
 
 
 def test_voicemail_tool_confusion_matrix():
-    """Pytest entry: skips without an API key; asserts zero false positives."""
+    """Pytest entry: detection only. Skips without an API key; asserts zero false positives."""
     import pytest
 
     api_key = _resolve_api_key(MODEL)
     if not api_key:
         pytest.skip(f"no API key for live voicemail eval (model={MODEL})")
-    matrix = asyncio.run(_eval_then_cleanup(MODEL, api_key))
+
+    async def _go() -> Matrix:
+        try:
+            return await run_detection_eval(MODEL, api_key)
+        finally:
+            with suppress(Exception):
+                await litellm.close_litellm_async_clients()
+
+    matrix = asyncio.run(_go())
     # The non-negotiable: never hang up on a human.
     assert matrix.fp == 0, f"hung up on {matrix.fp} human(s): {matrix.fp_examples}"
     # Sanity floor: unambiguous classic greetings should be caught.
@@ -265,4 +386,4 @@ def test_voicemail_tool_confusion_matrix():
 
 
 if __name__ == "__main__":
-    sys.exit(asyncio.run(_main_async()))
+    sys.exit(asyncio.run(_run_all()))

--- a/tests/real_api_test_voicemail_tool.py
+++ b/tests/real_api_test_voicemail_tool.py
@@ -226,6 +226,15 @@ def _resolve_api_key(model: str) -> Optional[str]:
     return os.getenv("OPENAI_API_KEY")
 
 
+def _quiet_logs() -> None:
+    """Drop loguru INFO spam (one line per agent/turn) so the eval tables aren't
+    buried in hundreds of log lines across the ~210 conversations."""
+    from loguru import logger
+
+    logger.remove()
+    logger.add(sys.stderr, level="WARNING")
+
+
 def _avg(xs: List[float]) -> float:
     return sum(xs) / len(xs) if xs else 0.0
 
@@ -309,17 +318,14 @@ async def run_detection_eval(model: str, api_key: str) -> Matrix:
 
 
 async def run_latency_sweep(model: str, api_key: str) -> None:
-    """Phase 2: average per-turn latency at each tool-active-turn limit."""
-    n_turns = sum(len(t) for t in LATENCY_SCENARIOS)
-    print(
-        f"\n[2] Latency sweep — {len(LATENCY_SCENARIOS)} human conversations, "
-        f"{n_turns} turns each limit, model={model}\n"
-    )
-    print(f"  {'active_turns':<13} {'avg ms/turn':>12} {'tool-present':>14} {'tool-absent':>13}")
-    print("  " + "-" * 54)
+    """Phase 2: average per-turn latency at each tool-active-turn limit.
 
+    All conversations run first; the table is printed as one contiguous block at
+    the end (so it isn't scattered across per-turn output).
+    """
     present_pool: List[float] = []
     absent_pool: List[float] = []
+    rows: List[tuple[str, float, List[float], List[float]]] = []
     for limit in TURN_LIMITS:
         per_turn: List[tuple[int, float]] = []
         for turns in LATENCY_SCENARIOS:
@@ -330,10 +336,19 @@ async def run_latency_sweep(model: str, api_key: str) -> None:
         present_pool += present
         absent_pool += absent
         all_ms = [ms for _, ms in per_turn]
-        label = "None" if limit is None else str(limit)
+        rows.append(("None" if limit is None else str(limit), _avg(all_ms), present, absent))
+
+    turns_each = len(LATENCY_SCENARIOS[0]) if LATENCY_SCENARIOS else 0
+    print(
+        f"\n[2] Latency sweep — {len(LATENCY_SCENARIOS)} human conversations × {turns_each} turns, "
+        f"model={model}"
+    )
+    print(f"  {'active_turns':<13} {'avg ms/turn':>12} {'tool-present':>14} {'tool-absent':>13}")
+    print("  " + "-" * 54)
+    for label, avg_all, present, absent in rows:
         present_str = f"{_avg(present):.0f}ms" if present else "—"
         absent_str = f"{_avg(absent):.0f}ms" if absent else "—"
-        print(f"  {label:<13} {_avg(all_ms):>10.0f}ms {present_str:>14} {absent_str:>13}")
+        print(f"  {label:<13} {avg_all:>10.0f}ms {present_str:>14} {absent_str:>13}")
 
     dp, da = _avg(present_pool), _avg(absent_pool)
     print(
@@ -343,6 +358,7 @@ async def run_latency_sweep(model: str, api_key: str) -> None:
 
 
 async def _run_all() -> int:
+    _quiet_logs()
     api_key = _resolve_api_key(MODEL)
     if not api_key:
         print(f"No API key for model {MODEL!r}. Set ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY.")
@@ -367,6 +383,7 @@ def test_voicemail_tool_confusion_matrix():
     """Pytest entry: detection only. Skips without an API key; asserts zero false positives."""
     import pytest
 
+    _quiet_logs()
     api_key = _resolve_api_key(MODEL)
     if not api_key:
         pytest.skip(f"no API key for live voicemail eval (model={MODEL})")

--- a/tests/real_api_test_voicemail_tool.py
+++ b/tests/real_api_test_voicemail_tool.py
@@ -21,10 +21,13 @@ Environment:
 """
 
 import asyncio
+from contextlib import suppress
 from dataclasses import dataclass, field
 import os
 import sys
 from typing import List, Literal, Optional
+
+import litellm
 
 from line.agent import AgentEnv, TurnEnv
 from line.events import AgentEndCall, AgentSendText, AgentTextSent, UserTextSent, UserTurnEnded
@@ -222,12 +225,23 @@ async def run_eval(model: str, api_key: str) -> Matrix:
     return m
 
 
+async def _eval_then_cleanup(model: str, api_key: str) -> Matrix:
+    """Run the eval and close litellm's cached async HTTP clients before the
+    event loop tears down — otherwise their SSL transports raise
+    "Event loop is closed" after the run finishes."""
+    try:
+        return await run_eval(model, api_key)
+    finally:
+        with suppress(Exception):
+            await litellm.close_litellm_async_clients()
+
+
 async def _main_async() -> int:
     api_key = _resolve_api_key(MODEL)
     if not api_key:
         print(f"No API key for model {MODEL!r}. Set ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY.")
         return 2
-    m = await run_eval(MODEL, api_key)
+    m = await _eval_then_cleanup(MODEL, api_key)
     # Hard guarantee: never hang up on a human.
     if m.fp:
         print(f"\nFAIL: {m.fp} false positive(s) — the agent hung up on a real person.")
@@ -243,7 +257,7 @@ def test_voicemail_tool_confusion_matrix():
     api_key = _resolve_api_key(MODEL)
     if not api_key:
         pytest.skip(f"no API key for live voicemail eval (model={MODEL})")
-    matrix = asyncio.run(run_eval(MODEL, api_key))
+    matrix = asyncio.run(_eval_then_cleanup(MODEL, api_key))
     # The non-negotiable: never hang up on a human.
     assert matrix.fp == 0, f"hung up on {matrix.fp} human(s): {matrix.fp_examples}"
     # Sanity floor: unambiguous classic greetings should be caught.

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -1591,8 +1591,12 @@ async def test_process_replaces_tools_with_same_name(turn_env):
     assert "Original" not in tool_result.result
 
 
-async def test_set_tools_forwards_to_provider(turn_env):
-    """Test that set_tools() updates both the agent and the underlying provider."""
+async def test_set_tools_updates_agent_tools(turn_env):
+    """set_tools() replaces the agent's tools and they take effect on the next turn.
+
+    The provider is not seeded with tools (the agent passes the resolved list to
+    each chat()), so there is no provider-side copy to forward to.
+    """
 
     @loopback_tool
     async def original_tool(ctx) -> str:
@@ -1604,12 +1608,18 @@ async def test_set_tools_forwards_to_provider(turn_env):
         """Replacement tool."""
         return "replacement"
 
-    agent, mock_llm = create_agent_with_mock([], tools=[original_tool])
+    agent, mock_llm = create_agent_with_mock([[StreamChunk(text="hi", is_final=True)]], tools=[original_tool])
 
     agent.set_tools([replacement_tool])
-
     assert agent._tools == [replacement_tool]
-    assert mock_llm._tools == [replacement_tool]
+
+    # The next turn sends the replacement tool to the LLM, not the original.
+    event = UserTextSent(content="hi", history=[UserTextSent(content="hi")])
+    async for _ in agent.process(turn_env, event):
+        pass
+    sent = [t.name for t in (mock_llm._recorded_tools[0] or [])]
+    assert "replacement_tool" in sent
+    assert "original_tool" not in sent
 
 
 async def test_process_replaces_config(turn_env):

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -1500,6 +1500,8 @@ async def test_http_server_tool_form_urlencoded(mock_ctx, anyio_backend, monkeyp
     assert "data" in captured
     assert "json" not in captured
     assert captured["data"]["name"] == "Alice"
+
+
 # ============================================================
 # Tests: voicemail
 # ============================================================

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -17,11 +17,13 @@ from line.llm_agent.tools.system import (
     EndCallTool,
     KnowledgeBaseTool,
     TransferCallTool,
+    VoicemailTool,
     end_call,
     http_server_tool,
     knowledge_base,
     send_dtmf,
     transfer_call,
+    voicemail,
 )
 from line.llm_agent.tools.utils import FunctionTool, ToolType
 
@@ -352,13 +354,15 @@ async def test_end_call_default_description(mock_ctx, anyio_backend):
 
 
 async def test_end_call_yields_agent_end_call(mock_ctx, anyio_backend):
-    """Test that end_call yields AgentEndCall event."""
+    """end_call always reports a normal agent hangup (reason=agent_ended)."""
     func_tool = end_call.as_function_tool()
-    # LLM must provide a reason when calling end_call
+    # The LLM supplies a free-form reason, but end_call hardcodes agent_ended;
+    # voicemail_detected only comes from the voicemail tool.
     events = await collect_events(func_tool.func(mock_ctx, reason="user said goodbye"))
 
     assert len(events) == 1
     assert isinstance(events[0], AgentEndCall)
+    assert events[0].reason == "agent_ended"
 
 
 async def test_end_call_requires_reason_parameter(mock_ctx, anyio_backend):
@@ -1496,3 +1500,46 @@ async def test_http_server_tool_form_urlencoded(mock_ctx, anyio_backend, monkeyp
     assert "data" in captured
     assert "json" not in captured
     assert captured["data"]["name"] == "Alice"
+# ============================================================
+# Tests: voicemail
+# ============================================================
+
+
+async def test_voicemail_with_message(mock_ctx, anyio_backend):
+    """voicemail(message=...) speaks the message (uninterruptible) then ends the call."""
+    tool = voicemail(message="Hi, please call us back.")
+    events = await collect_events(tool.as_function_tool().func(mock_ctx))
+
+    assert len(events) == 2
+    assert isinstance(events[0], AgentSendText)
+    assert events[0].text == "Hi, please call us back."
+    assert events[0].interruptible is False
+    assert isinstance(events[1], AgentEndCall)
+    assert events[1].reason == "voicemail_detected"
+    assert events[1].interruptible is False
+
+
+async def test_voicemail_no_message_silent_end(mock_ctx, anyio_backend):
+    """Bare voicemail silently ends the call with reason=voicemail_detected."""
+    events = await collect_events(voicemail.as_function_tool().func(mock_ctx))
+
+    assert len(events) == 1
+    assert isinstance(events[0], AgentEndCall)
+    assert events[0].reason == "voicemail_detected"
+
+
+async def test_voicemail_name_and_takes_no_llm_args(mock_ctx, anyio_backend):
+    """The tool is named 'voicemail' and exposes no LLM-facing parameters."""
+    func_tool = voicemail.as_function_tool()
+    assert voicemail.name == "voicemail"
+    assert func_tool.name == "voicemail"
+    assert func_tool.parameters == {}
+
+
+async def test_voicemail_custom_description(mock_ctx, anyio_backend):
+    """A custom description overrides the default; default carries detection cues."""
+    assert "voicemail" in VoicemailTool().description.lower()
+    tool = voicemail(description="Reached an answering machine — leave a message and hang up.")
+    assert (
+        tool.as_function_tool().description == "Reached an answering machine — leave a message and hang up."
+    )

--- a/tests/test_llm_agent_voicemail_tool.py
+++ b/tests/test_llm_agent_voicemail_tool.py
@@ -138,6 +138,12 @@ def test_voicemail_chaining_preserves_prior_config():
     assert rechained.active_turns == 1
 
 
+def test_as_function_tool_carries_active_turns():
+    """active_turns travels onto the resolved FunctionTool so removal still applies."""
+    assert voicemail(active_turns=3).as_function_tool().active_turns == 3
+    assert end_call.as_function_tool().active_turns is None
+
+
 def test_normalize_tools_resolves_voicemail():
     """VoicemailTool must resolve to a FunctionTool named 'voicemail' (not a loopback callable)."""
     fts, _ = _normalize_tools([voicemail(message="hi"), end_call], parse_model_id("gpt-4o"))
@@ -223,6 +229,19 @@ async def test_per_call_tools_override_cannot_reintroduce_windowed_tool():
     agent, mock = _agent([[StreamChunk(text="a", is_final=True)]] * 2, tools=[end_call])
     await _collect(agent, _turn("hi"), tools=[voicemail(active_turns=1)])  # turn 1: within window
     await _collect(agent, _turn("hi"), tools=[voicemail(active_turns=1)])  # turn 2: window closed
+
+    assert "voicemail" in _names(mock.recorded_tools[0])
+    assert "voicemail" not in _names(mock.recorded_tools[1])
+
+
+async def test_prereresolved_function_tool_is_still_windowed():
+    """A pre-resolved FunctionTool (voicemail(...).as_function_tool()) is still dropped."""
+    agent, mock = _agent(
+        [[StreamChunk(text="a", is_final=True)]] * 2,
+        tools=[voicemail(active_turns=1).as_function_tool(), end_call],
+    )
+    await _collect(agent, _turn("hi"))
+    await _collect(agent, _turn("hi"))
 
     assert "voicemail" in _names(mock.recorded_tools[0])
     assert "voicemail" not in _names(mock.recorded_tools[1])

--- a/tests/test_llm_agent_voicemail_tool.py
+++ b/tests/test_llm_agent_voicemail_tool.py
@@ -1,10 +1,11 @@
-"""Unit + integration tests for the built-in voicemail tool and its removal.
+"""Unit + integration tests for the built-in voicemail tool and turn-limited removal.
 
 These tests mock the LLM provider — no network. They cover:
-  - unit: VoicemailTool resolves through tool normalization; the _is_voicemail_tool helper.
+  - unit: VoicemailTool resolves through tool normalization; the ClassTool protocol;
+    `active_turns` defaults/chaining.
   - integration: the tool fires (speaks the message + ends the call with
-    reason="voicemail_detected"), and the agent drops the tool from its options
-    after `voicemail_tool_active_turns` user turns so it can't hang up mid-call.
+    reason="voicemail_detected"), and the agent drops any tool from its options
+    once that tool's `active_turns` window has elapsed so it can't fire mid-call.
 
     uv run pytest tests/test_llm_agent_voicemail_tool.py -v
 """
@@ -13,10 +14,10 @@ from typing import List, Optional
 
 from line.agent import AgentEnv, TurnEnv
 from line.events import AgentEndCall, AgentSendText, LogMetric, UserTextSent, UserTurnEnded
-from line.llm_agent.llm_agent import LlmAgent, _is_voicemail_tool
+from line.llm_agent.llm_agent import LlmAgent
 from line.llm_agent.provider import Message, StreamChunk, ToolCall, parse_model_id
-from line.llm_agent.tools.system import VoicemailTool, end_call, voicemail
-from line.llm_agent.tools.utils import _normalize_tools
+from line.llm_agent.tools.system import VoicemailTool, end_call, knowledge_base, transfer_call, voicemail
+from line.llm_agent.tools.utils import ClassTool, _normalize_tools
 
 # =============================================================================
 # Mocks / helpers
@@ -67,13 +68,9 @@ class _MockLLM:
         self.closed = True
 
 
-def _agent(responses, tools, *, active_turns=1) -> tuple:
-    agent = LlmAgent(
-        model="gpt-4o",
-        api_key="test-key",
-        tools=tools,
-        voicemail_tool_active_turns=active_turns,
-    )
+def _agent(responses, tools) -> tuple:
+    """Build an LlmAgent with a mock LM. `active_turns` lives on the tools themselves."""
+    agent = LlmAgent(model="gpt-4o", api_key="test-key", tools=tools)
     mock = _MockLLM(responses)
     agent._llm = mock
     return agent, mock
@@ -106,11 +103,30 @@ def _voicemail_call() -> List[StreamChunk]:
 # =============================================================================
 
 
-def test_is_voicemail_tool_matches_instance_and_function_tool():
-    assert _is_voicemail_tool(voicemail) is True
-    assert _is_voicemail_tool(voicemail(message="hi")) is True
-    assert _is_voicemail_tool(voicemail.as_function_tool()) is True
-    assert _is_voicemail_tool(end_call) is False
+def test_class_tools_satisfy_protocol():
+    """The built-in class tools satisfy ClassTool; web/function tools do not."""
+    from line.llm_agent.tools.system import web_search
+    from line.llm_agent.tools.utils import FunctionTool
+
+    assert isinstance(voicemail, ClassTool)
+    assert isinstance(end_call, ClassTool)
+    assert isinstance(transfer_call, ClassTool)
+    assert isinstance(knowledge_base, ClassTool)
+    assert not isinstance(web_search, ClassTool)
+    assert not isinstance(voicemail.as_function_tool(), ClassTool)
+    assert not isinstance(
+        FunctionTool(name="x", description="d", func=lambda c: None, parameters={}), ClassTool
+    )
+
+
+def test_active_turns_defaults_and_chaining():
+    """voicemail defaults to active_turns=2; others default None; chaining inherits/overrides."""
+    assert voicemail.active_turns == 2
+    assert end_call.active_turns is None
+    assert voicemail(active_turns=5).active_turns == 5
+    assert voicemail(active_turns=None).active_turns is None  # explicit None disables removal
+    assert voicemail(message="x").active_turns == 2  # omitted → inherited
+    assert end_call(active_turns=3).active_turns == 3
 
 
 def test_normalize_tools_resolves_voicemail():
@@ -149,16 +165,15 @@ async def test_voicemail_tool_silent_end_when_no_message():
 
 
 # =============================================================================
-# Integration: tool removal after the conversation starts
+# Integration: turn-limited removal (generic over any ClassTool's active_turns)
 # =============================================================================
 
 
 async def test_voicemail_tool_removed_after_first_turn():
-    """Default active_turns=1: tool present on turn 1, gone from turn 2."""
+    """active_turns=1: tool present on turn 1, gone from turn 2."""
     agent, mock = _agent(
         [[StreamChunk(text="hi", is_final=True)], [StreamChunk(text="hello", is_final=True)]],
-        tools=[voicemail, end_call],
-        active_turns=1,
+        tools=[voicemail(active_turns=1), end_call],
     )
     await _collect(agent, _turn("hello, who's this?"))
     await _collect(agent, _turn("okay, go on"))
@@ -170,10 +185,8 @@ async def test_voicemail_tool_removed_after_first_turn():
 
 
 async def test_default_active_turns_is_two():
-    """Default (no active_turns passed) keeps the tool for turns 1-2, drops it on turn 3."""
-    agent = LlmAgent(model="gpt-4o", api_key="test-key", tools=[voicemail, end_call])
-    mock = _MockLLM([[StreamChunk(text="a", is_final=True)]] * 3)
-    agent._llm = mock
+    """Default voicemail (active_turns=2) stays for turns 1-2, dropped on turn 3."""
+    agent, mock = _agent([[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail, end_call])
     for _ in range(3):
         await _collect(agent, _turn("hi"))
 
@@ -182,24 +195,38 @@ async def test_default_active_turns_is_two():
     assert "voicemail" not in _names(mock.recorded_tools[2])
 
 
-async def test_per_call_tools_override_cannot_reintroduce_voicemail_after_window():
-    """A per-call `tools` override must not resurrect voicemail once the window closed."""
-    agent, mock = _agent([[StreamChunk(text="a", is_final=True)]] * 2, tools=[end_call], active_turns=1)
-    await _collect(agent, _turn("hi"), tools=[voicemail(message="x")])  # turn 1: within window
-    await _collect(agent, _turn("hi"), tools=[voicemail(message="x")])  # turn 2: window closed
+async def test_any_class_tool_with_active_turns_is_removed():
+    """Removal is generic — not voicemail-specific. end_call(active_turns=1) is dropped too."""
+    agent, mock = _agent(
+        [[StreamChunk(text="a", is_final=True)]] * 2,
+        tools=[end_call(active_turns=1), voicemail(active_turns=None)],
+    )
+    await _collect(agent, _turn("hi"))
+    await _collect(agent, _turn("hi"))
+
+    assert "end_call" in _names(mock.recorded_tools[0])
+    assert "end_call" not in _names(mock.recorded_tools[1])  # dropped after its window
+    assert "voicemail" in _names(mock.recorded_tools[1])  # active_turns=None → kept
+
+
+async def test_per_call_tools_override_cannot_reintroduce_windowed_tool():
+    """A per-call `tools` override must not resurrect a tool once its window closed."""
+    agent, mock = _agent([[StreamChunk(text="a", is_final=True)]] * 2, tools=[end_call])
+    await _collect(agent, _turn("hi"), tools=[voicemail(active_turns=1)])  # turn 1: within window
+    await _collect(agent, _turn("hi"), tools=[voicemail(active_turns=1)])  # turn 2: window closed
 
     assert "voicemail" in _names(mock.recorded_tools[0])
     assert "voicemail" not in _names(mock.recorded_tools[1])
 
 
-async def test_voicemail_readded_after_window_is_stripped_again():
-    """No sticky flag: re-adding voicemail via set_tools after the window is re-stripped."""
+async def test_tool_readded_after_window_is_stripped_again():
+    """No sticky flag: re-adding a windowed tool via set_tools after the window is re-stripped."""
     agent, mock = _agent(
-        [[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail, end_call], active_turns=1
+        [[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail(active_turns=1), end_call]
     )
     await _collect(agent, _turn("hi"))  # turn 1: present
     await _collect(agent, _turn("hi"))  # turn 2: window closed → stripped
-    agent.set_tools([voicemail, end_call])  # caller re-adds it dynamically
+    agent.set_tools([voicemail(active_turns=1), end_call])  # caller re-adds it dynamically
     await _collect(agent, _turn("hi"))  # turn 3: still closed → stripped again
 
     assert "voicemail" in _names(mock.recorded_tools[0])
@@ -207,9 +234,9 @@ async def test_voicemail_readded_after_window_is_stripped_again():
     assert "voicemail" not in _names(mock.recorded_tools[2])
 
 
-async def test_voicemail_tool_kept_for_two_turns():
+async def test_tool_kept_for_two_turns():
     agent, mock = _agent(
-        [[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail, end_call], active_turns=2
+        [[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail(active_turns=2), end_call]
     )
     for _ in range(3):
         await _collect(agent, _turn("hi"))
@@ -219,9 +246,9 @@ async def test_voicemail_tool_kept_for_two_turns():
     assert "voicemail" not in _names(mock.recorded_tools[2])
 
 
-async def test_voicemail_tool_kept_for_whole_call_when_none():
+async def test_tool_kept_for_whole_call_when_active_turns_none():
     agent, mock = _agent(
-        [[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail, end_call], active_turns=None
+        [[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail(active_turns=None), end_call]
     )
     for _ in range(3):
         await _collect(agent, _turn("hi"))
@@ -230,10 +257,10 @@ async def test_voicemail_tool_kept_for_whole_call_when_none():
         assert "voicemail" in _names(recorded)
 
 
-async def test_no_voicemail_tool_is_a_noop():
-    """Removal logic must not disturb agents that don't use the voicemail tool."""
-    agent, mock = _agent([[StreamChunk(text="a", is_final=True)]] * 2, tools=[end_call], active_turns=1)
-    for _ in range(2):
+async def test_tools_without_active_turns_are_a_noop():
+    """Tools with no active_turns (here end_call default None) are never dropped."""
+    agent, mock = _agent([[StreamChunk(text="a", is_final=True)]] * 3, tools=[end_call])
+    for _ in range(3):
         await _collect(agent, _turn("hi"))
     for recorded in mock.recorded_tools:
         assert _names(recorded) == ["end_call"]

--- a/tests/test_llm_agent_voicemail_tool.py
+++ b/tests/test_llm_agent_voicemail_tool.py
@@ -129,6 +129,15 @@ def test_active_turns_defaults_and_chaining():
     assert end_call(active_turns=3).active_turns == 3
 
 
+def test_voicemail_chaining_preserves_prior_config():
+    """Re-configuring voicemail inherits omitted fields (chain-safe)."""
+    configured = voicemail(message="Call us back.", interruptible=True, active_turns=5)
+    rechained = configured(active_turns=1)  # only change active_turns
+    assert rechained.message == "Call us back."
+    assert rechained.interruptible is True
+    assert rechained.active_turns == 1
+
+
 def test_normalize_tools_resolves_voicemail():
     """VoicemailTool must resolve to a FunctionTool named 'voicemail' (not a loopback callable)."""
     fts, _ = _normalize_tools([voicemail(message="hi"), end_call], parse_model_id("gpt-4o"))

--- a/tests/test_llm_agent_voicemail_tool.py
+++ b/tests/test_llm_agent_voicemail_tool.py
@@ -1,0 +1,207 @@
+"""Unit + integration tests for the built-in voicemail tool and its removal.
+
+These tests mock the LLM provider — no network. They cover:
+  - unit: VoicemailTool resolves through tool normalization; the _is_voicemail_tool helper.
+  - integration: the tool fires (speaks the message + ends the call with
+    reason="voicemail_detected"), and the agent drops the tool from its options
+    after `voicemail_tool_active_turns` user turns so it can't hang up mid-call.
+
+    uv run pytest tests/test_llm_agent_voicemail_tool.py -v
+"""
+
+from typing import List, Optional
+
+from line.agent import AgentEnv, TurnEnv
+from line.events import AgentEndCall, AgentSendText, LogMetric, UserTextSent, UserTurnEnded
+from line.llm_agent.llm_agent import LlmAgent, _is_voicemail_tool
+from line.llm_agent.provider import Message, StreamChunk, ToolCall, parse_model_id
+from line.llm_agent.tools.system import VoicemailTool, end_call, voicemail
+from line.llm_agent.tools.utils import _normalize_tools
+
+# =============================================================================
+# Mocks / helpers
+# =============================================================================
+
+
+class _MockStream:
+    def __init__(self, chunks: List[StreamChunk]):
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        accumulated: dict = {}
+        for chunk in self._chunks:
+            if chunk.tool_calls:
+                for tc in chunk.tool_calls:
+                    accumulated[tc.id] = tc
+                yield StreamChunk(
+                    text=chunk.text, tool_calls=list(accumulated.values()), is_final=chunk.is_final
+                )
+            else:
+                yield chunk
+
+
+class _MockLLM:
+    """Mock main LM that records the tools it was called with each turn."""
+
+    def __init__(self, responses: List[List[StreamChunk]]):
+        self._responses = responses
+        self._call_count = 0
+        self.recorded_tools: List[Optional[List]] = []
+        self.closed = False
+
+    def chat(self, messages: List[Message], tools=None, **kwargs):
+        self.recorded_tools.append(tools)
+        if self._call_count < len(self._responses):
+            response = self._responses[self._call_count]
+            self._call_count += 1
+            return _MockStream(response)
+        return _MockStream([StreamChunk(is_final=True)])
+
+    async def warmup(self, config=None, tools=None):
+        pass
+
+    def _set_tools(self, tools):
+        pass
+
+    async def aclose(self):
+        self.closed = True
+
+
+def _agent(responses, tools, *, active_turns=1) -> tuple:
+    agent = LlmAgent(
+        model="gpt-4o",
+        api_key="test-key",
+        tools=tools,
+        voicemail_tool_active_turns=active_turns,
+    )
+    mock = _MockLLM(responses)
+    agent._llm = mock
+    return agent, mock
+
+
+def _turn(text: str) -> UserTurnEnded:
+    user_msg = UserTextSent(content=text)
+    return UserTurnEnded(content=[UserTextSent(content=text)], history=[user_msg])
+
+
+async def _collect(agent: LlmAgent, event):
+    env = TurnEnv(agent_env=AgentEnv())
+    return [o async for o in agent.process(env, event) if not isinstance(o, LogMetric)]
+
+
+def _names(recorded) -> List[str]:
+    return [t.name for t in (recorded or [])]
+
+
+def _voicemail_call() -> List[StreamChunk]:
+    return [
+        StreamChunk(
+            tool_calls=[ToolCall(id="c1", name="voicemail", arguments="{}", is_complete=True)], is_final=True
+        )
+    ]
+
+
+# =============================================================================
+# Unit
+# =============================================================================
+
+
+def test_is_voicemail_tool_matches_instance_and_function_tool():
+    assert _is_voicemail_tool(voicemail) is True
+    assert _is_voicemail_tool(voicemail(message="hi")) is True
+    assert _is_voicemail_tool(voicemail.as_function_tool()) is True
+    assert _is_voicemail_tool(end_call) is False
+
+
+def test_normalize_tools_resolves_voicemail():
+    """VoicemailTool must resolve to a FunctionTool named 'voicemail' (not a loopback callable)."""
+    fts, _ = _normalize_tools([voicemail(message="hi"), end_call], parse_model_id("gpt-4o"))
+    assert "voicemail" in [t.name for t in fts]
+    vm = next(t for t in fts if t.name == "voicemail")
+    assert vm.parameters == {}  # exposes no LLM-facing params
+
+
+# =============================================================================
+# Integration: the tool fires
+# =============================================================================
+
+
+async def test_voicemail_tool_fires_speaks_message_and_ends_call():
+    agent, _ = _agent([_voicemail_call()], tools=[voicemail(message="Sorry we missed you."), end_call])
+    outputs = await _collect(agent, _turn("please leave a message after the tone"))
+
+    sends = [o for o in outputs if isinstance(o, AgentSendText)]
+    ends = [o for o in outputs if isinstance(o, AgentEndCall)]
+    assert [s.text for s in sends] == ["Sorry we missed you."]
+    assert sends[0].interruptible is False
+    assert len(ends) == 1
+    assert ends[0].reason == "voicemail_detected"
+    assert ends[0].interruptible is False
+
+
+async def test_voicemail_tool_silent_end_when_no_message():
+    agent, _ = _agent([_voicemail_call()], tools=[voicemail, end_call])
+    outputs = await _collect(agent, _turn("at the tone please record"))
+
+    assert [o for o in outputs if isinstance(o, AgentSendText)] == []
+    ends = [o for o in outputs if isinstance(o, AgentEndCall)]
+    assert len(ends) == 1 and ends[0].reason == "voicemail_detected"
+
+
+# =============================================================================
+# Integration: tool removal after the conversation starts
+# =============================================================================
+
+
+async def test_voicemail_tool_removed_after_first_turn():
+    """Default active_turns=1: tool present on turn 1, gone from turn 2."""
+    agent, mock = _agent(
+        [[StreamChunk(text="hi", is_final=True)], [StreamChunk(text="hello", is_final=True)]],
+        tools=[voicemail, end_call],
+        active_turns=1,
+    )
+    await _collect(agent, _turn("hello, who's this?"))
+    await _collect(agent, _turn("okay, go on"))
+
+    assert "voicemail" in _names(mock.recorded_tools[0])
+    assert "end_call" in _names(mock.recorded_tools[0])
+    assert "voicemail" not in _names(mock.recorded_tools[1])
+    assert "end_call" in _names(mock.recorded_tools[1])
+
+
+async def test_voicemail_tool_kept_for_two_turns():
+    agent, mock = _agent(
+        [[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail, end_call], active_turns=2
+    )
+    for _ in range(3):
+        await _collect(agent, _turn("hi"))
+
+    assert "voicemail" in _names(mock.recorded_tools[0])
+    assert "voicemail" in _names(mock.recorded_tools[1])
+    assert "voicemail" not in _names(mock.recorded_tools[2])
+
+
+async def test_voicemail_tool_kept_for_whole_call_when_none():
+    agent, mock = _agent(
+        [[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail, end_call], active_turns=None
+    )
+    for _ in range(3):
+        await _collect(agent, _turn("hi"))
+
+    for recorded in mock.recorded_tools:
+        assert "voicemail" in _names(recorded)
+
+
+async def test_no_voicemail_tool_is_a_noop():
+    """Removal logic must not disturb agents that don't use the voicemail tool."""
+    agent, mock = _agent([[StreamChunk(text="a", is_final=True)]] * 2, tools=[end_call], active_turns=1)
+    for _ in range(2):
+        await _collect(agent, _turn("hi"))
+    for recorded in mock.recorded_tools:
+        assert _names(recorded) == ["end_call"]
+
+
+def test_constructor_accepts_voicemail_tool():
+    """VoicemailTool instances pass tool validation."""
+    agent = LlmAgent(model="gpt-4o", api_key="test-key", tools=[voicemail(message="x"), end_call])
+    assert any(isinstance(t, VoicemailTool) for t in agent._tools)

--- a/tests/test_llm_agent_voicemail_tool.py
+++ b/tests/test_llm_agent_voicemail_tool.py
@@ -13,7 +13,14 @@ These tests mock the LLM provider — no network. They cover:
 from typing import List, Optional
 
 from line.agent import AgentEnv, TurnEnv
-from line.events import AgentEndCall, AgentSendText, LogMetric, UserTextSent, UserTurnEnded
+from line.events import (
+    AgentEndCall,
+    AgentSendText,
+    CallStarted,
+    LogMetric,
+    UserTextSent,
+    UserTurnEnded,
+)
 from line.llm_agent.llm_agent import LlmAgent
 from line.llm_agent.provider import Message, StreamChunk, ToolCall, parse_model_id
 from line.llm_agent.tools.system import VoicemailTool, end_call, knowledge_base, transfer_call, voicemail
@@ -292,6 +299,23 @@ async def test_tools_without_active_turns_are_a_noop():
         await _collect(agent, _turn("hi"))
     for recorded in mock.recorded_tools:
         assert _names(recorded) == ["end_call"]
+
+
+async def test_call_started_resets_turn_window():
+    """A reused agent: CallStarted resets the window so voicemail is available again."""
+    agent, mock = _agent(
+        [[StreamChunk(text="a", is_final=True)]] * 5, tools=[voicemail(active_turns=1), end_call]
+    )
+    # First "call": tool present turn 1, dropped turn 2.
+    await _collect(agent, _turn("hi"))
+    await _collect(agent, _turn("hi"))
+    assert "voicemail" in _names(mock.recorded_tools[0])
+    assert "voicemail" not in _names(mock.recorded_tools[1])
+
+    # New call on the same instance resets the counter.
+    await _collect(agent, CallStarted())
+    await _collect(agent, _turn("new call opening"))
+    assert "voicemail" in _names(mock.recorded_tools[-1])  # available again on turn 1
 
 
 def test_constructor_accepts_voicemail_tool():

--- a/tests/test_llm_agent_voicemail_tool.py
+++ b/tests/test_llm_agent_voicemail_tool.py
@@ -84,9 +84,9 @@ def _turn(text: str) -> UserTurnEnded:
     return UserTurnEnded(content=[UserTextSent(content=text)], history=[user_msg])
 
 
-async def _collect(agent: LlmAgent, event):
+async def _collect(agent: LlmAgent, event, tools=None):
     env = TurnEnv(agent_env=AgentEnv())
-    return [o async for o in agent.process(env, event) if not isinstance(o, LogMetric)]
+    return [o async for o in agent.process(env, event, tools=tools) if not isinstance(o, LogMetric)]
 
 
 def _names(recorded) -> List[str]:
@@ -167,6 +167,44 @@ async def test_voicemail_tool_removed_after_first_turn():
     assert "end_call" in _names(mock.recorded_tools[0])
     assert "voicemail" not in _names(mock.recorded_tools[1])
     assert "end_call" in _names(mock.recorded_tools[1])
+
+
+async def test_default_active_turns_is_two():
+    """Default (no active_turns passed) keeps the tool for turns 1-2, drops it on turn 3."""
+    agent = LlmAgent(model="gpt-4o", api_key="test-key", tools=[voicemail, end_call])
+    mock = _MockLLM([[StreamChunk(text="a", is_final=True)]] * 3)
+    agent._llm = mock
+    for _ in range(3):
+        await _collect(agent, _turn("hi"))
+
+    assert "voicemail" in _names(mock.recorded_tools[0])
+    assert "voicemail" in _names(mock.recorded_tools[1])
+    assert "voicemail" not in _names(mock.recorded_tools[2])
+
+
+async def test_per_call_tools_override_cannot_reintroduce_voicemail_after_window():
+    """A per-call `tools` override must not resurrect voicemail once the window closed."""
+    agent, mock = _agent([[StreamChunk(text="a", is_final=True)]] * 2, tools=[end_call], active_turns=1)
+    await _collect(agent, _turn("hi"), tools=[voicemail(message="x")])  # turn 1: within window
+    await _collect(agent, _turn("hi"), tools=[voicemail(message="x")])  # turn 2: window closed
+
+    assert "voicemail" in _names(mock.recorded_tools[0])
+    assert "voicemail" not in _names(mock.recorded_tools[1])
+
+
+async def test_voicemail_readded_after_window_is_stripped_again():
+    """No sticky flag: re-adding voicemail via set_tools after the window is re-stripped."""
+    agent, mock = _agent(
+        [[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail, end_call], active_turns=1
+    )
+    await _collect(agent, _turn("hi"))  # turn 1: present
+    await _collect(agent, _turn("hi"))  # turn 2: window closed → stripped
+    agent.set_tools([voicemail, end_call])  # caller re-adds it dynamically
+    await _collect(agent, _turn("hi"))  # turn 3: still closed → stripped again
+
+    assert "voicemail" in _names(mock.recorded_tools[0])
+    assert "voicemail" not in _names(mock.recorded_tools[1])
+    assert "voicemail" not in _names(mock.recorded_tools[2])
 
 
 async def test_voicemail_tool_kept_for_two_turns():

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -1165,6 +1165,18 @@ class TestEndCallAndTransferCallMapping:
         assert isinstance(result, EndCallOutput)
         assert result.interruptible is True
 
+    def test_end_call_reason_forwarded(self):
+        """AgentEndCall(reason=...) forwards the reason to EndCallOutput."""
+        result = self._map(AgentEndCall(reason="voicemail_detected"))
+        assert isinstance(result, EndCallOutput)
+        assert result.reason == "voicemail_detected"
+
+    def test_end_call_reason_defaults_to_agent_ended(self):
+        """AgentEndCall() defaults the reason to agent_ended."""
+        result = self._map(AgentEndCall())
+        assert isinstance(result, EndCallOutput)
+        assert result.reason == "agent_ended"
+
     def test_transfer_call_interruptible_false(self):
         """AgentTransferCall(interruptible=False) maps to TransferOutput(interruptible=False)."""
         result = self._map(AgentTransferCall(target_phone_number="+14155551234", interruptible=False))


### PR DESCRIPTION
## What does this PR do?

Adds a new built-in `voicemail` tool that lets LLM agents detect and handle voicemail/answering-machine greetings. When invoked, the tool speaks an optional configured message and ends the call with `reason="voicemail_detected"`, which the Cartesia API records as the call's end reason.

Key features:
- **`voicemail` tool**: A configurable class tool that speaks an optional message before hanging up (or silently ends), recording `end_reason="voicemail_detected"`.
- **Turn-limited tool removal (generic)**: Built-in class tools accept `active_turns` — the number of user turns the tool stays available before the agent drops it. `voicemail` defaults to `2` so a greeting that arrives over a couple of turns (e.g. split by VAD) is still covered, then it's removed once the conversation is "deemed started" — preventing accidental mid-conversation hangups. Other class tools default to `None` (kept for the whole call). Removal is enforced per turn against the effective tool set, so a per-call `tools` override can't reintroduce a windowed tool, and there's no sticky flag.
- **`ClassTool` interface**: `end_call`, `transfer_call`, `voicemail`, and `knowledge_base` now share a `runtime_checkable` `ClassTool` Protocol (`name`, `as_function_tool()`, `active_turns`) — composition over inheritance, per `AGENTS.md`. `ToolSpec` collapses to `Union[FunctionTool, WebSearchTool, ClassTool, Callable]`, and the agent's removal logic is generic over any tool's `active_turns`.
- **LLM-facing description**: The tool carries its detection cues in its description (e.g., "please leave a message", "at the tone", recorded greetings), so the system prompt doesn't have to.
- **Live evaluation test**: A real-API test (`real_api_test_voicemail_tool.py`) runs labeled scenarios (voicemail vs. human) and enforces zero false positives (never hang up on a real person).

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing

**Unit & integration tests** (`test_llm_agent_voicemail_tool.py`):
- `ClassTool` protocol membership; `active_turns` defaults and chainable config (`voicemail` → 2, others → `None`; explicit `None` disables removal)
- Tool normalization (a class tool resolves to its `FunctionTool`)
- Tool execution: message speaking, call ending with the correct reason
- Removal lifecycle, generic over any class tool: present for the configured turns, then dropped; default `voicemail` is 2; `end_call(active_turns=1)` is dropped too
- Edge cases: silent end (no message), kept for whole call when `active_turns=None`, tools without `active_turns` never dropped, a per-call `tools` override can't resurrect a windowed tool, and a tool re-added via `set_tools` after the window is re-stripped

**System tool tests** (`test_llm_agent_tools_system.py`): message speaking + interruptibility, silent end, tool name/parameter exposure, custom description override.

**Voice agent app tests** (`test_voice_agent_app.py`): `AgentEndCall` reason forwarding to `EndCallOutput`; default reason handling.

**Live API evaluation** (`real_api_test_voicemail_tool.py`):
- Detection: 24 real scenarios (7 voicemail, 17 human multi-turn adversarial); confusion matrix; hard assertion of zero false positives
- Latency sweep: per-turn latency across `voicemail(active_turns=…)` ∈ {1, 2, 5, None} to quantify the cost of keeping the tool available longer
- Runs as a script or under pytest with a provider API key set

## Evaluation results (live API)

Ran `real_api_test_voicemail_tool.py` over the 24 labeled scenarios (7 voicemail, 17 human — adversarial: callers answering with their name, mentioning "voicemail"/"message" while live, call screeners, distracted pickups, etc.). The priority metric is **human-safety**: never hang up on a real person.

| Model | Accuracy | Precision | Recall | Humans preserved |
|---|---|---|---|---|
| `anthropic/claude-haiku-4-5` | 92% | 100% | 71% (5/7) | **17/17** |
| `openai/gpt-5.2` | 100% | 100% | 100% (7/7) | **17/17** |

- **Zero false positives on both models** — no human was ever hung up on (precision 100%, 17/17 humans preserved), including the adversarial human traps.
- Haiku missed 2 subtle, keyword-free voicemail greetings (recall 71%); gpt-5.2 caught all 7.
- The missed-voicemail failure mode is benign: the agent simply keeps talking as if to a person, rather than wrongly hanging up.

**Latency:** the per-turn cost of keeping the voicemail tool in the schema is ~40 ms/turn (≈3% of a ~1200 ms turn, within run-to-run noise) — so `active_turns` is not a meaningful latency lever. `voicemail` defaults to `active_turns=2` so a greeting split across a couple of turns is still covered, at negligible latency cost.

## Checklist
- [x] I have read the contributing guidelines
- [x] I have added tests that prove my feature works
- [x] I have formatted my code with `make format`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hangup semantics (end reasons) and per-turn tool lists in the core agent loop; behavior is well-tested but affects all calls using end_call and new voicemail flows.
> 
> **Overview**
> Adds a built-in **`voicemail`** tool for outbound agents: the LLM can hang up after an optional configured message with **`end_reason="voicemail_detected"`**, while **`end_call`** now always ends with **`agent_ended`**. **`AgentEndCall`** / websocket **`EndCallOutput`** carry a **`reason`** field; **`EndCallReason`** documents the canonical values.
> 
> Introduces **`active_turns`** on built-in class tools (**`ClassTool`** protocol): **`LlmAgent`** drops tools from the schema after N user turns ( **`voicemail`** defaults to **2** ). The provider is no longer seeded with a static tool list—tools are filtered per turn so per-call overrides cannot resurrect a windowed tool; **`CallStarted`** resets the turn counter on reused agents.
> 
> Docs and tests cover outbound setup, unit/integration behavior, and an optional live API eval script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b50f0ee22f1e4921aef26ce5e3fa7e20a3340a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->