### PR TITLE
Allow http_responses backend for all OpenAI chat models

### DIFF
--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -267,8 +267,8 @@ class LlmProvider:
             ``"realtime"``, or ``"websocket"``).  When ``None`` (default),
             the backend is auto-detected from the model name (HTTP/LiteLLM
             for all non-realtime models).  Set ``backend="http_responses"``
-            for Responses-API-capable OpenAI models (e.g. ``gpt-5.2``,
-            ``gpt-5.4-mini``) to speak the Responses API natively over
+            for any non-realtime OpenAI model (e.g. ``gpt-4.1``, ``gpt-4o``,
+            ``gpt-5.2``, ``gpt-5.4-mini``) to speak the Responses API natively over
             HTTPS via ``litellm.aresponses``, bypassing LiteLLM's
             chat-completions → responses bridge — useful for avoiding
             duplicated TTS output on gpt-5.4+ where the bridge drops the
@@ -508,23 +508,28 @@ def _get_model_config(
         )
 
     elif backend == "websocket" and not _is_websocket_model(model_id):
+        # The WS Responses endpoint (``wss://api.openai.com/v1/responses``)
+        # only accepts a narrow set of gpt-5.x models.
         raise ValueError(
             f"Backend 'websocket' requires a websocket-compatible model (e.g. gpt-5.2), got {str(model_id)!r}"
         )
-    elif backend == "http_responses" and not _is_websocket_model(model_id):
+    elif backend == "http_responses" and not _supports_http_responses(model_id):
         raise ValueError(
-            f"Backend 'http_responses' requires a Responses-API-capable model "
-            f"(e.g. gpt-5.2, gpt-5.4-mini), got {str(model_id)!r}"
+            f"Backend 'http_responses' requires an OpenAI chat model that supports the Responses "
+            f"API (e.g. gpt-4.1, gpt-4o, gpt-3.5-turbo, gpt-5.2). Legacy completion models "
+            f"(davinci-002, babbage-002) and realtime models are not supported; got {str(model_id)!r}"
         )
