### PR TITLE
history: concatenate current-turn AgentSendText in loopback context

### DIFF
--- a/line/llm_agent/history.py
+++ b/line/llm_agent/history.py
@@ -363,8 +363,14 @@ def _build_full_history(
     # Flush any remaining locals from the last trigger
     result.extend(_flush_queue(queue))
 
-    # Append current-turn events (not yet observed, use local version)
-    result.extend(current_local)
+    # Append current-turn events (not yet observed, use local version).
+    # Concatenate contiguous streamed AgentSendText chunks first, mirroring how
+    # prior-turn slices are handled above, so the model sees its own just-produced
+    # speech as one coherent assistant turn rather than as many single-chunk
+    # messages. This matters during a tool loopback within the same turn: the
+    # pre-tool preamble ("Let me verify that.") would otherwise reach the model
+    # as a run of one-token assistant messages instead of a single utterance.
+    result.extend(_concat_contiguous_agent_send_text(current_local))
 
     # Convert matchable OutputEvents to InputEvent counterparts
     return [h for e in result if (h := _to_history_event(e)) is not None]

--- a/tests/test_llm_agent_history.py
+++ b/tests/test_llm_agent_history.py
@@ -85,6 +85,37 @@ class TestBuildFullHistory:
         assert isinstance(result[0], AgentToolCalled)
         assert result[0].tool_name == "test"
 
+    async def test_current_turn_agent_send_text_chunks_are_concatenated(self):
+        """Current-turn streamed AgentSendText chunks collapse into one AgentTextSent.
+
+        The LLM streams text as many chunks; within a turn that also makes a
+        tool call (a loopback), the model must see its own just-produced
+        pre-tool speech as one coherent assistant turn, exactly as prior turns
+        are represented — not as a run of one-chunk messages.
+        """
+        local_history = self._annotate(
+            [
+                AgentSendText(text="Let"),
+                AgentSendText(text=" me"),
+                AgentSendText(text=" verify"),
+                AgentSendText(text=" that."),
+                AgentToolCalled(tool_call_id="1", tool_name="verify_otp", tool_args={"code": "123"}),
+                AgentToolReturned(
+                    tool_call_id="1", tool_name="verify_otp", tool_args={"code": "123"}, result="SUCCESS"
+                ),
+            ],
+            event_id="current",
+        )
+        result = _build_full_history([], local_history, current_event_id="current")
+
+        # The four chunks become a single assistant message, placed before the
+        # tool call — not four separate one-chunk messages.
+        assert len(result) == 3
+        assert isinstance(result[0], AgentTextSent)
+        assert result[0].content == "Let me verify that."
+        assert isinstance(result[1], AgentToolCalled)
+        assert isinstance(result[2], AgentToolReturned)
+
     async def test_only_local_history_with_observable_event_prior_excluded(self):
         """Prior local observable events without matching input are excluded."""
         # Prior events (event_id != current_event_id) with no input to match


### PR DESCRIPTION
## What does this PR do?

`_build_full_history` concatenates contiguous streamed `AgentSendText` chunks into a single `AgentTextSent` for **prior** turns (via `_concat_contiguous_agent_send_text`), but appended the **current** turn's chunks raw (`result.extend(current_local)`).

The LLM streams text as many small chunks. When a turn also makes a tool call (a loopback), the model's context for the post-tool response therefore contained its own just-produced pre-tool speech as a run of one-chunk assistant messages, rather than the single coherent turn every prior turn is represented as.

Concretely, the context for the response right after a tool call looked like:

**Before**
```
[assistant] 'Let'
[assistant] ' me'
[assistant] ' verify'
[assistant] ' that.'
[function_call] verify_otp(...)
```

**After**
```
[assistant] 'Let me verify that.'
[function_call] verify_otp(...)
```

Fix: apply `_concat_contiguous_agent_send_text` to `current_local` before extending, so the current turn is represented exactly like prior turns.

## Type of change
- [x] Bug fix

## Testing
Added `TestBuildFullHistory::test_current_turn_agent_send_text_chunks_are_concatenated` in `tests/test_llm_agent_history.py`: it streams a multi-chunk preamble followed by a tool call in the current turn and asserts the chunks collapse to one `AgentTextSent` placed before the tool call. Confirmed the test **fails** on the pre-fix code (chunks stay fragmented, `6 != 3`) and **passes** with the fix. Full unit suite green (`pytest tests/test_*.py` → 613 passed); `make format` clean.

## Checklist
- [x] I have read the contributing guidelines
- [x] I have added tests that prove my fix is effective
- [x] I have formatted my code with `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
