### PR TITLE
Add LiteLLM request and response debug logging

### DIFF
--- a/line/llm_agent/README.md
+++ b/line/llm_agent/README.md
@@ -58,8 +58,17 @@ config = LlmConfig(
 
     # Provider-specific options
     extra={"logprobs": True},
+
+    # Debugging
+    log_llm_calls=True,  # Logs sanitized LiteLLM input and output payloads
 )
 ```
+
+`log_llm_calls=True` is intended for local debugging. It logs the sanitized
+`litellm.acompletion(...)` input kwargs before the call and the assembled
+streamed chat-completion output after the call. API keys and authorization
+headers are redacted, but prompts, messages, tool schemas, tool arguments, and
+model outputs may still contain sensitive data.
 
 ### Creating Config from CallRequest
 

--- a/line/llm_agent/config.py
+++ b/line/llm_agent/config.py
@@ -46,6 +46,10 @@ class LlmConfig:
     # Provider-specific pass-through
     extra: Dict[str, Any] = _UNSET
 
+    # Debugging. When enabled, the LiteLLM HTTP backend logs the sanitized
+    # acompletion input kwargs and the assembled streamed completion output.
+    log_llm_calls: bool = _UNSET
+
     # Tool schema settings
     strict_tool_schemas: bool = _UNSET
 
@@ -143,6 +147,7 @@ _FIELD_DEFAULTS: Dict[str, Any] = {
     "fallbacks": None,
     "timeout": None,
     "extra": dict,  # callable → invoked each time
+    "log_llm_calls": False,
     "strict_tool_schemas": True,
     "zdr_enabled": False,
 }

--- a/line/llm_agent/http_provider.py
+++ b/line/llm_agent/http_provider.py
@@ -11,9 +11,12 @@ Model naming:
 """
 
 import inspect
+import json
+import time
 from typing import Any, AsyncIterator, Dict, List, NamedTuple, Optional, Protocol, cast
 
 from litellm import acompletion
+from loguru import logger
 
 from line.llm_agent.config import LlmConfig
 from line.llm_agent.provider import Message, ParsedModelId, StreamChunk, ToolCall
@@ -106,7 +109,7 @@ class _HttpProvider:
 
         llm_kwargs.update(kwargs)
 
-        return _ChatStream(llm_kwargs)
+        return _ChatStream(llm_kwargs, log_llm_calls=config.log_llm_calls)
 
     def _build_messages(self, messages: List[Message], config: LlmConfig) -> List[Dict[str, Any]]:
         """Convert Message objects to LiteLLM format."""
@@ -182,8 +185,9 @@ class _ChatStream:
     the WebSocket backends.
     """
 
-    def __init__(self, llm_kwargs: Dict[str, Any]):
+    def __init__(self, llm_kwargs: Dict[str, Any], *, log_llm_calls: bool = False):
         self._kwargs = llm_kwargs
+        self._log_llm_calls = log_llm_calls
 
     async def __aenter__(self) -> "_ChatStream":
         return self
@@ -192,20 +196,49 @@ class _ChatStream:
         pass
 
     async def __aiter__(self) -> AsyncIterator[StreamChunk]:
-        response = cast(_ClosableAsyncIterable, await acompletion(**self._kwargs))
+        started_at = time.perf_counter()
+        response_started_at: Optional[float] = None
+        first_chunk_at: Optional[float] = None
+        first_text_at: Optional[float] = None
+        first_tool_call_at: Optional[float] = None
+        chunk_count = 0
+        text_chunk_count = 0
+        tool_call_chunk_count = 0
+
+        if self._log_llm_calls:
+            _log_llm_call("LiteLLM input call", self._kwargs)
+
+        response: Optional[_ClosableAsyncIterable] = None
+        output_text_parts: List[str] = []
+        finish_reason = None
+        output_error: Optional[BaseException] = None
+        tool_calls: Dict[int, ToolCall] = {}
         try:
-            tool_calls: Dict[int, ToolCall] = {}
+            response = cast(_ClosableAsyncIterable, await acompletion(**self._kwargs))
+            response_started_at = time.perf_counter()
             arg_states: Dict[int, _ArgState] = {}
 
             async for chunk in response:
+                chunk_count += 1
+                if first_chunk_at is None:
+                    first_chunk_at = time.perf_counter()
+
                 text = None
                 if chunk.choices and chunk.choices[0].delta:
                     delta = chunk.choices[0].delta
                     text = getattr(delta, "content", None)
+                    if text:
+                        text_chunk_count += 1
+                        if first_text_at is None:
+                            first_text_at = time.perf_counter()
+                        output_text_parts.append(text)
 
                     # Handle incremental tool calls
                     tc_delta = getattr(delta, "tool_calls", None)
                     if tc_delta:
+                        tool_call_chunk_count += 1
+                        if first_tool_call_at is None:
+                            first_tool_call_at = time.perf_counter()
                         for tc in tc_delta:
                             idx = tc.index
                             if idx not in tool_calls:
@@ -232,7 +265,6 @@ class _ChatStream:
                                     tool_calls[idx].thought_signature = thought_sig
 
                 # Check finish reason
-                finish_reason = None
                 if chunk.choices and chunk.choices[0].finish_reason:
                     finish_reason = chunk.choices[0].finish_reason
                     if finish_reason in ("tool_calls", "stop"):
@@ -244,12 +276,38 @@ class _ChatStream:
                     tool_calls=list(tool_calls.values()) if tool_calls else [],
                     is_final=finish_reason is not None,
                 )
+        except BaseException as exc:
+            output_error = exc
+            raise
         finally:
-            aclose = getattr(response, "aclose", None)
-            if callable(aclose):
-                result = aclose()
-                if inspect.isawaitable(result):
-                    await result
+            if self._log_llm_calls:
+                _log_llm_call(
+                    "LiteLLM output call",
+                    _build_logged_completion_output(
+                        text="".join(output_text_parts),
+                        tool_calls=list(tool_calls.values()),
+                        finish_reason=finish_reason,
+                        debug=_build_logged_completion_debug(
+                            started_at=started_at,
+                            completed_at=time.perf_counter(),
+                            response_started_at=response_started_at,
+                            first_chunk_at=first_chunk_at,
+                            first_text_at=first_text_at,
+                            first_tool_call_at=first_tool_call_at,
+                            chunk_count=chunk_count,
+                            text_chunk_count=text_chunk_count,
+                            tool_call_chunk_count=tool_call_chunk_count,
+                            tool_call_count=len(tool_calls),
+                        ),
+                        error=output_error,
+                    ),
+                )
+            if response is not None:
+                aclose = getattr(response, "aclose", None)
+                if callable(aclose):
+                    result = aclose()
+                    if inspect.isawaitable(result):
+                        await result
 
 
 class _ArgState(NamedTuple):
@@ -297,3 +355,124 @@ def _feed_tool_args(state: Optional[_ArgState], fragment: str) -> _ArgState:
                 depth -= 1
 
     return _ArgState(args, depth, in_str, esc)
+
+
+_REDACTED = "<redacted>"
+_SENSITIVE_KEYS = frozenset(
+    {
+        "api_key",
+        "authorization",
+        "proxy_authorization",
+        "x-api-key",
+        "openai-api-key",
+    }
+)
+
+
+def _redact_llm_payload(value: Any) -> Any:
+    """Return a JSON-friendly copy of a LiteLLM payload with credentials hidden."""
+    if isinstance(value, dict):
+        redacted: Dict[str, Any] = {}
+        for key, item in value.items():
+            key_str = str(key)
+            normalized = key_str.lower().replace("_", "-")
+            if key_str.lower().endswith("api_key") or normalized in _SENSITIVE_KEYS:
+                redacted[key] = _REDACTED
+            else:
+                redacted[key] = _redact_llm_payload(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_llm_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_llm_payload(item) for item in value]
+    return value
+
+
+def _log_llm_call(label: str, payload: Any) -> None:
+    """Log a sanitized LLM payload as stable, readable JSON."""
+    logger.info(
+        "{}:\n{}",
+        label,
+        json.dumps(_redact_llm_payload(payload), indent=2, sort_keys=True, default=str),
+    )
+
+
+def _build_logged_completion_output(
+    *,
+    text: str,
+    tool_calls: List[ToolCall],
+    finish_reason: Optional[str],
+    debug: Optional[Dict[str, Any]] = None,
+    error: Optional[BaseException] = None,
+) -> Dict[str, Any]:
+    """Build a chat-completion-shaped summary from a streamed LiteLLM response."""
+    result: Dict[str, Any] = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": text or None,
+                    "tool_calls": [
+                        {
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {
+                                "name": tc.name,
+                                "arguments": tc.arguments,
+                            },
+                            "is_complete": tc.is_complete,
+                            **(
+                                {"provider_specific_fields": {"thought_signature": tc.thought_signature}}
+                                if tc.thought_signature
+                                else {}
+                            ),
+                        }
+                        for tc in tool_calls
+                    ],
+                },
+                "finish_reason": finish_reason,
+            }
+        ]
+    }
+    if debug is not None:
+        result["line_debug"] = debug
+    if error is not None:
+        result["error"] = {
+            "type": type(error).__name__,
+            "message": str(error),
+        }
+    return result
+
+
+def _ms_since(start: float, end: Optional[float]) -> Optional[float]:
+    if end is None:
+        return None
+    return round((end - start) * 1000, 3)
+
+
+def _build_logged_completion_debug(
+    *,
+    started_at: float,
+    completed_at: float,
+    response_started_at: Optional[float],
+    first_chunk_at: Optional[float],
+    first_text_at: Optional[float],
+    first_tool_call_at: Optional[float],
+    chunk_count: int,
+    text_chunk_count: int,
+    tool_call_chunk_count: int,
+    tool_call_count: int,
+) -> Dict[str, Any]:
+    """Build SDK-specific timing fields for a streamed LiteLLM call."""
+    return {
+        "invoked_tool": tool_call_count > 0,
+        "tool_call_count": tool_call_count,
+        "chunk_count": chunk_count,
+        "text_chunk_count": text_chunk_count,
+        "tool_call_chunk_count": tool_call_chunk_count,
+        "duration_ms": _ms_since(started_at, completed_at),
+        "time_to_stream_start_ms": _ms_since(started_at, response_started_at),
+        "time_to_first_chunk_ms": _ms_since(started_at, first_chunk_at),
+        "time_to_first_text_ms": _ms_since(started_at, first_text_at),
+        "time_to_first_tool_call_ms": _ms_since(started_at, first_tool_call_at),
+    }

--- a/tests/test_llm_agent_config.py
+++ b/tests/test_llm_agent_config.py
@@ -93,6 +93,17 @@ def test_from_call_request_with_extra_kwargs():
     assert config.introduction == FALLBACK_INTRODUCTION
 
 
+def test_from_call_request_with_log_llm_calls():
+    """log_llm_calls is a normal LlmConfig kwarg accepted by from_call_request."""
+    call_request = make_call_request()
+
+    config = LlmConfig.from_call_request(call_request, log_llm_calls=True)
+
+    assert config.log_llm_calls is True
+    assert config.system_prompt == FALLBACK_SYSTEM_PROMPT
+    assert config.introduction == FALLBACK_INTRODUCTION
+
+
 def test_from_call_request_mixed_none_and_provided():
     """Test mixing None and provided values."""
     call_request = make_call_request(
@@ -255,6 +266,30 @@ def test_zdr_enabled_defaults_to_false():
 
     config = _normalize_config(LlmConfig())
     assert config.zdr_enabled is False
+
+
+def test_log_llm_calls_defaults_to_false():
+    """LLM call logging is opt-in so normal calls do not expose prompt data."""
+    from line.llm_agent.config import _normalize_config
+
+    config = _normalize_config(LlmConfig())
+    assert config.log_llm_calls is False
+
+
+def test_log_llm_calls_propagates_through_normalize_and_merge():
+    """Explicit log_llm_calls values survive normalization and merge layering."""
+    from line.llm_agent.config import _merge_configs, _normalize_config
+
+    base = LlmConfig(log_llm_calls=True)
+    override = LlmConfig()
+    merged = _merge_configs(base, override)
+    assert merged.log_llm_calls is True
+
+    normalized = _normalize_config(base)
+    assert normalized.log_llm_calls is True
+
+    disabled = _merge_configs(base, LlmConfig(log_llm_calls=False))
+    assert disabled.log_llm_calls is False
 
 
 def test_zdr_enabled_explicit_true_propagates_through_merge():

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -4,7 +4,13 @@ import asyncio
 from typing import Annotated, Any, List, Optional, get_type_hints
 
 from line.llm_agent.config import LlmConfig, _normalize_config
-from line.llm_agent.http_provider import _feed_tool_args, _HttpProvider
+from line.llm_agent.http_provider import (
+    _build_logged_completion_debug,
+    _build_logged_completion_output,
+    _feed_tool_args,
+    _HttpProvider,
+    _redact_llm_payload,
+)
 from line.llm_agent.provider import (
     ChatStream,
     LlmProvider,
@@ -572,6 +578,120 @@ def test_http_provider_sends_reasoning_effort_verbatim():
 
     stream = provider.chat([], config=_normalize_config(LlmConfig()))
     assert "reasoning_effort" not in stream._kwargs
+
+
+def test_http_provider_propagates_log_llm_calls_flag():
+    provider = _HttpProvider(model_id=parse_model_id("openai/gpt-4o"))
+
+    stream = provider.chat(
+        [Message(role="user", content="hi")],
+        config=_normalize_config(LlmConfig(log_llm_calls=True)),
+    )
+
+    assert stream._log_llm_calls is True
+
+
+def test_redact_llm_payload_removes_credentials():
+    payload = {
+        "api_key": "secret",
+        "headers": {
+            "Authorization": "Bearer secret",
+            "X-API-Key": "also-secret",
+        },
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    assert _redact_llm_payload(payload) == {
+        "api_key": "<redacted>",
+        "headers": {
+            "Authorization": "<redacted>",
+            "X-API-Key": "<redacted>",
+        },
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+
+def test_build_logged_completion_output_is_chat_completion_shaped():
+    output = _build_logged_completion_output(
+        text="hello",
+        tool_calls=[
+            ToolCall(
+                id="call_1",
+                name="lookup",
+                arguments='{"q":"line"}',
+                is_complete=True,
+            )
+        ],
+        finish_reason="tool_calls",
+    )
+
+    assert output == {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "hello",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": '{"q":"line"}',
+                            },
+                            "is_complete": True,
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    }
+
+
+def test_build_logged_completion_output_includes_empty_tool_calls():
+    output = _build_logged_completion_output(
+        text="hello",
+        tool_calls=[],
+        finish_reason="stop",
+    )
+
+    assert output["choices"][0]["message"]["tool_calls"] == []
+
+
+def test_build_logged_completion_output_includes_debug_fields():
+    debug = _build_logged_completion_debug(
+        started_at=1.0,
+        completed_at=1.5,
+        response_started_at=1.1,
+        first_chunk_at=1.2,
+        first_text_at=None,
+        first_tool_call_at=1.3,
+        chunk_count=3,
+        text_chunk_count=0,
+        tool_call_chunk_count=2,
+        tool_call_count=1,
+    )
+
+    output = _build_logged_completion_output(
+        text="",
+        tool_calls=[],
+        finish_reason="tool_calls",
+        debug=debug,
+    )
+
+    assert output["line_debug"] == {
+        "invoked_tool": True,
+        "tool_call_count": 1,
+        "chunk_count": 3,
+        "text_chunk_count": 0,
+        "tool_call_chunk_count": 2,
+        "duration_ms": 500.0,
+        "time_to_stream_start_ms": 100.0,
+        "time_to_first_chunk_ms": 200.0,
+        "time_to_first_text_ms": None,
+        "time_to_first_tool_call_ms": 300.0,
+    }
 
 
 def test_is_websocket_model_matches_gpt52_variants():


### PR DESCRIPTION
## Summary
- Adds `LlmConfig(log_llm_calls=True)` for opt-in LiteLLM HTTP request/response logging.
- Logs sanitized `litellm.acompletion(...)` input kwargs before the call and an assembled streamed chat-completion output after the call.
- Includes explicit `tool_calls: []` when no tool call is produced, plus `line_debug` timing fields for stream start, first chunk, first text, and first tool call.

## Safety
- Defaults off so normal calls do not expose prompt data.
- Redacts API keys and authorization-style headers before logging.
- Documents that prompts, messages, tool schemas, tool arguments, and model outputs may still contain sensitive data when enabled.
- Keeps the behavior scoped to the LiteLLM HTTP backend.

## Example (Synthetic)
```
LiteLLM input call:
  {
    "api_key": "<redacted>",
    "model": "gpt-4o-mini",
    "messages": [
      {"role": "system", "content": "You are a helpful assistant."},
      {"role": "user", "content": "Book a follow-up appointment."}
    ],
    "stream": true,
    "tools": [...]
  }

  LiteLLM output call:
  {
    "choices": [
      {
        "finish_reason": "tool_calls",
        "message": {
          "content": null,
          "role": "assistant",
          "tool_calls": [
            {
              "id": "call_123",
              "type": "function",
              "function": {
                "name": "mark_for_follow_up",
                "arguments": "{\"reason\":\"follow-up appointment help\"}"
              },
              "is_complete": true
            }
          ]
        }
      }
    ],
    "line_debug": {
      "invoked_tool": true,
      "tool_call_count": 1,
      "time_to_first_tool_call_ms": 577.834
    }
  }
```

## Tests
- `uv run --extra dev pytest` (`620 passed`)
- `uv run --extra dev ruff check line/llm_agent/config.py line/llm_agent/http_provider.py tests/test_llm_agent_config.py tests/test_llm_agent_provider.py`
- `git diff --check`
- Tested this locally