### PR TITLE
Don't let malformed tool-call streams or histories kill the turn

### DIFF
--- a/line/llm_agent/http_provider.py
+++ b/line/llm_agent/http_provider.py
@@ -275,48 +275,88 @@ class _ArgState(NamedTuple):
 
 
 def _enforce_tool_adjacency(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Drop tool messages that don't follow an assistant message declaring them.
+    """Repair the tool-call pairing invariant on the final chat-completions payload.
 
     Chat-completions providers (OpenAI in particular) reject the whole request
-    with a 400 ("messages with role 'tool' must be a response to a preceeding
-    message with 'tool_calls'") when a ``role: "tool"`` message is not part of
-    the tool-response block immediately after the assistant message whose
-    ``tool_calls`` declared its ``tool_call_id``. ``_normalize_messages``
-    guards the known corruption paths upstream, but a violating sequence
-    observed in production still occasionally reaches the payload — and a 400
-    here kills the entire turn. Enforce the invariant on the final payload:
-    drop the offending tool message (degrading one tool result) and log the
-    role/``tool_call_id`` shape of the conversation so the upstream bug can be
+    with a 400 when the assistant ``tool_calls`` / ``role: "tool"`` pairing is
+    broken, in *either* direction:
+
+    * a ``role: "tool"`` message that is not part of the tool-response block
+      immediately after the assistant message whose ``tool_calls`` declared its
+      ``tool_call_id`` ("messages with role 'tool' must be a response to a
+      preceeding message with 'tool_calls'"), and
+    * an assistant ``tool_calls`` entry with no matching tool response ("an
+      assistant message with 'tool_calls' must be followed by tool messages
+      responding to each 'tool_call_id'").
+
+    ``_normalize_messages`` repairs the known corruption paths upstream, but a
+    violating sequence observed in production still occasionally reaches the
+    payload — and a 400 here kills the entire turn. Enforce the invariant on
+    the final payload by dropping the unmatched entries on *both* sides so the
+    request stays well-formed (degrading a tool exchange instead of the turn),
+    and log the role/``tool_call_id`` shape so the upstream bug can be
     root-caused from the warning alone.
     """
     validated: List[Dict[str, Any]] = []
-    block_ids: set = set()
     dropped = False
+    i = 0
+    n = len(messages)
 
-    for msg in messages:
-        if msg.get("role") == "tool":
-            if msg.get("tool_call_id") in block_ids:
-                validated.append(msg)
-            else:
+    while i < n:
+        msg = messages[i]
+        role = msg.get("role")
+
+        if role == "assistant" and msg.get("tool_calls"):
+            # Gather the contiguous run of tool messages immediately following;
+            # that run is the only place a valid response for this block can be.
+            j = i + 1
+            following_tools: List[Dict[str, Any]] = []
+            while j < n and messages[j].get("role") == "tool":
+                following_tools.append(messages[j])
+                j += 1
+
+            declared_ids = {tc.get("id") for tc in msg["tool_calls"]}
+            responded_ids = {t.get("tool_call_id") for t in following_tools}
+
+            kept_calls = [tc for tc in msg["tool_calls"] if tc.get("id") in responded_ids]
+            kept_tools = [t for t in following_tools if t.get("tool_call_id") in declared_ids]
+
+            if len(kept_calls) != len(msg["tool_calls"]) or len(kept_tools) != len(following_tools):
                 dropped = True
-                logger.warning(
-                    f"Dropping tool message (tool_call_id={msg.get('tool_call_id')!r}, "
-                    f"name={msg.get('name')!r}) not preceded by a matching tool_calls "
-                    "assistant message; the provider would reject the whole request"
-                )
+
+            if kept_calls:
+                validated.append({**msg, "tool_calls": kept_calls})
+            else:
+                # No surviving tool calls: keep the assistant turn only if it
+                # still carries text, otherwise drop it (an assistant message
+                # with neither content nor tool_calls is itself invalid).
+                stripped = {k: v for k, v in msg.items() if k != "tool_calls"}
+                content = stripped.get("content")
+                if content is not None and str(content).strip():
+                    validated.append(stripped)
+            validated.extend(kept_tools)
+            i = j
             continue
-        # Any non-tool message starts a new adjacency block.
-        block_ids = (
-            {tc.get("id") for tc in msg.get("tool_calls", [])} if msg.get("role") == "assistant" else set()
-        )
+
+        if role == "tool":
+            # Any tool message reached here is not immediately preceded by an
+            # assistant tool_calls block (those are consumed above) — an orphan.
+            dropped = True
+            i += 1
+            continue
+
         validated.append(msg)
+        i += 1
 
     if dropped:
         shape = [
             (m.get("role"), m.get("tool_call_id") or [tc.get("id") for tc in m.get("tool_calls", [])])
             for m in messages
         ][:50]
-        logger.warning(f"Conversation shape at tool-adjacency violation (role, tool ids): {shape}")
+        logger.warning(
+            "Repaired broken tool-call pairing before send (dropped unmatched "
+            f"tool_calls and/or tool messages); conversation shape (role, tool ids): {shape}"
+        )
 
     return validated
 

--- a/line/llm_agent/http_provider.py
+++ b/line/llm_agent/http_provider.py
@@ -147,7 +147,7 @@ class _HttpProvider:
                     llm_msg["name"] = msg.name
 
             result.append(llm_msg)
-        return result
+        return _enforce_tool_adjacency(result)
 
     async def warmup(
         self,
@@ -272,6 +272,53 @@ class _ArgState(NamedTuple):
     depth: int
     in_string: bool
     escape_next: bool
+
+
+def _enforce_tool_adjacency(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop tool messages that don't follow an assistant message declaring them.
+
+    Chat-completions providers (OpenAI in particular) reject the whole request
+    with a 400 ("messages with role 'tool' must be a response to a preceeding
+    message with 'tool_calls'") when a ``role: "tool"`` message is not part of
+    the tool-response block immediately after the assistant message whose
+    ``tool_calls`` declared its ``tool_call_id``. ``_normalize_messages``
+    guards the known corruption paths upstream, but a violating sequence
+    observed in production still occasionally reaches the payload — and a 400
+    here kills the entire turn. Enforce the invariant on the final payload:
+    drop the offending tool message (degrading one tool result) and log the
+    role/``tool_call_id`` shape of the conversation so the upstream bug can be
+    root-caused from the warning alone.
+    """
+    validated: List[Dict[str, Any]] = []
+    block_ids: set = set()
+    dropped = False
+
+    for msg in messages:
+        if msg.get("role") == "tool":
+            if msg.get("tool_call_id") in block_ids:
+                validated.append(msg)
+            else:
+                dropped = True
+                logger.warning(
+                    f"Dropping tool message (tool_call_id={msg.get('tool_call_id')!r}, "
+                    f"name={msg.get('name')!r}) not preceded by a matching tool_calls "
+                    "assistant message; the provider would reject the whole request"
+                )
+            continue
+        # Any non-tool message starts a new adjacency block.
+        block_ids = (
+            {tc.get("id") for tc in msg.get("tool_calls", [])} if msg.get("role") == "assistant" else set()
+        )
+        validated.append(msg)
+
+    if dropped:
+        shape = [
+            (m.get("role"), m.get("tool_call_id") or [tc.get("id") for tc in m.get("tool_calls", [])])
+            for m in messages
+        ]
+        logger.warning(f"Conversation shape at tool-adjacency violation (role, tool ids): {shape}")
+
+    return validated
 
 
 def _tool_args_complete(state: Optional[_ArgState]) -> bool:

--- a/line/llm_agent/http_provider.py
+++ b/line/llm_agent/http_provider.py
@@ -315,7 +315,7 @@ def _enforce_tool_adjacency(messages: List[Dict[str, Any]]) -> List[Dict[str, An
         shape = [
             (m.get("role"), m.get("tool_call_id") or [tc.get("id") for tc in m.get("tool_calls", [])])
             for m in messages
-        ]
+        ][:50]
         logger.warning(f"Conversation shape at tool-adjacency violation (role, tool ids): {shape}")
 
     return validated

--- a/line/llm_agent/http_provider.py
+++ b/line/llm_agent/http_provider.py
@@ -14,6 +14,7 @@ import inspect
 from typing import Any, AsyncIterator, Dict, List, NamedTuple, Optional, Protocol, cast
 
 from litellm import acompletion
+from loguru import logger
 
 from line.llm_agent.config import LlmConfig
 from line.llm_agent.provider import Message, ParsedModelId, StreamChunk, ToolCall
@@ -236,8 +237,20 @@ class _ChatStream:
                 if chunk.choices and chunk.choices[0].finish_reason:
                     finish_reason = chunk.choices[0].finish_reason
                     if finish_reason in ("tool_calls", "stop"):
-                        for tc in tool_calls.values():
-                            tc.is_complete = True
+                        for idx, tc in tool_calls.items():
+                            # A terminal finish reason does not guarantee the argument
+                            # stream was fully delivered (e.g. "stop" after truncation
+                            # or a cut stream). Only mark the call complete when the
+                            # accumulated arguments form complete JSON; otherwise the
+                            # partial args would fail json.loads downstream.
+                            if _tool_args_complete(arg_states.get(idx)):
+                                tc.is_complete = True
+                            else:
+                                logger.warning(
+                                    f"Tool call {tc.name or '<unnamed>'} (id={tc.id or '<no id>'}) "
+                                    f"has incomplete arguments at finish_reason={finish_reason}; "
+                                    "leaving it incomplete so it is skipped"
+                                )
 
                 yield StreamChunk(
                     text=text,
@@ -259,6 +272,19 @@ class _ArgState(NamedTuple):
     depth: int
     in_string: bool
     escape_next: bool
+
+
+def _tool_args_complete(state: Optional[_ArgState]) -> bool:
+    """Whether accumulated tool-call arguments form complete JSON.
+
+    ``None`` means no argument fragments were streamed at all — that is a
+    complete no-arg call (downstream treats empty arguments as ``{}``).
+    Otherwise the brace-depth tracking from ``_feed_tool_args`` tells us if
+    the object was closed and we are not mid-string.
+    """
+    if state is None:
+        return True
+    return state.depth == 0 and not state.in_string
 
 
 def _feed_tool_args(state: Optional[_ArgState], fragment: str) -> _ArgState:

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -402,7 +402,8 @@ class LlmAgent:
                     continue
 
                 try:
-                    tool_args = json.loads(tc.arguments) if tc.arguments.strip() else {}
+                    raw = tc.arguments or ""
+                    tool_args = json.loads(raw) if raw.strip() else {}
                 except json.JSONDecodeError as e:
                     # Malformed arguments (e.g. a truncated stream) must not kill the
                     # whole turn — skip this tool call and keep responding.

--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -401,7 +401,16 @@ class LlmAgent:
                     logger.warning(f"Unknown tool: {tc.name}")
                     continue
 
-                tool_args = json.loads(tc.arguments) if tc.arguments else {}
+                try:
+                    tool_args = json.loads(tc.arguments) if tc.arguments.strip() else {}
+                except json.JSONDecodeError as e:
+                    # Malformed arguments (e.g. a truncated stream) must not kill the
+                    # whole turn — skip this tool call and keep responding.
+                    logger.warning(
+                        f"Skipping tool call {tc.name} (id={tc.id}): "
+                        f"malformed arguments ({e}): {tc.arguments[:200]!r}"
+                    )
+                    continue
 
                 normalized_func = _normalize_to_async_gen(tool.func)
 

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -188,6 +188,28 @@ def _normalize_messages(messages: List["Message"]) -> Optional[List["Message"]]:
         logger.warning("Skipping LLM call: last user message must be non-empty")
         return None
 
+    # 5. Observe-only sentinel (see _enforce_tool_adjacency in http_provider,
+    # which *enforces* this invariant on the final payload). By construction the
+    # pairing/reordering above should make a violation here impossible — so if
+    # this warning ever fires, the corruption originates inside this function;
+    # if only the payload-side guard fires, the request bypassed Provider.chat.
+    # Together the two probes localize the upstream bug behind the provider 400
+    # "messages with role 'tool' must be a response to a preceeding message
+    # with 'tool_calls'". Log-only on purpose: this function's contract is
+    # repair, the serializer's is enforcement.
+    block_ids: set = set()
+    for msg in result:
+        if msg.role == "tool":
+            if msg.tool_call_id not in block_ids:
+                shape = [(m.role, m.tool_call_id or [tc.id for tc in (m.tool_calls or [])]) for m in result]
+                logger.warning(
+                    f"_normalize_messages produced an orphan tool message "
+                    f"(tool_call_id={msg.tool_call_id!r}, name={msg.name!r}) — normalization bug; "
+                    f"shape: {shape}"
+                )
+            continue
+        block_ids = {tc.id for tc in (msg.tool_calls or [])} if msg.role == "assistant" else set()
+
     return result
 
 

--- a/line/llm_agent/provider.py
+++ b/line/llm_agent/provider.py
@@ -658,6 +658,7 @@ def _supports_http_responses(model_id: ParsedModelId) -> bool:
     try:
         return get_model_info(model=model_id.model).get("mode") != "completion"
     except Exception:
+        logger.debug(f"get_model_info({model_id.model!r}) failed; assuming chat-capable")
         return True
 
 

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -2230,3 +2230,87 @@ async def test_background_tool_responding_to_references_triggering_event(turn_en
         assert evt.responding_to == "evt-A", (
             f"AgentToolReturned responding_to should be 'evt-A', got '{evt.responding_to}'"
         )
+
+
+# =============================================================================
+# Tests: Malformed tool-call arguments must not kill the turn
+# =============================================================================
+
+
+async def test_malformed_tool_arguments_skips_tool_without_crashing(turn_env):
+    """A tool call whose arguments are not valid JSON is skipped, not fatal.
+
+    Seen in production: a stream marked a truncated tool call complete, and the
+    unguarded json.loads raised out of agent.process, silencing the whole turn.
+    """
+    executed = []
+
+    @loopback_tool
+    async def get_weather(ctx, city: Annotated[str, "City name"]) -> str:
+        """Get weather for a city."""
+        executed.append(city)
+        return f"72°F in {city}"
+
+    responses = [
+        [
+            StreamChunk(text="Let me check. "),
+            StreamChunk(
+                tool_calls=[
+                    ToolCall(
+                        id="call_1",
+                        name="get_weather",
+                        arguments='{"city": "NY',  # truncated JSON
+                        is_complete=True,
+                    )
+                ]
+            ),
+            StreamChunk(is_final=True),
+        ],
+    ]
+
+    agent, mock_llm = create_agent_with_mock(responses, tools=[get_weather])
+
+    # Must not raise
+    outputs = await collect_outputs(
+        agent,
+        turn_env,
+        UserTextSent(content="Weather?", history=[UserTextSent(content="Weather?")]),
+    )
+
+    # The tool never ran, but the text generated before the bad call was emitted.
+    assert executed == []
+    text_outputs = [o for o in outputs if isinstance(o, AgentSendText)]
+    assert any("Let me check." in o.text for o in text_outputs)
+
+
+async def test_whitespace_only_tool_arguments_treated_as_empty(turn_env):
+    """Whitespace-only arguments parse as {} instead of raising JSONDecodeError."""
+    executed = []
+
+    @loopback_tool
+    async def ping(ctx) -> str:
+        """No-arg tool."""
+        executed.append(True)
+        return "pong"
+
+    responses = [
+        [
+            StreamChunk(tool_calls=[ToolCall(id="call_1", name="ping", arguments="  ", is_complete=True)]),
+            StreamChunk(is_final=True),
+        ],
+        [
+            StreamChunk(text="Done."),
+            StreamChunk(is_final=True),
+        ],
+    ]
+
+    agent, mock_llm = create_agent_with_mock(responses, tools=[ping])
+
+    outputs = await collect_outputs(
+        agent,
+        turn_env,
+        UserTextSent(content="Ping", history=[UserTextSent(content="Ping")]),
+    )
+
+    assert executed == [True]
+    assert any(isinstance(o, AgentSendText) and o.text == "Done." for o in outputs)

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import Annotated, Any, List, Optional, get_type_hints
 
 from line.llm_agent.config import LlmConfig, _normalize_config
-from line.llm_agent.http_provider import _feed_tool_args, _HttpProvider
+from line.llm_agent.http_provider import _feed_tool_args, _HttpProvider, _tool_args_complete
 from line.llm_agent.provider import (
     ChatStream,
     LlmProvider,
@@ -1072,3 +1072,43 @@ class TestNormalizeMessages:
         assert len(tool_msgs) == 2
         assert tool_msgs[0].content == "first"
         assert tool_msgs[1].content == "second"
+
+
+# ---------------------------------------------------------------------------
+# _tool_args_complete
+# ---------------------------------------------------------------------------
+
+
+class TestToolArgsComplete:
+    """Completeness gating for streamed tool-call arguments at stream end.
+
+    A terminal finish_reason (including "stop") must not mark a tool call
+    complete when its argument stream was cut mid-object — the partial JSON
+    would crash json.loads downstream and kill the turn.
+    """
+
+    def test_no_fragments_is_complete(self):
+        # A tool call that never streamed arguments is a valid no-arg call.
+        assert _tool_args_complete(None) is True
+
+    def test_complete_object(self):
+        state = _feed_tool_args(None, '{"city": "Tokyo"}')
+        assert _tool_args_complete(state) is True
+
+    def test_truncated_mid_object(self):
+        state = _feed_tool_args(None, '{"city": ')
+        assert _tool_args_complete(state) is False
+
+    def test_truncated_mid_string(self):
+        state = _feed_tool_args(None, '{"city": "Tok')
+        assert _tool_args_complete(state) is False
+
+    def test_complete_after_many_fragments(self):
+        state = None
+        for frag in ["{", '"query"', ": ", '"orari"', "}"]:
+            state = _feed_tool_args(state, frag)
+        assert _tool_args_complete(state) is True
+
+    def test_empty_object_is_complete(self):
+        state = _feed_tool_args(None, "{}")
+        assert _tool_args_complete(state) is True

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -1203,3 +1203,52 @@ class TestEnforceToolAdjacency:
         ]
         result = _enforce_tool_adjacency(messages)
         assert [m["role"] for m in result] == ["user"]
+
+
+class TestNormalizeOutputAdjacency:
+    """The observe-only sentinel at the end of _normalize_messages.
+
+    Normalization's pairing/reordering should make adjacency violations in its
+    output impossible; these tests feed it the corruption shapes seen upstream
+    and assert the output satisfies the invariant (and thus that the sentinel
+    stays silent on everything we know how to construct).
+    """
+
+    def _adjacency_holds(self, messages):
+        block_ids = set()
+        for msg in messages:
+            if msg.role == "tool":
+                if msg.tool_call_id not in block_ids:
+                    return False
+                continue
+            block_ids = {tc.id for tc in (msg.tool_calls or [])} if msg.role == "assistant" else set()
+        return True
+
+    def test_orphan_tool_response_output_is_valid(self):
+        result = _normalize_messages(
+            [
+                Message(role="user", content="hi"),
+                Message(role="tool", content="orphan", tool_call_id="ghost", name="t"),
+                Message(role="user", content="still there?"),
+            ]
+        )
+        assert result is not None
+        assert self._adjacency_holds(result)
+
+    def test_displaced_and_duplicated_responses_output_is_valid(self):
+        result = _normalize_messages(
+            [
+                Message(role="user", content="go"),
+                Message(role="tool", content="early", tool_call_id="x1", name="t"),
+                Message(
+                    role="assistant",
+                    content=None,
+                    tool_calls=[ToolCall(id="x1", name="t", arguments="{}")],
+                ),
+                Message(role="assistant", content="text in between"),
+                Message(role="tool", content="late dup", tool_call_id="x1", name="t"),
+                Message(role="user", content="and?"),
+            ]
+        )
+        assert result is not None
+        assert self._adjacency_holds(result)

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -1125,11 +1125,14 @@ class TestToolArgsComplete:
 
 
 class TestEnforceToolAdjacency:
-    """Final-payload guard against tool messages OpenAI would 400 on.
+    """Final-payload guard against broken tool-call pairing OpenAI would 400 on.
 
     Seen in production as `openai.BadRequestError: messages with role 'tool'
     must be a response to a preceeding message with 'tool_calls'`, which kills
-    the whole turn. The guard drops the offending tool message instead.
+    the whole turn. The guard repairs the pairing in *both* directions so the
+    payload stays well-formed: it drops orphan tool messages AND strips
+    assistant tool_calls that never get a matching response (which OpenAI also
+    rejects).
     """
 
     def _assistant(self, *ids, content=None):
@@ -1141,6 +1144,33 @@ class TestEnforceToolAdjacency:
                 {"id": i, "type": "function", "function": {"name": "t", "arguments": "{}"}} for i in ids
             ]
         return msg
+
+    def _pairing_valid(self, messages) -> bool:
+        """Both directions of OpenAI's tool-call pairing rule hold."""
+        for idx, m in enumerate(messages):
+            if m.get("role") == "tool":
+                # walk back over the contiguous tool run to the assistant
+                k = idx
+                while k > 0 and messages[k].get("role") == "tool":
+                    k -= 1
+                anchor = messages[k]
+                declared = (
+                    {tc.get("id") for tc in anchor.get("tool_calls", [])}
+                    if anchor.get("role") == "assistant"
+                    else set()
+                )
+                if m.get("tool_call_id") not in declared:
+                    return False
+            if m.get("role") == "assistant" and m.get("tool_calls"):
+                declared = {tc.get("id") for tc in m["tool_calls"]}
+                responded = set()
+                k = idx + 1
+                while k < len(messages) and messages[k].get("role") == "tool":
+                    responded.add(messages[k].get("tool_call_id"))
+                    k += 1
+                if declared - responded:
+                    return False
+        return True
 
     def test_valid_sequence_untouched(self):
         messages = [
@@ -1177,15 +1207,48 @@ class TestEnforceToolAdjacency:
         result = _enforce_tool_adjacency(messages)
         assert [m["role"] for m in result] == ["user", "assistant"]
 
-    def test_tool_after_plain_assistant_dropped(self):
+    def test_tool_after_plain_assistant_repaired_both_sides(self):
         # An assistant message WITHOUT tool_calls in between breaks the block.
+        # The displaced tool message must be dropped AND the now-unanswered
+        # tool_calls stripped — leaving the dangling call would still 400.
+        # (Regression for the Bugbot finding on this shape.)
         messages = [
             self._assistant("x1"),
             self._assistant(content="interrupting text"),
             {"role": "tool", "content": "late", "tool_call_id": "x1"},
         ]
         result = _enforce_tool_adjacency(messages)
-        assert [m["role"] for m in result] == ["assistant", "assistant"]
+        # Only the plain-text assistant survives; no dangling tool_calls, no orphan tool.
+        assert [m["role"] for m in result] == ["assistant"]
+        assert result[0].get("content") == "interrupting text"
+        assert all("tool_calls" not in m for m in result)
+        assert self._pairing_valid(result)
+
+    def test_assistant_with_content_and_dangling_call_keeps_text(self):
+        # Assistant carries text AND an unanswered tool call: keep the text,
+        # strip the unanswered call.
+        messages = [
+            {"role": "user", "content": "hi"},
+            {**self._assistant("x1"), "content": "let me check"},
+        ]
+        result = _enforce_tool_adjacency(messages)
+        assert [m["role"] for m in result] == ["user", "assistant"]
+        assert result[1]["content"] == "let me check"
+        assert "tool_calls" not in result[1]
+        assert self._pairing_valid(result)
+
+    def test_partial_block_keeps_answered_strips_unanswered(self):
+        # x1 answered, x2 not: keep x1 + its response, drop x2 from the call list.
+        messages = [
+            self._assistant("x1", "x2"),
+            {"role": "tool", "content": "ok", "tool_call_id": "x1"},
+        ]
+        result = _enforce_tool_adjacency(messages)
+        assert result[0]["tool_calls"] == [
+            {"id": "x1", "type": "function", "function": {"name": "t", "arguments": "{}"}}
+        ]
+        assert [m.get("tool_call_id") for m in result if m["role"] == "tool"] == ["x1"]
+        assert self._pairing_valid(result)
 
     def test_tool_id_not_in_preceding_block_dropped(self):
         messages = [
@@ -1195,6 +1258,7 @@ class TestEnforceToolAdjacency:
         ]
         result = _enforce_tool_adjacency(messages)
         assert [m.get("tool_call_id") for m in result if m["role"] == "tool"] == ["x1"]
+        assert self._pairing_valid(result)
 
     def test_tool_as_first_message_dropped(self):
         messages = [
@@ -1203,6 +1267,16 @@ class TestEnforceToolAdjacency:
         ]
         result = _enforce_tool_adjacency(messages)
         assert [m["role"] for m in result] == ["user"]
+
+    def test_trailing_unanswered_call_stripped(self):
+        # Assistant tool_calls at the very end with no following tool response.
+        messages = [
+            {"role": "user", "content": "hi"},
+            self._assistant("x1"),
+        ]
+        result = _enforce_tool_adjacency(messages)
+        assert [m["role"] for m in result] == ["user"]
+        assert self._pairing_valid(result)
 
 
 class TestNormalizeOutputAdjacency:

--- a/tests/test_llm_agent_provider.py
+++ b/tests/test_llm_agent_provider.py
@@ -4,7 +4,12 @@ import asyncio
 from typing import Annotated, Any, List, Optional, get_type_hints
 
 from line.llm_agent.config import LlmConfig, _normalize_config
-from line.llm_agent.http_provider import _feed_tool_args, _HttpProvider, _tool_args_complete
+from line.llm_agent.http_provider import (
+    _enforce_tool_adjacency,
+    _feed_tool_args,
+    _HttpProvider,
+    _tool_args_complete,
+)
 from line.llm_agent.provider import (
     ChatStream,
     LlmProvider,
@@ -1112,3 +1117,89 @@ class TestToolArgsComplete:
     def test_empty_object_is_complete(self):
         state = _feed_tool_args(None, "{}")
         assert _tool_args_complete(state) is True
+
+
+# ---------------------------------------------------------------------------
+# _enforce_tool_adjacency
+# ---------------------------------------------------------------------------
+
+
+class TestEnforceToolAdjacency:
+    """Final-payload guard against tool messages OpenAI would 400 on.
+
+    Seen in production as `openai.BadRequestError: messages with role 'tool'
+    must be a response to a preceeding message with 'tool_calls'`, which kills
+    the whole turn. The guard drops the offending tool message instead.
+    """
+
+    def _assistant(self, *ids, content=None):
+        msg = {"role": "assistant"}
+        if content is not None:
+            msg["content"] = content
+        if ids:
+            msg["tool_calls"] = [
+                {"id": i, "type": "function", "function": {"name": "t", "arguments": "{}"}} for i in ids
+            ]
+        return msg
+
+    def test_valid_sequence_untouched(self):
+        messages = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "hi"},
+            self._assistant("x1"),
+            {"role": "tool", "content": "ok", "tool_call_id": "x1"},
+            self._assistant(content="done"),
+        ]
+        assert _enforce_tool_adjacency(list(messages)) == messages
+
+    def test_multiple_responses_same_id_kept(self):
+        messages = [
+            self._assistant("x1"),
+            {"role": "tool", "content": "first", "tool_call_id": "x1"},
+            {"role": "tool", "content": "second", "tool_call_id": "x1"},
+        ]
+        assert _enforce_tool_adjacency(list(messages)) == messages
+
+    def test_multiple_ids_one_block_kept(self):
+        messages = [
+            self._assistant("x1", "x2"),
+            {"role": "tool", "content": "a", "tool_call_id": "x2"},
+            {"role": "tool", "content": "b", "tool_call_id": "x1"},
+        ]
+        assert _enforce_tool_adjacency(list(messages)) == messages
+
+    def test_orphan_tool_message_dropped(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "content": "orphan", "tool_call_id": "ghost"},
+            self._assistant(content="hello"),
+        ]
+        result = _enforce_tool_adjacency(messages)
+        assert [m["role"] for m in result] == ["user", "assistant"]
+
+    def test_tool_after_plain_assistant_dropped(self):
+        # An assistant message WITHOUT tool_calls in between breaks the block.
+        messages = [
+            self._assistant("x1"),
+            self._assistant(content="interrupting text"),
+            {"role": "tool", "content": "late", "tool_call_id": "x1"},
+        ]
+        result = _enforce_tool_adjacency(messages)
+        assert [m["role"] for m in result] == ["assistant", "assistant"]
+
+    def test_tool_id_not_in_preceding_block_dropped(self):
+        messages = [
+            self._assistant("x1"),
+            {"role": "tool", "content": "ok", "tool_call_id": "x1"},
+            {"role": "tool", "content": "wrong block", "tool_call_id": "x2"},
+        ]
+        result = _enforce_tool_adjacency(messages)
+        assert [m.get("tool_call_id") for m in result if m["role"] == "tool"] == ["x1"]
+
+    def test_tool_as_first_message_dropped(self):
+        messages = [
+            {"role": "tool", "content": "orphan", "tool_call_id": "x1"},
+            {"role": "user", "content": "hi"},
+        ]
+        result = _enforce_tool_adjacency(messages)
+        assert [m["role"] for m in result] == ["user"]


### PR DESCRIPTION
## What does this PR do?
Fixes three related production failure modes where a malformed tool call kills the entire agent turn (the agent goes silent mid-call until the silence timeout hangs up). All were observed on a high-volume outbound agent (gpt-4o-mini + tools) as turn-aborting errors in `agent.process`.

1. **`_HttpProvider` marked partial tool calls complete.** On any terminal `finish_reason` — including `"stop"` — every accumulated tool call was set `is_complete=True`. A stream that ends mid-tool-call (truncation, cut stream) therefore delivered partial JSON arguments flagged as complete. Now a tool call is only marked complete when its accumulated arguments form complete JSON, reusing the brace-depth state `_feed_tool_args` already tracks (new `_tool_args_complete` helper); otherwise it's left incomplete (with a warning) so the existing `is_complete` guard in `LlmAgent` skips it. `"stop"` is kept in the terminal set since some OpenAI-compatible providers end tool-call turns with it.

2. **`LlmAgent` parsed tool arguments with an unguarded `json.loads`.** The `if tc.arguments` truthiness check only caught the empty string — whitespace-only or partial arguments raised `JSONDecodeError` out of `agent.process` (production: `Expecting value: line 1 column 1 (char 0)`), silencing the whole turn. Now malformed arguments log a warning and skip that one tool call (matching the existing unknown-tool pattern), and whitespace-only arguments are treated as no-arg calls.

3. **Corrupted tool-message ordering reached OpenAI as a hard 400.** Production also hit `openai.BadRequestError: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'` (27 occurrences/7 days), which aborts the turn. `_normalize_messages` guards the known corruption paths, but a violating sequence still occasionally reaches the payload. New `_enforce_tool_adjacency` pass validates the final payload `_HttpProvider` actually sends: any `role:"tool"` message whose `tool_call_id` is not declared by the immediately-preceding assistant block is dropped (worst case: one degraded tool result instead of a dead turn), and the guard logs the full role/`tool_call_id` shape of the conversation so the upstream history bug can be root-caused from the warning alone the next time it fires.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
- New unit tests:
  - `TestToolArgsComplete` in `tests/test_llm_agent_provider.py` — completeness gating for no-fragment, complete, mid-object-truncated, mid-string-truncated, and multi-fragment argument streams.
  - `TestEnforceToolAdjacency` in `tests/test_llm_agent_provider.py` — valid sequences pass through untouched (including multiple responses per id and multi-id blocks); orphan tool messages, tool-after-plain-assistant, wrong-block ids, and tool-as-first-message are dropped.
  - `test_malformed_tool_arguments_skips_tool_without_crashing` and `test_whitespace_only_tool_arguments_treated_as_empty` in `tests/test_llm_agent_llm_agent.py` — the turn survives, the bad tool call is skipped, prior text output still streams.
- Full unit suite passes: `uv run --extra dev python -m pytest tests/` → 631 passed.
- `ruff check` and `ruff format` clean on all touched files.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM request serialization and tool execution paths used on every tool turn; behavior degrades gracefully on failure but may drop tool calls or messages that previously caused hard failures.
> 
> **Overview**
> Fixes production cases where malformed tool calls **silenced the whole agent turn** instead of degrading gracefully.
> 
> **Stream completion:** Terminal `finish_reason` no longer blindly sets `is_complete` on tool calls. Completion now requires accumulated arguments to be valid JSON (`_tool_args_complete`); truncated streams stay incomplete and are skipped.
> 
> **Argument parsing:** `LlmAgent` wraps `json.loads` in try/except so bad or whitespace-only arguments skip that tool call instead of aborting `process`.
> 
> **HTTP payload:** `_enforce_tool_adjacency` runs on the outgoing chat-completions payload and drops orphan `tool` messages and unmatched assistant `tool_calls` so OpenAI 400s on broken pairing do not kill the turn. `_normalize_messages` adds a log-only sentinel to help localize upstream history bugs.
> 
> Tests cover completeness gating, adjacency repair, and malformed/whitespace arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5486359809be7a268d20a231b59f0ae433c8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->