### PR TITLE
Speculative turns: eager endpointing (SDK)

### DIFF
--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -58,6 +58,32 @@ class CustomInput(BaseModel):
     event_id: Optional[str] = None
 
 
+class SpeculativeTurnInput(BaseModel):
+    """Eager (predicted-final) user turn from STT turn.eager_end.
+
+    Run the turn early; every output it produces is stamped with this
+    speculation_id so the harness can hold the reply until the turn commits
+    (turn.end) or drops it on rollback (turn.resume).
+    """
+
+    content: str
+    speculation_id: int
+    language: Optional[str] = None
+    type: Literal["speculative_turn"] = "speculative_turn"
+    event_id: Optional[str] = None
+
+
+class RollbackTurnInput(BaseModel):
+    """User resumed after an eager-end: scrap this speculation.
+
+    Cancel the in-flight generation and rewind any conversation history it wrote.
+    """
+
+    speculation_id: int
+    type: Literal["rollback_turn"] = "rollback_turn"
+    event_id: Optional[str] = None
+
+
 InputMessage = Union[
     TranscriptionInput,
     DTMFInput,
@@ -66,6 +92,8 @@ InputMessage = Union[
     ValidationErrorInput,
     AgentSpeechInput,
     CustomInput,
+    SpeculativeTurnInput,
+    RollbackTurnInput,
 ]
 
 
@@ -81,6 +109,8 @@ class DTMFOutput(BaseModel):
     type: Literal["dtmf"] = "dtmf"
     button: str
     responding_to: Optional[str] = None
+    # Set when this output answers a speculative turn; None for normal turns.
+    speculation_id: Optional[int] = None
 
 
 class MessageOutput(BaseModel):
@@ -88,6 +118,7 @@ class MessageOutput(BaseModel):
     content: str
     interruptible: bool = True
     responding_to: Optional[str] = None
+    speculation_id: Optional[int] = None
 
 
 class ToolCallOutput(BaseModel):
@@ -97,6 +128,7 @@ class ToolCallOutput(BaseModel):
     result: Optional[str] = None
     id: Optional[str] = None
     responding_to: Optional[str] = None
+    speculation_id: Optional[int] = None
 
 
 class TransferOutput(BaseModel):
@@ -104,6 +136,7 @@ class TransferOutput(BaseModel):
     target_phone_number: str
     responding_to: Optional[str] = None
     interruptible: bool = True
+    speculation_id: Optional[int] = None
 
 
 class EndCallOutput(BaseModel):
@@ -113,6 +146,7 @@ class EndCallOutput(BaseModel):
     reason: Optional[str] = None
     responding_to: Optional[str] = None
     interruptible: bool = True
+    speculation_id: Optional[int] = None
 
 
 class LogEventOutput(BaseModel):

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -61,13 +61,12 @@ class CustomInput(BaseModel):
 class SpeculativeTurnInput(BaseModel):
     """Eager (predicted-final) user turn from STT turn.eager_end.
 
-    Run the turn early; every output it produces is stamped with this
-    speculation_id so the harness can hold the reply until the turn commits
+    Run the turn early; every output it produces is stamped with responding_to ==
+    this turn's event_id, so the harness can hold the reply until the turn commits
     (turn.end) or drops it on rollback (turn.resume).
     """
 
     content: str
-    speculation_id: int
     language: Optional[str] = None
     type: Literal["speculative_turn"] = "speculative_turn"
     event_id: Optional[str] = None
@@ -76,10 +75,11 @@ class SpeculativeTurnInput(BaseModel):
 class RollbackTurnInput(BaseModel):
     """User resumed after an eager-end: scrap this speculation.
 
-    Cancel the in-flight generation and rewind any conversation history it wrote.
+    Cancel the in-flight generation and rewind any conversation history it wrote
+    for the turn whose event_id is ``responding_to``.
     """
 
-    speculation_id: int
+    responding_to: str
     type: Literal["rollback_turn"] = "rollback_turn"
     event_id: Optional[str] = None
 
@@ -109,8 +109,6 @@ class DTMFOutput(BaseModel):
     type: Literal["dtmf"] = "dtmf"
     button: str
     responding_to: Optional[str] = None
-    # Set when this output answers a speculative turn; None for normal turns.
-    speculation_id: Optional[int] = None
 
 
 class MessageOutput(BaseModel):
@@ -118,7 +116,6 @@ class MessageOutput(BaseModel):
     content: str
     interruptible: bool = True
     responding_to: Optional[str] = None
-    speculation_id: Optional[int] = None
 
 
 class ToolCallOutput(BaseModel):
@@ -128,7 +125,6 @@ class ToolCallOutput(BaseModel):
     result: Optional[str] = None
     id: Optional[str] = None
     responding_to: Optional[str] = None
-    speculation_id: Optional[int] = None
 
 
 class TransferOutput(BaseModel):
@@ -136,7 +132,6 @@ class TransferOutput(BaseModel):
     target_phone_number: str
     responding_to: Optional[str] = None
     interruptible: bool = True
-    speculation_id: Optional[int] = None
 
 
 class EndCallOutput(BaseModel):
@@ -146,7 +141,6 @@ class EndCallOutput(BaseModel):
     reason: Optional[str] = None
     responding_to: Optional[str] = None
     interruptible: bool = True
-    speculation_id: Optional[int] = None
 
 
 class LogEventOutput(BaseModel):

--- a/line/llm_agent/history.py
+++ b/line/llm_agent/history.py
@@ -219,6 +219,26 @@ class History:
     # Private API (called by LlmAgent)
     # ------------------------------------------------------------------
 
+    def mark(self) -> tuple[int, int]:
+        """Snapshot local history + mutations so a speculative turn can be undone.
+
+        Returns an opaque marker for :meth:`restore`. Only the agent-owned state
+        (``_local_history`` and ``_mutations``) is captured; ``_input_history`` is
+        replaced wholesale on every :meth:`_set_input`, so it needs no snapshot.
+        """
+        return (len(self._local_history), len(self._mutations))
+
+    def restore(self, marker: tuple[int, int]) -> None:
+        """Truncate local history + mutations back to a :meth:`mark`.
+
+        Drops everything the agent appended since the mark — i.e. the
+        generated-but-rolled-back speculative turn.
+        """
+        local_len, mutations_len = marker
+        del self._local_history[local_len:]
+        del self._mutations[mutations_len:]
+        self._cache = None  # invalidate cache
+
     def _set_input(self, input_history: List[InputEvent], current_event_id: str) -> None:
         """Update merge sources from a new process() call."""
         self._input_history = input_history

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -333,9 +333,9 @@ class ConversationRunner:
         # Speculative turns (eager endpointing). When a speculation is open, the
         # agent task runs early and its outputs are stamped with this id; on
         # rollback we cancel + rewind to the matching checkpoint.
-        self._active_speculation_id: Optional[int] = None
-        # speculation_id -> (history_len, emitted_len, agent_history_mark)
-        self._speculation_checkpoints: Dict[int, Tuple[int, int, Optional[object]]] = {}
+        self._pending_responding_to: Optional[str] = None
+        # responding_to (the eager turn's event_id) -> (history_len, emitted_len, agent_history_mark)
+        self._speculation_checkpoints: Dict[str, Tuple[int, int, Optional[object]]] = {}
 
     @property
     def shutdown_event(self) -> asyncio.Event:
@@ -468,10 +468,10 @@ class ConversationRunner:
         # Commit: a finalized user turn while a speculation is open just confirms
         # the eager prediction. The reply was already generated speculatively, so
         # drop the checkpoint and do NOT regenerate.
-        if self._active_speculation_id is not None and isinstance(event, UserTurnEnded):
-            logger.info(f"-> ✅ Commit speculation {self._active_speculation_id}")
-            self._speculation_checkpoints.pop(self._active_speculation_id, None)
-            self._active_speculation_id = None
+        if self._pending_responding_to is not None and isinstance(event, UserTurnEnded):
+            logger.info(f"-> ✅ Commit speculation {self._pending_responding_to}")
+            self._speculation_checkpoints.pop(self._pending_responding_to, None)
+            self._pending_responding_to = None
             return
 
         if self.run_filter(event):
@@ -483,11 +483,9 @@ class ConversationRunner:
         """Start the agent async iterable for the given event."""
         await self._cancel_agent_task()
 
-        # Use the triggering event's event_id for setting responding_to
+        # Stamp outputs with the triggering event's event_id. On a speculative turn the synthetic
+        # UserTurnEnded carries the eager turn's event_id, which is what the harness holds the reply by.
         responding_to_id = event.event_id
-        # Stamp this task's outputs with the open speculation (if any) so the
-        # harness can hold them until the turn commits or drop them on rollback.
-        speculation_id = self._active_speculation_id
 
         async def runner():
             try:
@@ -503,8 +501,6 @@ class ConversationRunner:
                         break
                     if mapped is None:
                         continue
-                    if speculation_id is not None and hasattr(mapped, "speculation_id"):
-                        mapped.speculation_id = speculation_id
                     await self.websocket.send_json(mapped.model_dump())
             except asyncio.CancelledError:
                 pass
@@ -534,49 +530,53 @@ class ConversationRunner:
 
         Checkpoints history, injects the predicted user text, then drives a
         synthetic UserTurnEnded so the agent generates now. Outputs from this run
-        carry the speculation_id (see _start_agent_task) so the harness holds them.
+        are stamped with responding_to == the eager turn's event_id (see
+        _start_agent_task) so the harness holds them.
         """
-        spec_id = message.speculation_id
-        logger.info(f'-> 🔮 Speculative turn {spec_id}: "{message.content}"')
+        turn_id = message.event_id
+        logger.info(f'-> 🔮 Speculative turn {turn_id}: "{message.content}"')
 
         # Latest-wins: a newer eager-end supersedes the prior open speculation.
-        if self._active_speculation_id is not None and self._active_speculation_id != spec_id:
-            await self._rollback_speculation(self._active_speculation_id)
+        if self._pending_responding_to is not None and self._pending_responding_to != turn_id:
+            await self._rollback_speculation(self._pending_responding_to)
 
         # Checkpoint everything a rollback must undo.
-        self._speculation_checkpoints[spec_id] = (
+        self._speculation_checkpoints[turn_id] = (
             len(self.history),
             len(self.emitted_agent_text),
             self._agent_history_mark(),
         )
-        self._active_speculation_id = spec_id
+        self._pending_responding_to = turn_id
 
-        # Inject the predicted transcript, then synthesize the turn end that runs
-        # the agent. We start the task directly rather than via _handle_event so
-        # this synthetic UserTurnEnded isn't swallowed by the commit guard (which
-        # exists for the *real* turn end that follows).
-        _, self.history = self._process_input_event(self.history, UserTextSent(content=message.content))
+        # Inject the predicted transcript, then synthesize the turn end that runs the agent. Start the
+        # task directly (not via _handle_event) so this synthetic UserTurnEnded isn't swallowed by the
+        # commit guard; the synthetic events carry the eager event_id so outputs inherit responding_to.
+        _, self.history = self._process_input_event(
+            self.history, UserTextSent(content=message.content, event_id=turn_id)
+        )
         content = self._turn_content(self.history, UserTurnStarted, (UserTextSent, UserDtmfSent))
-        ev, self.history = self._process_input_event(self.history, UserTurnEnded(content=content))
+        ev, self.history = self._process_input_event(
+            self.history, UserTurnEnded(content=content, event_id=turn_id)
+        )
         if ev is not None:
             await self._start_agent_task(TurnEnv(agent_env=self.env), ev)
 
     async def _handle_rollback_turn(self, message: RollbackTurnInput) -> None:
         """User resumed: scrap the speculation (cancel generation + rewind history)."""
-        logger.info(f"-> ↩️ Rollback speculation {message.speculation_id}")
-        await self._rollback_speculation(message.speculation_id)
+        logger.info(f"-> ↩️ Rollback speculation {message.responding_to}")
+        await self._rollback_speculation(message.responding_to)
 
-    async def _rollback_speculation(self, spec_id: int) -> None:
+    async def _rollback_speculation(self, responding_to: str) -> None:
         """Cancel the in-flight speculative run and rewind to its checkpoint."""
         await self._cancel_agent_task()
-        checkpoint = self._speculation_checkpoints.pop(spec_id, None)
+        checkpoint = self._speculation_checkpoints.pop(responding_to, None)
         if checkpoint is not None:
             history_len, emitted_len, agent_mark = checkpoint
             del self.history[history_len:]
             del self.emitted_agent_text[emitted_len:]
             self._agent_history_restore(agent_mark)
-        if self._active_speculation_id == spec_id:
-            self._active_speculation_id = None
+        if self._pending_responding_to == responding_to:
+            self._pending_responding_to = None
 
     def _agent_history_mark(self) -> Optional[object]:
         """Snapshot the agent's own history, if it supports it (LlmAgent does)."""

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -40,6 +40,8 @@ from line._harness_types import (
     LogMetricOutput,
     MessageOutput,
     OutputMessage,
+    RollbackTurnInput,
+    SpeculativeTurnInput,
     StartInput,
     STTConfig,
     ToolCallOutput,
@@ -328,6 +330,13 @@ class ConversationRunner:
         self.agent_callable, self.run_filter, self.cancel_filter = self._prepare_agent(agent_spec)
         self.agent_task: Optional[asyncio.Task] = None
 
+        # Speculative turns (eager endpointing). When a speculation is open, the
+        # agent task runs early and its outputs are stamped with this id; on
+        # rollback we cancel + rewind to the matching checkpoint.
+        self._active_speculation_id: Optional[int] = None
+        # speculation_id -> (history_len, emitted_len, agent_history_mark)
+        self._speculation_checkpoints: Dict[int, Tuple[int, int, Optional[object]]] = {}
+
     @property
     def shutdown_event(self) -> asyncio.Event:
         return self._shutdown_event
@@ -359,6 +368,10 @@ class ConversationRunner:
             agent_obj = agent_spec
             run_spec = default_run
             cancel_spec = default_cancel
+
+        # Kept so speculation rollback can rewind the agent's own history
+        # (LlmAgent exposes history.mark()/restore(); other agents are skipped).
+        self._agent_obj = agent_obj
 
         run_filter = self._normalize_filter(run_spec)
         cancel_filter = self._normalize_filter(cancel_spec)
@@ -402,6 +415,15 @@ class ConversationRunner:
                     logger.warning(f"Dropping unparseable websocket message: {message}")
                     continue
 
+                # Speculative turns are handled out-of-band: they drive an early
+                # agent run / rollback rather than mapping to a single InputEvent.
+                if isinstance(input_msg, SpeculativeTurnInput):
+                    await self._handle_speculative_turn(input_msg)
+                    continue
+                if isinstance(input_msg, RollbackTurnInput):
+                    await self._handle_rollback_turn(input_msg)
+                    continue
+
                 # Convert and process the input message
                 event = self._convert_input_message(input_msg)
                 if event is None:
@@ -443,6 +465,15 @@ class ConversationRunner:
 
     async def _handle_event(self, turn_env: TurnEnv, event: InputEvent) -> None:
         """Apply run/cancel filters for a single event."""
+        # Commit: a finalized user turn while a speculation is open just confirms
+        # the eager prediction. The reply was already generated speculatively, so
+        # drop the checkpoint and do NOT regenerate.
+        if self._active_speculation_id is not None and isinstance(event, UserTurnEnded):
+            logger.info(f"-> ✅ Commit speculation {self._active_speculation_id}")
+            self._speculation_checkpoints.pop(self._active_speculation_id, None)
+            self._active_speculation_id = None
+            return
+
         if self.run_filter(event):
             await self._start_agent_task(turn_env, event)
         elif self.cancel_filter(event):
@@ -454,6 +485,9 @@ class ConversationRunner:
 
         # Use the triggering event's event_id for setting responding_to
         responding_to_id = event.event_id
+        # Stamp this task's outputs with the open speculation (if any) so the
+        # harness can hold them until the turn commits or drop them on rollback.
+        speculation_id = self._active_speculation_id
 
         async def runner():
             try:
@@ -469,6 +503,8 @@ class ConversationRunner:
                         break
                     if mapped is None:
                         continue
+                    if speculation_id is not None and hasattr(mapped, "speculation_id"):
+                        mapped.speculation_id = speculation_id
                     await self.websocket.send_json(mapped.model_dump())
             except asyncio.CancelledError:
                 pass
@@ -490,6 +526,72 @@ class ConversationRunner:
             except asyncio.CancelledError:
                 pass
         self.agent_task = None
+
+    ######### Speculative Turn Methods #########
+
+    async def _handle_speculative_turn(self, message: SpeculativeTurnInput) -> None:
+        """Run the agent early on an eagerly-predicted (not-yet-final) user turn.
+
+        Checkpoints history, injects the predicted user text, then drives a
+        synthetic UserTurnEnded so the agent generates now. Outputs from this run
+        carry the speculation_id (see _start_agent_task) so the harness holds them.
+        """
+        spec_id = message.speculation_id
+        logger.info(f'-> 🔮 Speculative turn {spec_id}: "{message.content}"')
+
+        # Latest-wins: a newer eager-end supersedes the prior open speculation.
+        if self._active_speculation_id is not None and self._active_speculation_id != spec_id:
+            await self._rollback_speculation(self._active_speculation_id)
+
+        # Checkpoint everything a rollback must undo.
+        self._speculation_checkpoints[spec_id] = (
+            len(self.history),
+            len(self.emitted_agent_text),
+            self._agent_history_mark(),
+        )
+        self._active_speculation_id = spec_id
+
+        # Inject the predicted transcript, then synthesize the turn end that runs
+        # the agent. We start the task directly rather than via _handle_event so
+        # this synthetic UserTurnEnded isn't swallowed by the commit guard (which
+        # exists for the *real* turn end that follows).
+        _, self.history = self._process_input_event(self.history, UserTextSent(content=message.content))
+        content = self._turn_content(self.history, UserTurnStarted, (UserTextSent, UserDtmfSent))
+        ev, self.history = self._process_input_event(self.history, UserTurnEnded(content=content))
+        if ev is not None:
+            await self._start_agent_task(TurnEnv(agent_env=self.env), ev)
+
+    async def _handle_rollback_turn(self, message: RollbackTurnInput) -> None:
+        """User resumed: scrap the speculation (cancel generation + rewind history)."""
+        logger.info(f"-> ↩️ Rollback speculation {message.speculation_id}")
+        await self._rollback_speculation(message.speculation_id)
+
+    async def _rollback_speculation(self, spec_id: int) -> None:
+        """Cancel the in-flight speculative run and rewind to its checkpoint."""
+        await self._cancel_agent_task()
+        checkpoint = self._speculation_checkpoints.pop(spec_id, None)
+        if checkpoint is not None:
+            history_len, emitted_len, agent_mark = checkpoint
+            del self.history[history_len:]
+            del self.emitted_agent_text[emitted_len:]
+            self._agent_history_restore(agent_mark)
+        if self._active_speculation_id == spec_id:
+            self._active_speculation_id = None
+
+    def _agent_history_mark(self) -> Optional[object]:
+        """Snapshot the agent's own history, if it supports it (LlmAgent does)."""
+        agent_history = getattr(self._agent_obj, "history", None)
+        if agent_history is not None and hasattr(agent_history, "mark"):
+            return agent_history.mark()
+        return None
+
+    def _agent_history_restore(self, marker: Optional[object]) -> None:
+        """Rewind the agent's own history to a prior mark."""
+        if marker is None:
+            return
+        agent_history = getattr(self._agent_obj, "history", None)
+        if agent_history is not None and hasattr(agent_history, "restore"):
+            agent_history.restore(marker)
 
     async def send_error(self, error: str):
         """Send an error message via WebSocket."""

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -1462,12 +1462,12 @@ async def reply_agent(env: TurnEnv, event: InputEvent) -> AsyncIterator[OutputEv
 
 class TestSpeculativeTurns:
     @pytest.mark.asyncio
-    async def test_speculative_turn_runs_agent_and_stamps_id(self):
-        """A speculative_turn runs the agent early; outputs carry the speculation_id."""
+    async def test_speculative_turn_runs_agent_and_stamps_responding_to(self):
+        """A speculative_turn runs the agent early; outputs carry responding_to == event_id."""
         ws = create_mock_websocket()
         runner = ConversationRunner(ws, reply_agent, env)
 
-        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", speculation_id=1))
+        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", event_id="e1"))
         if runner.agent_task:
             await runner.agent_task
 
@@ -1475,8 +1475,8 @@ class TestSpeculativeTurns:
         messages = [m for m in sent if m.get("type") == "message"]
         assert len(messages) == 1
         assert messages[0]["content"] == "reply"
-        assert messages[0]["speculation_id"] == 1
-        assert runner._active_speculation_id == 1
+        assert messages[0]["responding_to"] == "e1"
+        assert runner._pending_responding_to == "e1"
 
     @pytest.mark.asyncio
     async def test_rollback_cancels_and_rewinds_history(self):
@@ -1484,16 +1484,16 @@ class TestSpeculativeTurns:
         runner = ConversationRunner(ws, reply_agent, env)
         history_before = len(runner.history)
 
-        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", speculation_id=1))
+        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", event_id="e1"))
         if runner.agent_task:
             await runner.agent_task
         # The speculative run appended events + emitted text.
         assert len(runner.history) > history_before
         assert len(runner.emitted_agent_text) == 1
 
-        await runner._handle_rollback_turn(RollbackTurnInput(speculation_id=1))
+        await runner._handle_rollback_turn(RollbackTurnInput(responding_to="e1"))
 
-        assert runner._active_speculation_id is None
+        assert runner._pending_responding_to is None
         assert len(runner.history) == history_before  # rewound
         assert runner.emitted_agent_text == []  # rewound
 
@@ -1503,7 +1503,7 @@ class TestSpeculativeTurns:
         ws = create_mock_websocket()
         runner = ConversationRunner(ws, reply_agent, env)
 
-        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", speculation_id=1))
+        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", event_id="e1"))
         if runner.agent_task:
             await runner.agent_task
         ws.send_json.reset_mock()
@@ -1515,20 +1515,22 @@ class TestSpeculativeTurns:
         sent = [c.args[0] for c in ws.send_json.call_args_list]
         messages = [m for m in sent if m.get("type") == "message"]
         assert messages == []  # no second reply
-        assert runner._active_speculation_id is None
+        assert runner._pending_responding_to is None
 
     @pytest.mark.asyncio
     async def test_newer_speculation_supersedes_older(self):
         ws = create_mock_websocket()
         runner = ConversationRunner(ws, reply_agent, env)
 
-        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", speculation_id=1))
+        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", event_id="e1"))
         if runner.agent_task:
             await runner.agent_task
-        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello there", speculation_id=2))
+        await runner._handle_speculative_turn(
+            SpeculativeTurnInput(content="hello there", event_id="e2")
+        )
         if runner.agent_task:
             await runner.agent_task
 
         # Only the latest speculation stays open; the old checkpoint was dropped.
-        assert runner._active_speculation_id == 2
-        assert 1 not in runner._speculation_checkpoints
+        assert runner._pending_responding_to == "e2"
+        assert "e1" not in runner._speculation_checkpoints

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -16,7 +16,13 @@ from unittest.mock import AsyncMock, MagicMock
 from fastapi import WebSocket, WebSocketDisconnect
 import pytest
 
-from line._harness_types import EndCallOutput, MessageOutput, TransferOutput
+from line._harness_types import (
+    EndCallOutput,
+    MessageOutput,
+    RollbackTurnInput,
+    SpeculativeTurnInput,
+    TransferOutput,
+)
 from line.agent import TurnEnv
 from line.events import (
     AgentEndCall,
@@ -1441,3 +1447,88 @@ class TestCreateChatSessionErrorAttribution:
         # carries the agent-code attribution.
         assert response.status_code == 403
         assert response.headers.get("X-Cartesia-Error-Source") == "agent-code"
+
+
+# ============================================================
+# Speculative turns (eager endpointing)
+# ============================================================
+
+
+async def reply_agent(env: TurnEnv, event: InputEvent) -> AsyncIterator[OutputEvent]:
+    """Agent that replies once to a user turn end."""
+    if isinstance(event, UserTurnEnded):
+        yield AgentSendText(text="reply")
+
+
+class TestSpeculativeTurns:
+    @pytest.mark.asyncio
+    async def test_speculative_turn_runs_agent_and_stamps_id(self):
+        """A speculative_turn runs the agent early; outputs carry the speculation_id."""
+        ws = create_mock_websocket()
+        runner = ConversationRunner(ws, reply_agent, env)
+
+        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", speculation_id=1))
+        if runner.agent_task:
+            await runner.agent_task
+
+        sent = [c.args[0] for c in ws.send_json.call_args_list]
+        messages = [m for m in sent if m.get("type") == "message"]
+        assert len(messages) == 1
+        assert messages[0]["content"] == "reply"
+        assert messages[0]["speculation_id"] == 1
+        assert runner._active_speculation_id == 1
+
+    @pytest.mark.asyncio
+    async def test_rollback_cancels_and_rewinds_history(self):
+        ws = create_mock_websocket()
+        runner = ConversationRunner(ws, reply_agent, env)
+        history_before = len(runner.history)
+
+        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", speculation_id=1))
+        if runner.agent_task:
+            await runner.agent_task
+        # The speculative run appended events + emitted text.
+        assert len(runner.history) > history_before
+        assert len(runner.emitted_agent_text) == 1
+
+        await runner._handle_rollback_turn(RollbackTurnInput(speculation_id=1))
+
+        assert runner._active_speculation_id is None
+        assert len(runner.history) == history_before  # rewound
+        assert runner.emitted_agent_text == []  # rewound
+
+    @pytest.mark.asyncio
+    async def test_commit_does_not_regenerate(self):
+        """A real UserTurnEnded while a speculation is open commits without re-running."""
+        ws = create_mock_websocket()
+        runner = ConversationRunner(ws, reply_agent, env)
+
+        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", speculation_id=1))
+        if runner.agent_task:
+            await runner.agent_task
+        ws.send_json.reset_mock()
+
+        await runner._handle_event(TurnEnv(agent_env=env), UserTurnEnded(content=[]))
+        if runner.agent_task:
+            await runner.agent_task
+
+        sent = [c.args[0] for c in ws.send_json.call_args_list]
+        messages = [m for m in sent if m.get("type") == "message"]
+        assert messages == []  # no second reply
+        assert runner._active_speculation_id is None
+
+    @pytest.mark.asyncio
+    async def test_newer_speculation_supersedes_older(self):
+        ws = create_mock_websocket()
+        runner = ConversationRunner(ws, reply_agent, env)
+
+        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello", speculation_id=1))
+        if runner.agent_task:
+            await runner.agent_task
+        await runner._handle_speculative_turn(SpeculativeTurnInput(content="hello there", speculation_id=2))
+        if runner.agent_task:
+            await runner.agent_task
+
+        # Only the latest speculation stays open; the old checkpoint was dropped.
+        assert runner._active_speculation_id == 2
+        assert 1 not in runner._speculation_checkpoints


### PR DESCRIPTION
SDK-side of speculative turns / eager endpointing (RFD-180, Approach B).
Handles the harness `speculative_turn` / `rollback_turn` messages so the agent
runs early on an eager end-of-turn prediction.

- `ConversationRunner` runs the agent early on `speculative_turn` (checkpointing
  history), stamps its outputs with `speculation_id`, commits silently on the
  real turn end, and on `rollback_turn` cancels generation + rewinds history
  (new `History.mark()` / `restore()`). A newer eager-end supersedes the prior one.
- No behavior change for agents that never receive the new messages.

Pairs with cartesia-ai/bifrost#6190 (the inferno half that emits the signals,
holds the reply, and flushes/drops it).

## Testing
- `make test` / `pytest tests/test_voice_agent_app.py tests/test_llm_agent_history.py` — pass, incl. 4 new speculative-turn cases (early run + stamping, rollback rewind, commit no-regen, latest-wins supersede).
- `ruff check` clean.