### PR TITLE
[VA-970] Simplify voicemail tool documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,18 +137,17 @@ agent = LlmAgent(
 | `end_call` | Ends the call |
 | `send_dtmf` | Presses phone buttons (0-9, *, #) |
 | `transfer_call` | Transfers to a phone number (E.164). LLM-supplied by default, or pin a fixed destination with `transfer_call(target_phone_number="+1...")` |
-| `voicemail` | Ends the call when you reach a voicemail: optionally leaves a message first, then hangs up with `end_reason="voicemail_detected"`. Configure with `voicemail(message="…")`. See [Voicemail detection](#voicemail-detection-outbound-calls). |
+| `voicemail` | Ends the call when you reach a voicemail, optionally leaving a message first. Configure with `voicemail(message="…")`. See [Voicemail detection](#voicemail-detection-outbound-calls). |
 | `web_search` | Searches the web (native LLM search or DuckDuckGo fallback) |
 | `knowledge_base` | Looks up information from the agent's knowledge base via natural-language query. Call `knowledge_base(filters={...}, top_k=10)` to pre-filter retrievals or override `top_k` |
 | `http_server_tool` | Creates an HTTP tool from JSON schemas (see below) |
 
 ### Voicemail Detection (outbound calls)
 
-On an outbound call you usually want the agent to hear the callee's opening line
-before speaking, so set `introduction=""` — the agent stays silent on
-`CallStarted` and only responds after the first `UserTurnEnded`. Give it the
-`voicemail` tool and it will hang up (after an optional message) when the LLM
-recognizes a machine greeting, recording `end_reason="voicemail_detected"`:
+Add the `voicemail` tool and the agent hangs up — after an optional message —
+when it recognizes a voicemail or answering-machine greeting. On outbound calls,
+set `introduction=""` so the agent stays silent until it hears the callee's
+opening line:
 
 ```python
 from line.llm_agent import LlmAgent, LlmConfig, end_call, voicemail
@@ -161,7 +160,7 @@ agent = LlmAgent(
 )
 ```
 
-Behavior modes (all from the one tool):
+Configuration options:
 
 ```python
 voicemail                                  # silently end the call on a voicemail
@@ -169,29 +168,6 @@ voicemail(message="Sorry we missed you.")  # speak the message (uninterruptible)
 voicemail(interruptible=True)              # allow the message/hangup to be interrupted
 voicemail(description="…")                 # override the LLM-facing "when to call this" text
 ```
-
-**Optionally remove the tool once the conversation starts.** Set `active_turns`
-to drop the `voicemail` tool after that many user turns. It defaults to `None`
-(available the whole call): a voicemail greeting often transcribes into several
-short turns that arrive before the agent first responds, so a small window is
-exhausted before the LLM can act. The tool's description keeps the model off it
-once a real person is talking, so keeping it available is safe.
-
-```python
-agent = LlmAgent(
-    model="anthropic/claude-haiku-4-5-20251001",
-    api_key=os.getenv("ANTHROPIC_API_KEY"),
-    # active_turns lives on the tool. Default None keeps it for the whole call;
-    # set a finite value to drop it after that many user turns.
-    tools=[voicemail(message="Hi, please call us back."), end_call],
-    config=LlmConfig(system_prompt=SYSTEM_PROMPT, introduction=""),
-)
-```
-
-`active_turns` is a general feature of the built-in class tools (`end_call`,
-`transfer_call`, `voicemail`, `knowledge_base`): any of them can be set to drop
-after N user turns. It defaults to `None` (kept for the whole call) for every
-tool.
 
 ### HTTP Tools — Connect to HTTP APIs Without Code
 

--- a/examples/basic_chat/AGENTS.md
+++ b/examples/basic_chat/AGENTS.md
@@ -156,10 +156,10 @@ agent = LlmAgent(
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `end_call` | passthrough | End call gracefully (`end_reason="agent_ended"`) |
+| `end_call` | passthrough | End call gracefully |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
-| `voicemail` | passthrough | End on a voicemail greeting: optional message, then hang up with `end_reason="voicemail_detected"`. Stays available the whole call by default (`active_turns=None`); set a finite `active_turns` to drop it after N user turns. |
+| `voicemail` | passthrough | End the call on a voicemail greeting, optionally leaving a message first (`voicemail(message="…")`) |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/examples/basic_chat/AGENTS.md
+++ b/examples/basic_chat/AGENTS.md
@@ -156,10 +156,10 @@ agent = LlmAgent(
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `end_call` | passthrough | End call gracefully |
+| `end_call` | passthrough | End call gracefully if the conversation has wrapped up. Customize when it's invoked with `end_call(description="…")` |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
-| `voicemail` | passthrough | End the call on a voicemail greeting, optionally leaving a message first (`voicemail(message="…")`) |
+| `voicemail` | passthrough | Detect a voicemail greeting and end the call, optionally leaving a message first (`voicemail(message="…")`) |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/examples/chat_supervisor/AGENTS.md
+++ b/examples/chat_supervisor/AGENTS.md
@@ -239,9 +239,10 @@ agent = LlmAgent(
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `end_call` | passthrough | End call gracefully |
+| `end_call` | passthrough | End call gracefully if the conversation has wrapped up. Customize when it's invoked with `end_call(description="…")` |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
+| `voicemail` | passthrough | Detect a voicemail greeting and end the call, optionally leaving a message first (`voicemail(message="…")`) |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/examples/echo/AGENTS.md
+++ b/examples/echo/AGENTS.md
@@ -168,9 +168,10 @@ agent = LlmAgent(
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `end_call` | passthrough | End call gracefully |
+| `end_call` | passthrough | End call gracefully if the conversation has wrapped up. Customize when it's invoked with `end_call(description="…")` |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
+| `voicemail` | passthrough | Detect a voicemail greeting and end the call, optionally leaving a message first (`voicemail(message="…")`) |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/examples/guardrails_wrapper/AGENTS.md
+++ b/examples/guardrails_wrapper/AGENTS.md
@@ -209,9 +209,10 @@ agent = LlmAgent(
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `end_call` | passthrough | End call gracefully |
+| `end_call` | passthrough | End call gracefully if the conversation has wrapped up. Customize when it's invoked with `end_call(description="…")` |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
+| `voicemail` | passthrough | Detect a voicemail greeting and end the call, optionally leaving a message first (`voicemail(message="…")`) |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/examples/sales_with_leads/AGENTS.md
+++ b/examples/sales_with_leads/AGENTS.md
@@ -292,9 +292,10 @@ agent = LlmAgent(
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `end_call` | passthrough | End call gracefully |
+| `end_call` | passthrough | End call gracefully if the conversation has wrapped up. Customize when it's invoked with `end_call(description="…")` |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
+| `voicemail` | passthrough | Detect a voicemail greeting and end the call, optionally leaving a message first (`voicemail(message="…")`) |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/examples/transfer_agent/AGENTS.md
+++ b/examples/transfer_agent/AGENTS.md
@@ -194,9 +194,10 @@ agent = LlmAgent(
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `end_call` | passthrough | End call gracefully |
+| `end_call` | passthrough | End call gracefully if the conversation has wrapped up. Customize when it's invoked with `end_call(description="…")` |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
+| `voicemail` | passthrough | Detect a voicemail greeting and end the call, optionally leaving a message first (`voicemail(message="…")`) |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/examples/transfer_phone_call/AGENTS.md
+++ b/examples/transfer_phone_call/AGENTS.md
@@ -212,9 +212,10 @@ agent = LlmAgent(
 
 | Tool | Type | Purpose |
 |------|------|---------|
-| `end_call` | passthrough | End call gracefully |
+| `end_call` | passthrough | End call gracefully if the conversation has wrapped up. Customize when it's invoked with `end_call(description="…")` |
 | `send_dtmf` | passthrough | Send DTMF tone (0-9, *, #) |
 | `transfer_call` | passthrough | Transfer to E.164 number |
+| `voicemail` | passthrough | Detect a voicemail greeting and end the call, optionally leaving a message first (`voicemail(message="…")`) |
 | `web_search` | WebSearchTool | Real-time search (native or DuckDuckGo fallback) |
 | `agent_as_handoff` | helper | Create handoff tool from an Agent (pass to tools list) |
 

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -91,14 +91,6 @@ class LlmAgent:
         max_tool_iterations: int = 10,
         backend: Optional[str] = None,
     ):
-        """
-        A tool may opt into turn-limited availability via its ``active_turns``
-        (e.g. ``voicemail(active_turns=2)``): the agent drops it from its options
-        after that many user turns, so the LM can no longer call it once the
-        conversation is "deemed started". ``active_turns`` defaults to ``None`` for
-        every built-in tool (kept for the whole call); set a finite value to drop a
-        tool after N user turns.
-        """
         if not api_key:
             raise ValueError("Missing API key in LLmAgent initialization")
 

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -475,9 +475,7 @@ class VoicemailTool:
 
     The detection cues live in the tool's description (below), so the agent's system
     prompt doesn't need to carry voicemail-handling instructions. When invoked the tool
-    speaks the configured message (if any) and then ends the call with
-    ``reason="voicemail_detected"``, which the Cartesia API records as the call's
-    ``end_reason``.
+    speaks the configured message (if any) and then ends the call.
 
     Behavior modes (all from this one tool):
       - voicemail(message="...")  -> speak the message (uninterruptible), then end.


### PR DESCRIPTION
Cleans up the documentation added with the voicemail tool (#246, #248), which was verbose and exposed internals users don't need.

## Changes

- **README**: rewrote the "Voicemail Detection (outbound calls)" section to be shorter and clearer — one example plus the configuration options. Removed the two `active_turns` paragraphs and the redundant second code example.
- **Removed `end_reason` values from docs** (`voicemail_detected`, `agent_ended` in README and `examples/basic_chat/AGENTS.md`): that's backend plumbing, not something users configure.
- **Removed `active_turns` from documentation language for now**: dropped it from the README, the AGENTS.md tool table, and the `LlmAgent.__init__` docstring. The parameter and its behavior are unchanged — this is docs-only.

## Testing

```
uv run --extra dev python -m pytest tests/test_llm_agent_voicemail_tool.py tests/test_llm_agent_tools_system.py -q   # 138 passed
```

https://claude.ai/code/session_01SZV2JMj8Z8JvnyzjvMu7SN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZV2JMj8Z8JvnyzjvMu7SN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment edits only; voicemail, `active_turns`, and end-call behavior are explicitly unchanged per the PR description.
> 
> **Overview**
> Streamlines **user-facing docs** for the `voicemail` tool and related built-ins after earlier verbose additions—no runtime changes.
> 
> **README:** The outbound voicemail section is shorter (one example plus configuration options). Table copy for `voicemail` drops `end_reason` and internal hangup details. Removed the extra `active_turns` guidance, the duplicate example, and the general `active_turns` explanation for class tools.
> 
> **Example `AGENTS.md` files:** Built-in tool tables now describe `end_call` with optional `end_call(description="…")` and add a concise `voicemail` row. Several examples no longer document `active_turns` or `end_reason` values.
> 
> **Code comments only:** `LlmAgent.__init__` no longer documents `active_turns` in its docstring, and `VoicemailTool`’s class docstring no longer mentions `voicemail_detected` / API `end_reason` plumbing. **`active_turns` and hangup reasons are unchanged in implementation.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03803a1efb308fe41bb65bea95291b7186571c7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->