-    elif _is_websocket_model(model_id) and backend in ("websocket", "http_responses"):
-        # Opt-in Responses-API-native paths.  WS speaks the Responses
-        # API over ``wss://api.openai.com/v1/responses``; http_responses
-        # speaks it over HTTPS via ``litellm.aresponses``.  Either
-        # avoids LiteLLM's chat-completions → responses bridge
-        # translator, which drops the ``phase`` field on ``message``
-        # output items and produces duplicated TTS output for gpt-5.4+.
-        responses_supported = get_supported_openai_params(model=litellm_model) or []
-        responses_supports_reasoning = "reasoning_effort" in responses_supported
+    elif backend in ("websocket", "http_responses"):
+        # Opt-in Responses-API-native paths.  WS speaks the Responses API
+        # over ``wss://api.openai.com/v1/responses`` (limited to a few
+        # gpt-5.x models); http_responses speaks it over HTTPS via
+        # ``litellm.aresponses`` (any OpenAI non-realtime model — the WS
+        # allowlist is a strict subset).  Either avoids LiteLLM's
+        # chat-completions → responses bridge translator, which drops the
+        # ``phase`` field on ``message`` output items and produces
+        # duplicated TTS output for gpt-5.4+.  The guards above have
+        # already rejected models incompatible with the chosen backend.
+        responses_supports_reasoning = "reasoning_effort" in (litellm_support or [])
         mcfg = _ModelConfig(
             backend=backend,
             supports_reasoning_effort=responses_supports_reasoning,
@@ -604,8 +609,56 @@ _WEBSOCKET_MODELS = frozenset(
 
 
 def _is_websocket_model(model_id: ParsedModelId) -> bool:
-    """Check if a model should use the WebSocket (Responses API) backend."""
+    """Check if a model is accepted by the WebSocket (Responses API) endpoint.
+
+    The ``wss://api.openai.com/v1/responses`` endpoint only accepts a narrow
+    set of gpt-5.x models; ``http_responses`` (HTTPS) is far less restrictive
+    — see :func:`_supports_http_responses`.
+    """
     return _is_openai_model(model_id) and model_id.model in _WEBSOCKET_MODELS
+
+
+def _supports_http_responses(model_id: ParsedModelId) -> bool:
+    """Check if a model can be driven via the HTTPS Responses API backend.
+
+    ``http_responses`` reaches the Responses API through
+    ``litellm.aresponses``, which OpenAI serves for every **chat** model —
+    gpt-4o, gpt-4.1, gpt-4-turbo, gpt-4, gpt-3.5-turbo, the o-series, and
+    gpt-5.x (verified against ``/v1/responses`` directly).  This is a strict
+    superset of the WebSocket-endpoint allowlist in
+    :func:`_is_websocket_model`.
+
+    Two classes of OpenAI models are excluded:
+
+    * **Realtime** models — they have their own transport and are rejected
+      earlier as incompatible with any non-realtime backend.
+    * **Legacy base/completion** models (``davinci-002``, ``babbage-002``) —
+      they speak only ``/v1/completions``, never ``/v1/responses``. litellm
+      tags them ``mode="completion"``; an unknown model is assumed
+      chat-capable so we never reject a valid model on a metadata gap.
+    """
+    if not _is_openai_model(model_id) or _is_realtime_model(model_id):
+        return False
+
+    from litellm import get_model_info
+
+    # Query the bare model name: litellm keys legacy completion models under
+    # the ``text-completion-openai`` namespace (e.g. "davinci-002"), so the
+    # ``openai/``-prefixed form raises "not mapped" and would slip through.
+    #
+    # Fail open on an unmapped model. get_model_info raises only when litellm
+    # has no record of the model at all — a chat model newer than litellm's
+    # model DB, or a fine-tuned id (``ft:gpt-4o:...``). Known completion
+    # models resolve successfully and are caught by the mode check above, so
+    # the sole effect of returning True here is to *not* reject a model we
+    # merely lack metadata for. The alternative (fail closed) would block
+    # valid, working models at construction the moment they outpace the DB;
+    # a genuinely-unsupported model instead surfaces OpenAI's own error at
+    # call time — the same behavior as before this gate existed.
+    try:
+        return get_model_info(model=model_id.model).get("mode") != "completion"
+    except Exception:
+        return True
 
 
 # Backward-compat alias — emits a deprecation warning on instantiation.

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -407,11 +407,39 @@ class TestGetModelConfig:
         cfg = _get_model_config(parse_model_id("openai/gpt-5.2"), backend="http_responses")
         assert cfg.backend == "http_responses"
 
-    def test_http_responses_backend_with_non_responses_model_raises(self):
+    def test_http_responses_backend_accepts_non_websocket_openai_model(self):
+        # gpt-4.1 / gpt-4o / gpt-3.5-turbo support the Responses API over HTTPS
+        # (litellm.aresponses) even though they are not accepted by the WS Responses
+        # endpoint. They are non-reasoning models, so reasoning_effort stays unsupported.
+        for model in ("openai/gpt-4.1", "openai/gpt-4.1-mini", "openai/gpt-4o", "openai/gpt-3.5-turbo"):
+            cfg = _get_model_config(parse_model_id(model), backend="http_responses")
+            assert cfg.backend == "http_responses", model
+            assert cfg.supports_reasoning_effort is False, model
+            assert cfg.default_reasoning_effort is None, model
+
+    def test_http_responses_backend_rejects_legacy_completion_model(self):
+        # Base/completion models speak only /v1/completions, never /v1/responses.
+        for model in ("openai/davinci-002", "openai/babbage-002"):
+            try:
+                _get_model_config(parse_model_id(model), backend="http_responses")
+            except ValueError as exc:
+                assert "http_responses" in str(exc), model
+            else:
+                raise AssertionError(f"Expected ValueError for {model}")
+
+    def test_http_responses_backend_with_non_openai_model_raises(self):
         try:
-            _get_model_config(parse_model_id("openai/gpt-4o"), backend="http_responses")
+            _get_model_config(parse_model_id("anthropic/claude-sonnet-4-5"), backend="http_responses")
         except ValueError as exc:
             assert "http_responses" in str(exc)
+        else:
+            raise AssertionError("Expected ValueError")
+
+    def test_http_responses_backend_with_realtime_model_raises(self):
+        try:
+            _get_model_config(parse_model_id("openai/gpt-4o-realtime-preview"), backend="http_responses")
+        except ValueError as exc:
+            assert "realtime" in str(exc).lower()
         else:
             raise AssertionError("Expected ValueError")
 


### PR DESCRIPTION
## What does this PR do?

Fixes `LlmProvider(model="gpt-4.1", backend="http_responses")` (and `gpt-4.1-mini`) raising `ValueError` at construction, even though those models fully support the OpenAI Responses API.

**Root cause:** the `http_responses` backend was gated on `_is_websocket_model()` — a hardcoded allowlist of the few gpt-5.x models the **WebSocket** Responses endpoint (`wss://api.openai.com/v1/responses`) accepts. But `http_responses` reaches the Responses API over **HTTPS** via `litellm.aresponses`, which OpenAI serves for every chat model. The two eligibility checks were incorrectly conflated onto one predicate.

**Fix:** decouple `http_responses` eligibility from the WebSocket allowlist via a new `_supports_http_responses()` predicate (`websocket` stays restricted to `_is_websocket_model()`). Eligibility rule — any OpenAI model except:
- **realtime** models (own transport; already rejected earlier as incompatible with non-realtime backends), and
- **legacy base/completion** models (`davinci-002`, `babbage-002`) which speak only `/v1/completions` — litellm tags these `mode="completion"`, so we reject them fast at construction with a clear error instead of a cryptic runtime failure. Unmapped models fail open (assumed chat-capable) so we never block a valid model newer than litellm's model DB.

The shared `_plan_responses_chat` planner is already model-agnostic and omits reasoning for non-reasoning models, so no other changes were needed.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

**Unit tests** (`tests/test_llm_agent_provider.py`):
- `test_http_responses_backend_accepts_non_websocket_openai_model` — gpt-4.1 / gpt-4.1-mini / gpt-4o / gpt-3.5-turbo accepted, reasoning correctly disabled
- `test_http_responses_backend_rejects_legacy_completion_model` — davinci-002 / babbage-002 rejected
- `test_http_responses_backend_with_non_openai_model_raises` / `..._with_realtime_model_raises`
- Replaced the stale `test_http_responses_backend_with_non_responses_model_raises` (it encoded the old, overly-narrow assumption that gpt-4o should be rejected)

Full suite `pytest tests/`: **615 passed**.

**Live API:** confirmed against the real `/v1/responses` endpoint — text, tool calls, and multi-turn all work for `gpt-4o`, `gpt-4o-mini`, `gpt-4.1(-mini/-nano)`, `gpt-4-turbo`, `gpt-4`, `gpt-3.5-turbo`, and the o-series. (Multi-turn requires `LlmConfig(zdr_enabled=True)` on Zero-Data-Retention orgs, since `previous_response_id` chaining is rejected there — unrelated to this change.)

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
