### PR TITLE
Voicemail tool defaults: keep available whole call + don't narrate before the fixed message

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,17 +170,12 @@ voicemail(interruptible=True)              # allow the message/hangup to be inte
 voicemail(description="…")                 # override the LLM-facing "when to call this" text
 ```
 
-**Optionally remove the tool once the conversation starts.** Voicemail is only
-worth checking at the very start of a call, so you can have the agent **drop the
-`voicemail` tool after its `active_turns`** — once the conversation is "deemed
-started" the LLM can no longer trigger a voicemail hangup mid-call. This defaults
-to `None` (the tool stays available for the whole call), because a real voicemail
-greeting transcribes into a variable, often large number of short turns (split by
-VAD, e.g. "…forwarded to voicemail.", "…not available.", "At the tone…") that can
-all arrive before the agent first responds — a small window like `2` is exhausted
-and the tool is gone by the time the LLM acts. Keeping it available is safe (the
-tool's description tells the model not to use it once a real person is talking);
-set a finite value if you want it forced off after N turns:
+**Optionally remove the tool once the conversation starts.** Set `active_turns`
+to drop the `voicemail` tool after that many user turns. It defaults to `None`
+(available the whole call): a voicemail greeting often transcribes into several
+short turns that arrive before the agent first responds, so a small window is
+exhausted before the LLM can act. The tool's description keeps the model off it
+once a real person is talking, so keeping it available is safe.
 
 ```python
 agent = LlmAgent(

--- a/README.md
+++ b/README.md
@@ -170,20 +170,25 @@ voicemail(interruptible=True)              # allow the message/hangup to be inte
 voicemail(description="…")                 # override the LLM-facing "when to call this" text
 ```
 
-**Automatic removal once the conversation starts.** Voicemail is only worth
-checking at the very start of a call, so the agent **drops the `voicemail` tool
-after its `active_turns`** (default `2`) — once the conversation is "deemed
-started" the LLM can no longer trigger a voicemail hangup mid-call. The default
-of `2` covers a greeting that arrives over a couple of turns (e.g. split by VAD);
-set it higher for heavily fragmented greetings, or `None` to keep the tool for
-the whole call:
+**Optionally remove the tool once the conversation starts.** Voicemail is only
+worth checking at the very start of a call, so you can have the agent **drop the
+`voicemail` tool after its `active_turns`** — once the conversation is "deemed
+started" the LLM can no longer trigger a voicemail hangup mid-call. This defaults
+to `None` (the tool stays available for the whole call), because a real voicemail
+greeting transcribes into a variable, often large number of short turns (split by
+VAD, e.g. "…forwarded to voicemail.", "…not available.", "At the tone…") that can
+all arrive before the agent first responds — a small window like `2` is exhausted
+and the tool is gone by the time the LLM acts. Keeping it available is safe (the
+tool's description tells the model not to use it once a real person is talking);
+set a finite value if you want it forced off after N turns:
 
 ```python
 agent = LlmAgent(
     model="anthropic/claude-haiku-4-5-20251001",
     api_key=os.getenv("ANTHROPIC_API_KEY"),
-    # active_turns lives on the tool. Default is 2; None keeps it for the whole call.
-    tools=[voicemail(message="Hi, please call us back.", active_turns=2), end_call],
+    # active_turns lives on the tool. Default None keeps it for the whole call;
+    # set a finite value to drop it after that many user turns.
+    tools=[voicemail(message="Hi, please call us back."), end_call],
     config=LlmConfig(system_prompt=SYSTEM_PROMPT, introduction=""),
 )
 ```
@@ -191,7 +196,7 @@ agent = LlmAgent(
 `active_turns` is a general feature of the built-in class tools (`end_call`,
 `transfer_call`, `voicemail`, `knowledge_base`): any of them can be set to drop
 after N user turns. It defaults to `None` (kept for the whole call) for every
-tool except `voicemail`, which defaults to `2`.
+tool.
 
 ### HTTP Tools — Connect to HTTP APIs Without Code
 

--- a/examples/basic_chat/AGENTS.md
+++ b/examples/basic_chat/AGENTS.md
@@ -159,7 +159,7 @@ agent = LlmAgent(
 | `end_call` | passthrough | End call gracefully (`end_reason="agent_ended"`) |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
-| `voicemail` | passthrough | End on a voicemail greeting: optional message, then hang up with `end_reason="voicemail_detected"`. Auto-removed after its `active_turns` (default 2). |
+| `voicemail` | passthrough | End on a voicemail greeting: optional message, then hang up with `end_reason="voicemail_detected"`. Stays available the whole call by default (`active_turns=None`); set a finite `active_turns` to drop it after N user turns. |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -95,8 +95,9 @@ class LlmAgent:
         A tool may opt into turn-limited availability via its ``active_turns``
         (e.g. ``voicemail(active_turns=2)``): the agent drops it from its options
         after that many user turns, so the LM can no longer call it once the
-        conversation is "deemed started". The built-in ``voicemail`` tool defaults
-        to ``active_turns=2``; pass ``None`` to keep a tool for the whole call.
+        conversation is "deemed started". ``active_turns`` defaults to ``None`` for
+        every built-in tool (kept for the whole call); set a finite value to drop a
+        tool after N user turns.
         """
         if not api_key:
             raise ValueError("Missing API key in LLmAgent initialization")

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -493,11 +493,8 @@ Use when the greeting is a machine, e.g.:
 
 Do NOT use this if a real person is talking with you."""
 
-    # Appended to DEFAULT_DESCRIPTION depending on whether a fixed message is set.
-    # With a fixed message the tool speaks it for you, so the model must NOT add its
-    # own words (otherwise it narrates a preamble like "I've reached a voicemail, so
-    # I'll end the call now." before the configured message). Without one, the model
-    # may speak its own brief message in its turn before calling the tool.
+    # Appended to DEFAULT_DESCRIPTION. With a fixed message the tool speaks it, so
+    # the model must not add its own preamble; without one, it may speak first.
     _FIXED_MESSAGE_GUIDANCE = (
         "This tool speaks a fixed message and ends the call. Do not say anything "
         "yourself — no preamble, acknowledgement, or narration; just call this tool."
@@ -515,20 +512,13 @@ Do NOT use this if a real person is talking with you."""
         # and we want the message left in full.
         self.message = message
         self.interruptible = interruptible
-        # Remember whether the description was explicitly overridden, so chaining
-        # (__call__) only carries forward a *custom* description — otherwise the
-        # default is recomputed for the (possibly new) message.
+        # Track an explicit description override so chaining (__call__) carries only
+        # that forward; otherwise the default is recomputed for the new message.
         self._custom_description = description
         self.description = description if description else self._build_default_description()
-        # active_turns bounds how long the tool stays available (the agent drops it
-        # after that many user turns). Default None = available for the whole call.
-        # A finite window is unreliable for voicemail because greetings transcribe
-        # into a variable, often large number of short turns ("…forwarded to
-        # voicemail.", "…not available.", "At the tone…", "…you may hang up.") that
-        # can all arrive before the agent first responds — exhausting a small window
-        # so the tool is gone by the time the LLM acts. The tool's description still
-        # tells the model not to use it once a real person is talking, so keeping it
-        # available is safe; set a finite value to force removal after N turns.
+        # User turns the tool stays available before the agent drops it. Default
+        # None (whole call): a voicemail greeting fragments into many short turns
+        # that can exhaust a small window before the agent first responds.
         self.active_turns = active_turns
         self._function_tool = self._create_function_tool()
 

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -499,16 +499,22 @@ first; this tool ends the call."""
         message: Optional[str] = None,
         interruptible: bool = False,
         description: Optional[str] = None,
-        active_turns: Optional[int] = 2,
+        active_turns: Optional[int] = None,
     ):
         # interruptible defaults to False: on a voicemail there's no human to interrupt
         # and we want the message left in full.
         self.message = message
         self.interruptible = interruptible
         self.description = description if description else self.DEFAULT_DESCRIPTION
-        # Voicemail is only worth checking at the start of a call, so the agent drops
-        # this tool after `active_turns` user turns (default 2, covering a greeting that
-        # arrives over a couple of turns). None keeps it for the whole call.
+        # active_turns bounds how long the tool stays available (the agent drops it
+        # after that many user turns). Default None = available for the whole call.
+        # A finite window is unreliable for voicemail because greetings transcribe
+        # into a variable, often large number of short turns ("…forwarded to
+        # voicemail.", "…not available.", "At the tone…", "…you may hang up.") that
+        # can all arrive before the agent first responds — exhausting a small window
+        # so the tool is gone by the time the LLM acts. The tool's description still
+        # tells the model not to use it once a real person is talking, so keeping it
+        # available is safe; set a finite value to force removal after N turns.
         self.active_turns = active_turns
         self._function_tool = self._create_function_tool()
 
@@ -557,7 +563,7 @@ first; this tool ends the call."""
             interruptible: Whether the message/end are interruptible.
             description: Override the default LLM-facing description (when to invoke).
             active_turns: User turns the tool stays available before the agent drops it
-                (default 2; ``None`` = whole call). Omit to inherit the current value.
+                (``None`` = whole call, the default). Omit to inherit the current value.
         """
         return VoicemailTool(
             message=message if message is not None else self.message,

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -491,8 +491,18 @@ Use when the greeting is a machine, e.g.:
 - "please leave a message", "at the tone", "you've reached the voicemail of…"
 - a beep, or a one-sided recorded greeting with no back-and-forth
 
-Do NOT use this if a real person is talking with you. You may leave a brief message
-first; this tool ends the call."""
+Do NOT use this if a real person is talking with you."""
+
+    # Appended to DEFAULT_DESCRIPTION depending on whether a fixed message is set.
+    # With a fixed message the tool speaks it for you, so the model must NOT add its
+    # own words (otherwise it narrates a preamble like "I've reached a voicemail, so
+    # I'll end the call now." before the configured message). Without one, the model
+    # may speak its own brief message in its turn before calling the tool.
+    _FIXED_MESSAGE_GUIDANCE = (
+        "This tool speaks a fixed message and ends the call. Do not say anything "
+        "yourself — no preamble, acknowledgement, or narration; just call this tool."
+    )
+    _DYNAMIC_MESSAGE_GUIDANCE = "You may leave a brief message first; this tool ends the call."
 
     def __init__(
         self,
@@ -505,7 +515,11 @@ first; this tool ends the call."""
         # and we want the message left in full.
         self.message = message
         self.interruptible = interruptible
-        self.description = description if description else self.DEFAULT_DESCRIPTION
+        # Remember whether the description was explicitly overridden, so chaining
+        # (__call__) only carries forward a *custom* description — otherwise the
+        # default is recomputed for the (possibly new) message.
+        self._custom_description = description
+        self.description = description if description else self._build_default_description()
         # active_turns bounds how long the tool stays available (the agent drops it
         # after that many user turns). Default None = available for the whole call.
         # A finite window is unreliable for voicemail because greetings transcribe
@@ -517,6 +531,11 @@ first; this tool ends the call."""
         # available is safe; set a finite value to force removal after N turns.
         self.active_turns = active_turns
         self._function_tool = self._create_function_tool()
+
+    def _build_default_description(self) -> str:
+        """Default LLM-facing description, tailored to whether a fixed message is set."""
+        tail = self._FIXED_MESSAGE_GUIDANCE if self.message else self._DYNAMIC_MESSAGE_GUIDANCE
+        return f"{self.DEFAULT_DESCRIPTION}\n\n{tail}"
 
     @property
     def name(self) -> str:
@@ -549,7 +568,7 @@ first; this tool ends the call."""
         self,
         message: Optional[str] = None,
         interruptible: Optional[bool] = None,
-        description: Optional[str] = None,
+        description: Any = _INHERIT,
         active_turns: Any = _INHERIT,
     ) -> "VoicemailTool":
         """Create a configured VoicemailTool instance.
@@ -561,14 +580,17 @@ first; this tool ends the call."""
         Args:
             message: Optional message spoken (uninterruptible by default) before the call ends.
             interruptible: Whether the message/end are interruptible.
-            description: Override the default LLM-facing description (when to invoke).
+            description: Override the default LLM-facing description (when to invoke). Omit
+                to inherit any prior override; the built-in default is otherwise recomputed
+                for the resulting message (the fixed-message default tells the model not to
+                narrate, the no-message default lets it speak first).
             active_turns: User turns the tool stays available before the agent drops it
                 (``None`` = whole call, the default). Omit to inherit the current value.
         """
         return VoicemailTool(
             message=message if message is not None else self.message,
             interruptible=interruptible if interruptible is not None else self.interruptible,
-            description=description if description is not None else self.description,
+            description=self._custom_description if description is _INHERIT else description,
             active_turns=self.active_turns if active_turns is _INHERIT else active_turns,
         )
 

--- a/tests/test_llm_agent_voicemail_tool.py
+++ b/tests/test_llm_agent_voicemail_tool.py
@@ -136,6 +136,19 @@ def test_active_turns_defaults_and_chaining():
     assert end_call(active_turns=3).active_turns == 3
 
 
+def test_default_description_is_message_aware():
+    """A fixed-message voicemail tells the model not to narrate; dynamic mode lets it speak."""
+    with_msg = voicemail(message="Call us back.").description
+    assert "Do not say anything yourself" in with_msg
+    assert "leave a brief message" not in with_msg
+    # No fixed message -> the model may speak its own message before ending.
+    assert "leave a brief message" in voicemail.description
+    # An explicit description override wins and is preserved through chaining.
+    custom = voicemail(message="x", description="CUSTOM")
+    assert custom.description == "CUSTOM"
+    assert custom(active_turns=3).description == "CUSTOM"
+
+
 def test_voicemail_chaining_preserves_prior_config():
     """Re-configuring voicemail inherits omitted fields (chain-safe)."""
     configured = voicemail(message="Call us back.", interruptible=True, active_turns=5)

--- a/tests/test_llm_agent_voicemail_tool.py
+++ b/tests/test_llm_agent_voicemail_tool.py
@@ -127,12 +127,12 @@ def test_class_tools_satisfy_protocol():
 
 
 def test_active_turns_defaults_and_chaining():
-    """voicemail defaults to active_turns=2; others default None; chaining inherits/overrides."""
-    assert voicemail.active_turns == 2
+    """active_turns defaults to None for all built-ins; chaining inherits/overrides."""
+    assert voicemail.active_turns is None
     assert end_call.active_turns is None
     assert voicemail(active_turns=5).active_turns == 5
     assert voicemail(active_turns=None).active_turns is None  # explicit None disables removal
-    assert voicemail(message="x").active_turns == 2  # omitted → inherited
+    assert voicemail(active_turns=2)(message="x").active_turns == 2  # omitted → inherited
     assert end_call(active_turns=3).active_turns == 3
 
 
@@ -206,15 +206,19 @@ async def test_voicemail_tool_removed_after_first_turn():
     assert "end_call" in _names(mock.recorded_tools[1])
 
 
-async def test_default_active_turns_is_two():
-    """Default voicemail (active_turns=2) stays for turns 1-2, dropped on turn 3."""
+async def test_default_active_turns_is_none():
+    """Default voicemail (active_turns=None) stays available for the whole call.
+
+    Real voicemail greetings fragment into a variable number of short turns that
+    can exhaust a small finite window before the agent first responds, so the
+    default keeps the tool available; set a finite active_turns to force removal.
+    """
     agent, mock = _agent([[StreamChunk(text="a", is_final=True)]] * 3, tools=[voicemail, end_call])
     for _ in range(3):
         await _collect(agent, _turn("hi"))
 
-    assert "voicemail" in _names(mock.recorded_tools[0])
-    assert "voicemail" in _names(mock.recorded_tools[1])
-    assert "voicemail" not in _names(mock.recorded_tools[2])
+    for recorded in mock.recorded_tools:
+        assert "voicemail" in _names(recorded)
 
 
 async def test_any_class_tool_with_active_turns_is_removed():


### PR DESCRIPTION
Two related fixes to the built-in `voicemail` tool defaults, both found while running it on real phone calls.

## 1. `active_turns` defaults to `None` (was `2`)

The tool defaulted to `active_turns=2`, dropping it after 2 user turns. But a real voicemail greeting is transcribed into a **variable, often large number of short turns** (split by VAD), all arriving before the agent first responds:

1. "call has been forwarded to voicemail."
2. "The person you're trying to reach is not available."
3. "At the tone, please record your message."
4. "When you have finished recording you may hang up."

By the time the agent gets a turn, `user_turns_seen` is already 4 > 2, so the tool has been removed — the model recognizes the voicemail but can't call it. (Only reproduces on a live call; in `cartesia chat` the greeting is one typed turn.) Default to `None` (available the whole call); the description still tells the model not to use it once a real person is talking. Pass an explicit `active_turns` for the old behavior.

## 2. Fixed-message default no longer invites a preamble

With a fixed message (`voicemail(message="…")`), the default description still said *"You may leave a brief message first"* — so the model narrated a preamble before the tool spoke the configured message:

> "**I've reached a voicemail system, so I'll end this call now.** Hi, this is Acme support returning your call…"

The default description is now message-aware: with a fixed message it instructs the model to call the tool and **say nothing else** (the tool speaks the message); the "leave a brief message" guidance remains only for the no-message/dynamic mode. Chaining recomputes the default for the resulting message and preserves only an *explicit* `description` override.

## Testing

```
uv run --extra dev python -m pytest tests/test_llm_agent_voicemail_tool.py -q   # 19 passed
uv run --extra dev python -m pytest tests/test_llm_agent_tools_system.py tests/test_voice_agent_app.py -q   # 221 passed
```

Updated docstrings, README, and `examples/basic_chat/AGENTS.md`. No version bump (`0.2.14a0`) — happy to add one if you'd prefer to ship under a new alpha.

https://claude.ai/code/session_017Zwqq28UU7fRqrESxBkh35

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default outbound voicemail handling; callers who relied on auto-dropping after two turns must pass `active_turns=2` explicitly.
> 
> **Overview**
> Fixes two **default behaviors** on the built-in `voicemail` tool for real outbound calls.
> 
> **`active_turns` is now `None` (was `2`).** The tool stays in the LLM’s tool list for the whole call unless you set a finite `active_turns`. That avoids voicemail greetings being split into many short user turns (VAD) and exhausting a 2-turn window before the agent can invoke the tool. Docs (`README`, `AGENTS.md`, `LlmAgent` docstring) now describe `active_turns` as optional for all class tools, not voicemail-specific.
> 
> **Default tool description is message-aware.** With `voicemail(message="…")`, the description tells the model to **call the tool only**—no preamble—because the tool speaks the fixed message. Without a fixed message, it still allows speaking a brief message first. Chaining uses `_INHERIT` for `description` so only explicit overrides stick; otherwise the default is recomputed when `message` changes.
> 
> Tests cover the new defaults, description text, and that default voicemail remains available across multiple turns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e8b8f5c365aeeeaeae9903297e64cfd097fec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->