### PR TITLE
Make tool configuration chainable by inheriting unset fields

### DIFF
--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -73,10 +73,13 @@ class WebSearchTool:
 
     def __call__(
         self,
-        search_context_size: Literal["low", "medium", "high"] = "medium",
+        search_context_size: Optional[Literal["low", "medium", "high"]] = None,
         **extra: Any,
     ) -> "WebSearchTool":
         """Create a configured WebSearchTool instance.
+
+        Unset arguments inherit from this instance, so re-configuring a tool
+        doesn't silently reset prior settings.
 
         Args:
             search_context_size: Amount of search context to include.
@@ -91,8 +94,10 @@ class WebSearchTool:
         """
         return WebSearchTool(
             name=self.name,
-            search_context_size=search_context_size,
-            extra=extra,
+            search_context_size=(
+                search_context_size if search_context_size is not None else self.search_context_size
+            ),
+            extra=extra if extra else self.extra,
         )
 
     def get_web_search_options(self) -> Dict[str, Any]:
@@ -232,9 +237,12 @@ is possible."""
     def __call__(
         self,
         description: Optional[str] = None,
-        interruptible: bool = True,
+        interruptible: Optional[bool] = None,
     ) -> "EndCallTool":
         """Create a configured EndCallTool instance.
+
+        Unset arguments inherit from this instance, so re-configuring a tool
+        doesn't silently reset prior settings.
 
         Args:
             description: Description that replaces the default. Use this to customize
@@ -243,7 +251,10 @@ is possible."""
         Returns:
             A new EndCallTool instance with the specified configuration.
         """
-        return EndCallTool(description=description, interruptible=interruptible)
+        return EndCallTool(
+            description=description if description is not None else self.description,
+            interruptible=interruptible if interruptible is not None else self.interruptible,
+        )
 
 
 # Default instance - can be used directly or called to configure

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -17,11 +17,13 @@ from line.llm_agent.tools.system import (
     EndCallTool,
     KnowledgeBaseTool,
     TransferCallTool,
+    WebSearchTool,
     end_call,
     http_server_tool,
     knowledge_base,
     send_dtmf,
     transfer_call,
+    web_search,
 )
 from line.llm_agent.tools.utils import FunctionTool, ToolType
 
@@ -413,6 +415,17 @@ async def test_end_call_callable_returns_new_instance(mock_ctx, anyio_backend):
     assert end_call.description == EndCallTool.DEFAULT_DESCRIPTION
     # Configured should have custom description
     assert configured.description == custom_desc
+
+
+async def test_end_call_call_inherits_prior_config(mock_ctx, anyio_backend):
+    """Re-configuring an instance inherits unset fields (chain-safe)."""
+    configured = end_call(description="Bye now", interruptible=False)
+    # Refine nothing relevant; description and interruptible must carry over.
+    refined = configured()
+    assert refined.description == "Bye now"
+    assert refined.interruptible is False
+    # Per-arg override wins, the rest inherited.
+    assert configured(interruptible=True).description == "Bye now"
 
 
 # =============================================================================
@@ -1496,3 +1509,24 @@ async def test_http_server_tool_form_urlencoded(mock_ctx, anyio_backend, monkeyp
     assert "data" in captured
     assert "json" not in captured
     assert captured["data"]["name"] == "Alice"
+
+
+# =============================================================================
+# Tests: web_search
+# =============================================================================
+
+
+def test_web_search_call_inherits_prior_config(anyio_backend):
+    """Re-configuring a WebSearchTool inherits unset fields (chain-safe)."""
+    configured = web_search(search_context_size="high", foo="bar")
+    assert isinstance(configured, WebSearchTool)
+
+    # Calling again with no overrides preserves prior config.
+    rechained = configured()
+    assert rechained.search_context_size == "high"
+    assert rechained.extra == {"foo": "bar"}
+
+    # Per-arg override wins; the rest are inherited.
+    overridden = configured(search_context_size="low")
+    assert overridden.search_context_size == "low"
+    assert overridden.extra == {"foo": "bar"}


### PR DESCRIPTION
## What does this PR do?

This PR makes tool configuration methods (`__call__`) chainable by inheriting unset fields from the current instance. Previously, calling a tool's configuration method without specifying all arguments would reset unspecified fields to their defaults, making it impossible to refine configuration incrementally.

Changes:
- **`WebSearchTool.__call__`**: Changed `search_context_size` parameter from defaulting to `"medium"` to `None`, and now inherits the current instance's value when not explicitly provided. Also preserves `extra` kwargs from the prior instance.
- **`EndCallTool.__call__`**: Changed `interruptible` parameter from defaulting to `True` to `None`, and now inherits the current instance's value when not explicitly provided. Also preserves `description` from the prior instance when not explicitly provided.
- Added comprehensive tests for both tools demonstrating the chainable configuration pattern.

This enables patterns like:
```python
configured = end_call(description="Bye now", interruptible=False)
refined = configured()  # Inherits both settings
overridden = configured(interruptible=True)  # Keeps description, overrides interruptible
```

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing

Added unit tests:
- `test_end_call_call_inherits_prior_config`: Verifies `EndCallTool` configuration inheritance and per-argument overrides
- `test_web_search_call_inherits_prior_config`: Verifies `WebSearchTool` configuration inheritance and per-argument overrides

Both tests confirm that unset arguments inherit from the prior instance while explicit arguments override inherited values.

## Checklist
- [x] I have read the contributing guidelines
- [x] I have added tests that prove my feature works
- [x] I have formatted my code with `make format`

https://claude.ai/code/session_01DT2w8PEaUwu7E5sUdoziUr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized API ergonomics change on tool factories with tests; first-call behavior for explicit defaults is unchanged.
> 
> **Overview**
> Makes **`web_search`** and **`end_call`** configuration **chainable**: calling `__call__` on an already-configured instance no longer resets omitted options to defaults.
> 
> For **`WebSearchTool`**, `search_context_size` and provider **`extra`** kwargs now default to “inherit from this instance” (`None` / empty `extra` means keep prior values). For **`EndCallTool`**, **`description`** and **`interruptible`** behave the same way, so patterns like `configured()` or `configured(interruptible=True)` keep the rest of the settings.
> 
> Adds unit tests that assert full carry-over on `configured()` and per-field overrides on the second call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb9361614e04967f18343ecd916369fb59559cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->