### PR TITLE
Keenable integration example

### DIFF
--- a/example_integrations/keenable/README.md
+++ b/example_integrations/keenable/README.md
@@ -1,0 +1,77 @@
+# Web Research Agent with Keenable
+
+A voice agent that searches the web and fetches page content using the [Keenable](https://keenable.ai) API, then synthesizes results into conversational responses. Keenable is a search API built for AI agents, **keyless by default**: the agent works with no API key against the public endpoints (rate-limited); set `KEENABLE_API_KEY` to lift the cap.
+
+## Setup
+
+### Prerequisites
+
+- [OpenAI API key](https://platform.openai.com/api-keys)
+- A Keenable API key is **optional** (keyless works out of the box); get one at [keenable.ai/console](https://keenable.ai/console) to lift the rate limit.
+
+### Environment Variables
+
+Create a `.env` file:
+
+```bash
+OPENAI_API_KEY=your-openai-key
+# Optional — keyless by default:
+# KEENABLE_API_KEY=keen_...
+```
+
+### Installation
+
+```bash
+uv sync
+```
+
+## Running
+
+```bash
+python main.py
+```
+
+Then connect:
+
+```bash
+cartesia chat 8000
+```
+
+## How It Works
+
+Everything is in `main.py`:
+
+1. **`web_search`** - A `@loopback_tool` that calls Keenable Search and returns formatted results to the LLM
+2. **`web_fetch`** - A `@loopback_tool` that fetches the full content of a webpage by URL as clean text, useful for deep-diving into a promising search result
+3. **`get_agent`** - Creates an `LlmAgent` with both tools and a voice-optimized system prompt
+4. **`VoiceAgentApp`** - Handles the voice connection
+
+Both tools share a single `httpx.AsyncClient`. No provider SDK is required — the agent calls the Keenable HTTP API directly, selecting the public (keyless) or authenticated endpoint based on whether `KEENABLE_API_KEY` is set.
+
+## Configuration
+
+### Search
+
+`web_search` posts to `POST /v1/search/public` (keyless) or `POST /v1/search` (with an `X-API-Key` header when `KEENABLE_API_KEY` is set):
+
+```python
+payload = {"query": query, "mode": "pro"}
+# optional: payload["published_after"] = "2026-01-01"
+```
+
+Results are trimmed to the first 5 for voice-friendly latency. You can extend the tool with Keenable filters such as `site`, `published_after` / `published_before`, and `acquired_after` / `acquired_before`.
+
+### Fetch
+
+`web_fetch` calls `GET /v1/fetch/public?url=...` (keyless) or `GET /v1/fetch?url=...` (keyed) and returns the page's main content as markdown, truncated to 3000 characters to keep LLM context manageable (adjust `FETCH_MAX_CHARS` in `main.py`).
+
+### LLM Configuration
+
+```python
+LlmConfig(
+    system_prompt=SYSTEM_PROMPT,
+    introduction=INTRODUCTION,
+    max_tokens=600,
+    temperature=0.7,
+)
+```

--- a/example_integrations/keenable/main.py
+++ b/example_integrations/keenable/main.py
@@ -1,0 +1,177 @@
+"""Web Research Agent with Keenable and Cartesia Line SDK.
+
+Keenable is keyless by default: with no API key the agent calls the public
+endpoints (rate-limited). Set KEENABLE_API_KEY to switch to the authenticated
+endpoints and lift the rate limit.
+"""
+
+from datetime import datetime
+import os
+from typing import Annotated, Optional
+
+import httpx
+from loguru import logger
+
+from line.llm_agent import LlmAgent, LlmConfig, ToolEnv, end_call, loopback_tool
+from line.voice_agent_app import AgentEnv, CallRequest, VoiceAgentApp
+
+KEENABLE_BASE_URL = "https://api.keenable.ai"
+
+SYSTEM_PROMPT_TEMPLATE = """Today is {today}. You are a sharp, fast research assistant on a live voice call.
+
+You have two web tools powered by Keenable:
+
+1. web_search — Find relevant pages across the web. Use for questions about current events, \
+facts, prices, people, or anything that needs fresh data. Start here for most questions.
+
+2. web_fetch — Pull the full content from a specific URL as clean text. Use when a search \
+snippet is too thin to answer confidently, or when the user mentions a specific link.
+
+Your workflow: search first, scan the snippets. If you can answer from snippets alone, do it \
+immediately. If a result looks right but you need more detail, fetch that page and then answer. \
+Don't fetch unless you need to.
+
+When answering:
+- Lead with the answer, not the preamble. No "Great question" or "Let me look that up."
+- Keep it to two or three sentences unless the user asks you to go deeper.
+- Name your source naturally when it matters. "According to Reuters" beats rattling off URLs.
+- If results conflict or seem stale, say so. Don't fake confidence.
+- If you genuinely can't find it, say that and suggest how the user could refine.
+
+Use end_call when the user wraps up.
+
+CRITICAL: This is a voice call. Speak in plain, natural sentences only. No markdown, no bullet \
+points, no numbered lists, no asterisks, no dashes, no special characters of any kind."""
+
+INTRODUCTION = (
+    "Hey! I'm your research assistant, powered by Keenable and Cartesia. "
+    "Ask me anything and I'll dig it up live. What do you want to know?"
+)
+
+MAX_OUTPUT_TOKENS = 600
+TEMPERATURE = 0.7
+MAX_RESULTS = 5
+FETCH_MAX_CHARS = 3000
+
+
+class KeenableTools:
+    """Holds a single httpx.AsyncClient so the connection pool is reused across
+    tool calls. Keyless by default; an optional API key lifts the rate limit."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        self._api_key = (api_key or "").strip()
+        self._client = httpx.AsyncClient(timeout=15.0)
+
+    def _headers(self) -> dict:
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "keenable-cartesia-line",
+            "X-Keenable-Title": "Cartesia Line",
+        }
+        if self._api_key:
+            headers["X-API-Key"] = self._api_key
+        return headers
+
+    @loopback_tool
+    async def web_search(
+        self,
+        ctx: ToolEnv,
+        query: Annotated[
+            str,
+            "The search query. Be specific and include key terms.",
+        ],
+        published_after: Annotated[
+            Optional[str],
+            "Optional date filter (YYYY-MM-DD). Only return pages published on or after this date.",
+        ] = None,
+    ) -> str:
+        """Search the web for current information.
+        Use when you need up-to-date facts, news, or any information that requires factual accuracy."""
+        logger.info(f"Performing Keenable web search: '{query}'")
+
+        path = "/v1/search" if self._api_key else "/v1/search/public"
+        payload: dict = {"query": query, "mode": "pro"}
+        if published_after is not None:
+            payload["published_after"] = published_after
+
+        try:
+            resp = await self._client.post(
+                f"{KEENABLE_BASE_URL}{path}", json=payload, headers=self._headers()
+            )
+            resp.raise_for_status()
+            results = resp.json().get("results", [])[:MAX_RESULTS]
+            if not results:
+                return "No relevant information found."
+
+            parts = [f"Search Results for: '{query}'\n"]
+            for i, result in enumerate(results):
+                parts.append(f"\n--- Source {i + 1}: {result.get('title', 'Untitled')} ---\n")
+                if result.get("description"):
+                    parts.append(f"{result['description']}\n")
+                parts.append(f"URL: {result.get('url', '')}\n")
+
+            logger.info(f"Search completed: {len(results)} sources found")
+            return "".join(parts)
+
+        except Exception as e:
+            logger.error(f"Keenable search failed: {e}")
+            return f"Web search failed: {e}"
+
+    @loopback_tool
+    async def web_fetch(
+        self,
+        ctx: ToolEnv,
+        url: Annotated[
+            str,
+            "The URL to fetch content from.",
+        ],
+    ) -> str:
+        """Fetch the full content of a webpage given its URL, as clean text.
+        Use when you need detailed information from a specific page found via web_search."""
+        logger.info(f"Fetching content from: '{url}'")
+
+        path = "/v1/fetch" if self._api_key else "/v1/fetch/public"
+        try:
+            resp = await self._client.get(
+                f"{KEENABLE_BASE_URL}{path}", params={"url": url}, headers=self._headers()
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            content = data.get("content", "")
+            if not content:
+                return "The page was reached but no readable content was found."
+
+            if len(content) > FETCH_MAX_CHARS:
+                content = content[:FETCH_MAX_CHARS] + "\n\n[Content truncated]"
+
+            logger.info(f"Fetch completed: {len(content)} characters from {url}")
+            title = data.get("title", "")
+            header = f"{title}\n\n" if title else ""
+            return f"Content from {url}:\n\n{header}{content}"
+
+        except Exception as e:
+            logger.error(f"Keenable fetch failed: {e}")
+            return f"Content fetch failed: {e}"
+
+
+async def get_agent(env: AgentEnv, call_request: CallRequest):
+    today = datetime.now().strftime("%Y-%m-%d")
+    # Keenable is keyless by default; KEENABLE_API_KEY is optional (lifts the rate limit).
+    keenable = KeenableTools(api_key=os.environ.get("KEENABLE_API_KEY"))
+    return LlmAgent(
+        model="openai/gpt-4o-mini",
+        api_key=os.getenv("OPENAI_API_KEY"),
+        tools=[keenable.web_search, keenable.web_fetch, end_call],
+        config=LlmConfig(
+            system_prompt=SYSTEM_PROMPT_TEMPLATE.format(today=today),
+            introduction=INTRODUCTION,
+            max_tokens=MAX_OUTPUT_TOKENS,
+            temperature=TEMPERATURE,
+        ),
+    )
+
+
+app = VoiceAgentApp(get_agent=get_agent)
+
+if __name__ == "__main__":
+    app.run()

--- a/example_integrations/keenable/main.py
+++ b/example_integrations/keenable/main.py
@@ -52,6 +52,9 @@ MAX_OUTPUT_TOKENS = 600
 TEMPERATURE = 0.7
 MAX_RESULTS = 5
 FETCH_MAX_CHARS = 3000
+# Keenable returns whole-page text on every search result; a voice turn only
+# needs enough to decide whether to fetch the page.
+SNIPPET_MAX_CHARS = 500
 
 
 class KeenableTools:
@@ -106,8 +109,13 @@ class KeenableTools:
             parts = [f"Search Results for: '{query}'\n"]
             for i, result in enumerate(results):
                 parts.append(f"\n--- Source {i + 1}: {result.get('title', 'Untitled')} ---\n")
-                if result.get("description"):
-                    parts.append(f"{result['description']}\n")
+                # Keenable returns both `snippet` and `description`: `snippet` carries
+                # the page text and `description` is the page's meta description,
+                # which is empty for most pages.
+                page_text = str(result.get("snippet") or result.get("description") or "")
+                snippet = " ".join(page_text.split())[:SNIPPET_MAX_CHARS]
+                if snippet:
+                    parts.append(f"{snippet}\n")
                 parts.append(f"URL: {result.get('url', '')}\n")
 
             logger.info(f"Search completed: {len(results)} sources found")

--- a/example_integrations/keenable/pyproject.toml
+++ b/example_integrations/keenable/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "keenable-web-search"
+version = "0.1.0"
+description = "A web research voice agent using the Keenable API and Cartesia Line SDK (keyless by default)"
+requires-python = ">=3.10"
+dependencies = [
+    "cartesia-line==0.2.16",
+    "httpx>=0.27",
+    "loguru>=0.7.3",
+    "python-dotenv>=1.2.2",
+]
+
+[project.scripts]
+keenable-search = "main:app.run"


### PR DESCRIPTION
## What does this PR do?

Adds a new example integration under `example_integrations/keenable/` that demonstrates a voice agent doing real-time web research with the [Keenable](https://keenable.ai) API, mirroring the existing Tavily example.

The agent exposes two `@loopback_tool`s:
- **`web_search`** — posts to Keenable's search API for low-latency, voice-friendly web lookups, with an optional `published_after` date filter.
- **`web_fetch`** — fetches the full content of a URL as clean markdown for deep-diving into a promising result.

## Why Keenable

Keenable is a search API built for AI agents. Unlike most search providers it is **keyless by default**: the example works with no API key against the public endpoints (rate-limited), so it runs out of the box. Setting `KEENABLE_API_KEY` switches to the authenticated endpoints and lifts the cap. No provider SDK is needed — the tools share a single `httpx.AsyncClient`.

## Notes

- Follows the structure of `example_integrations/tavily/` (README, `main.py`, `pyproject.toml`, `cartesia.toml`).
- `ruff check` passes; `python -m py_compile` clean.