### PR TITLE
Add Inception Mercury 2 example integration

### DIFF
--- a/example_integrations/inception/README.md
+++ b/example_integrations/inception/README.md
@@ -1,0 +1,133 @@
+# Quick-Service Ordering Agent with Inception Mercury 2
+
+A low-latency order-taking voice agent built on [Mercury 2](https://www.inceptionlabs.ai/blog/introducing-mercury-2), Inception Labs' diffusion large language model, and the Cartesia Line SDK.
+
+Mercury 2 generates over 1,000 tokens per second by refining all tokens in parallel instead of decoding them one at a time. On a live voice call that translates directly into lower time-to-first-token, so this example uses a use case where snappy turnaround matters: taking a coffee order with rapid back-and-forth and tool calls on nearly every turn.
+
+The [Inception API](https://docs.inceptionlabs.ai/) is OpenAI-compatible, so Mercury 2 plugs into `LlmAgent` through the SDK's HTTP/LiteLLM backend — no extra dependencies, just a custom `api_base`:
+
+```python
+LlmAgent(
+    model="openai/mercury-2",
+    api_key=os.environ["INCEPTION_API_KEY"],
+    config=LlmConfig(
+        ...,
+        extra={
+            "api_base": "https://api.inceptionlabs.ai/v1",
+            "extra_body": {"reasoning_effort": "instant"},
+        },
+    ),
+)
+```
+
+## Setup
+
+### Prerequisites
+
+- An [Inception API key](https://platform.inceptionlabs.ai/) (new accounts include free tokens)
+- A [Cartesia](https://play.cartesia.ai/agents) account and the Cartesia CLI:
+
+```bash
+curl -fsSL https://cartesia.sh | sh
+```
+
+### Environment Variables
+
+Create a `.env` file:
+
+```bash
+INCEPTION_API_KEY=your-inception-key
+```
+
+### Installation
+
+```bash
+# uv (recommended)
+uv sync
+# or with pip
+pip install -e .
+```
+
+## Running Locally
+
+1) Start the agent:
+
+```bash
+uv run python main.py
+```
+
+2) In another terminal, chat with the agent in text-only mode:
+
+```bash
+cartesia chat 8000
+```
+
+Try: "Can I get a medium latte with oat milk and a croissant?" then "Actually make that a large" and "That's everything."
+
+## File Overview
+
+| File | Description |
+|------|-------------|
+| `main.py` | Agent, order tools, prompts, and Mercury 2 configuration |
+| `pyproject.toml` | Project metadata and dependencies |
+| `cartesia.toml` | Line platform deployment configuration |
+
+## How It Works
+
+Everything is in `main.py`:
+
+1. **`OrderTools`** — a per-call class holding the in-progress order, exposing three `@loopback_tool` methods: `add_item`, `remove_item`, and `confirm_order`
+2. **`get_agent`** — creates an `LlmAgent` pointed at Mercury 2 with the order tools plus the built-in `end_call`
+3. **`VoiceAgentApp`** — handles the voice connection
+
+## Mercury 2 Configuration
+
+### Model Selection
+
+The Inception API serves several models — see [Models, Endpoints, and Pricing](https://docs.inceptionlabs.ai/get-started/models) for the current list. This example uses `mercury-2`. Because the API is OpenAI-compatible, the model is addressed as `openai/mercury-2` with `api_base` pointing at `https://api.inceptionlabs.ai/v1`.
+
+### Reasoning Effort
+
+Mercury 2 is a reasoning model with a `reasoning_effort` control: `"instant"`, `"low"`, `"medium"`, or `"high"`. Higher settings spend more time reasoning before answering; `"instant"` skips extended reasoning for the fastest response, which is usually the right trade-off for voice. It is passed through `extra_body` so LiteLLM forwards it verbatim:
+
+```python
+extra={
+    "api_base": "https://api.inceptionlabs.ai/v1",
+    "extra_body": {"reasoning_effort": "instant"},
+}
+```
+
+Note: use `extra_body` rather than the `LlmConfig.reasoning_effort` field — that field is validated against LiteLLM's model registry, which does not know Mercury's effort levels.
+
+### Sampling
+
+```python
+LlmConfig(
+    system_prompt=SYSTEM_PROMPT,
+    introduction=INTRODUCTION,
+    temperature=0.3,
+    max_tokens=300,
+)
+```
+
+Low temperature keeps order read-backs consistent; 300 output tokens is plenty for short conversational turns.
+
+## Deploying to Cartesia
+
+1) Initialize the agent:
+
+```bash
+cartesia init
+```
+
+2) Deploy:
+
+```bash
+cartesia deploy
+```
+
+3) Upload your API key:
+
+```bash
+cartesia env set INCEPTION_API_KEY=your-inception-key
+```

--- a/example_integrations/inception/README.md
+++ b/example_integrations/inception/README.md
@@ -2,7 +2,7 @@
 
 A low-latency order-taking voice agent built on [Mercury 2](https://www.inceptionlabs.ai/blog/introducing-mercury-2), Inception Labs' diffusion large language model, and the Cartesia Line SDK.
 
-Mercury 2 generates over 1,000 tokens per second by refining all tokens in parallel instead of decoding them one at a time. On a live voice call that translates directly into lower time-to-first-token, so this example uses a use case where snappy turnaround matters: taking a coffee order with rapid back-and-forth and tool calls on nearly every turn.
+Mercury 2 generates over 1,000 tokens per second by refining all tokens in parallel instead of decoding them one at a time. On a live voice call that cuts both time-to-first-token and end-to-end response latency: a ~300-token reasoning trace completes in under 300 ms, so the model can actually deliberate — tool selection, policy compliance, multi-step workflows — while staying inside the ~500 ms end-to-end LLM budget that natural conversation demands. This example leans into that with a use case where snappy turnaround matters: taking a coffee order with rapid back-and-forth and tool calls on nearly every turn.
 
 The [Inception API](https://docs.inceptionlabs.ai/) is OpenAI-compatible, so Mercury 2 plugs into `LlmAgent` through the SDK's HTTP/LiteLLM backend — no extra dependencies, just a custom `api_base`:
 
@@ -14,7 +14,7 @@ LlmAgent(
         ...,
         extra={
             "api_base": "https://api.inceptionlabs.ai/v1",
-            "extra_body": {"reasoning_effort": "instant"},
+            "extra_body": {"reasoning_effort": "medium", "realtime": True},
         },
     ),
 )
@@ -88,12 +88,19 @@ The Inception API serves several models — see [Models, Endpoints, and Pricing]
 
 ### Reasoning Effort
 
-Mercury 2 is a reasoning model with a `reasoning_effort` control: `"instant"`, `"low"`, `"medium"`, or `"high"`. Higher settings spend more time reasoning before answering; `"instant"` skips extended reasoning for the fastest response, which is usually the right trade-off for voice. It is passed through `extra_body` so LiteLLM forwards it verbatim:
+Mercury 2 is a reasoning model with a `reasoning_effort` control: `"instant"`, `"low"`, `"medium"`, or `"high"`. This example defaults to `"medium"`, [Inception's recommended setting for production voice agents](https://docs.inceptionlabs.ai/usecases/voice/quickstart). How to choose:
+
+- **`instant`** trades intelligence for reflex speed — suitable for acknowledgments, backchannels, and turns that don't require tool calls.
+- **`low`** already beats GPT 4.1 on instruction following at a fraction of the latency; pair it with `realtime` for the most TTFT-sensitive workflows.
+- **`medium`** is the headline setting: it beats GPT 4.1 by 27 points on IFBench and 24 points on Tau3Bench Telecom while still decoding faster than GPT 4.1's non-reasoning baseline. Since this agent makes a tool call on nearly every turn, medium is the right default here.
+- **`high`** spends the most time reasoning for highest intelligence; rarely needed on a live call.
+
+The setting is passed through `extra_body` so LiteLLM forwards it verbatim, along with `realtime`, Inception's recommended low-latency serving mode for voice:
 
 ```python
 extra={
     "api_base": "https://api.inceptionlabs.ai/v1",
-    "extra_body": {"reasoning_effort": "instant"},
+    "extra_body": {"reasoning_effort": "medium", "realtime": True},
 }
 ```
 
@@ -105,12 +112,16 @@ Note: use `extra_body` rather than the `LlmConfig.reasoning_effort` field — th
 LlmConfig(
     system_prompt=SYSTEM_PROMPT,
     introduction=INTRODUCTION,
-    temperature=0.3,
-    max_tokens=300,
+    temperature=0.75,
+    max_tokens=4096,
 )
 ```
 
-Low temperature keeps order read-backs consistent; 300 output tokens is plenty for short conversational turns.
+These follow the [voice quickstart](https://docs.inceptionlabs.ai/usecases/voice/quickstart) recommendations: `temperature=0.75` (the API default) suits most voice use cases — consider lowering toward `0.6` if tool routing needs to be extra consistent. Because Mercury is a reasoning model, its reasoning tokens count against `max_tokens`, so Inception recommends a budget of at least 3,000 at `reasoning_effort="medium"`.
+
+### Prompting
+
+The system prompt in `main.py` follows [Inception's prompt guide](https://docs.inceptionlabs.ai/resources/prompt-guide): persona and menu up top, few-shot tool-routing examples (including a negative example), and critical voice rules — markdown suppression, one question at a time — placed last, where Mercury weights context most heavily.
 
 ## Deploying to Cartesia
 

--- a/example_integrations/inception/main.py
+++ b/example_integrations/inception/main.py
@@ -16,13 +16,9 @@ load_dotenv()
 MODEL_ID = "openai/mercury-2"
 INCEPTION_API_BASE = "https://api.inceptionlabs.ai/v1"
 
-# Mercury 2 decoding control: "instant", "low", "medium", or "high".
-# "instant" skips extended reasoning for the lowest time-to-first-token,
-# which is usually the right trade-off on a live voice call.
-REASONING_EFFORT = "instant"
-
-MAX_OUTPUT_TOKENS = 300
-TEMPERATURE = 0.3
+REASONING_EFFORT = "medium"
+MAX_OUTPUT_TOKENS = 4096
+TEMPERATURE = 0.75
 
 SYSTEM_PROMPT = """You are the order-taker at Mercury Coffee, a quick-service coffee bar. \
 Keep the line moving: short, friendly, instant replies.
@@ -41,9 +37,16 @@ HOW TO WORK THE ORDER
   and tell them the total number of items.
 - After they confirm, thank them and call end_call.
 
-VOICE RULES
-This is a phone call. Plain natural sentences only: no markdown, no lists, no special characters.
-One question at a time. Never mention the tools or your reasoning."""
+TOOL ROUTING EXAMPLES
+User: "Can I get a large cold brew?" -> call add_item("large cold brew").
+User: "Actually, scratch the cold brew." -> call remove_item("large cold brew").
+User: "That's everything." -> call confirm_order().
+User: "What milks do you have?" -> no tool call; answer from the menu.
+
+VOICE RULES (critical)
+Your responses are read aloud by a text-to-speech engine. Respond in natural spoken language
+only: no markdown, no bullet points, no headers, no numbered lists, no special characters.
+Ask for only ONE piece of information at a time. Never mention the tools or your reasoning."""
 
 INTRODUCTION = "Hi, welcome to Mercury Coffee! What can I get started for you?"
 
@@ -106,11 +109,11 @@ async def get_agent(env: AgentEnv, call_request: CallRequest):
             temperature=TEMPERATURE,
             max_tokens=MAX_OUTPUT_TOKENS,
             extra={
-                # Point LiteLLM's OpenAI client at the Inception API.
                 "api_base": INCEPTION_API_BASE,
-                # Mercury-specific parameters go in extra_body so they are
-                # forwarded verbatim to the API.
-                "extra_body": {"reasoning_effort": REASONING_EFFORT},
+                "extra_body": {
+                    "reasoning_effort": REASONING_EFFORT,
+                    "realtime": True,
+                },
             },
         ),
     )

--- a/example_integrations/inception/main.py
+++ b/example_integrations/inception/main.py
@@ -1,0 +1,122 @@
+"""Quick-service ordering agent with Inception Mercury 2 and Cartesia Line SDK."""
+
+import os
+from typing import Annotated, List
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from line.llm_agent import LlmAgent, LlmConfig, ToolEnv, end_call, loopback_tool
+from line.voice_agent_app import AgentEnv, CallRequest, VoiceAgentApp
+
+load_dotenv()
+
+# Mercury 2 speaks the OpenAI chat-completions protocol, so it runs on the SDK's
+# HTTP/LiteLLM backend using the `openai/` prefix with a custom `api_base`.
+MODEL_ID = "openai/mercury-2"
+INCEPTION_API_BASE = "https://api.inceptionlabs.ai/v1"
+
+# Mercury 2 decoding control: "instant", "low", "medium", or "high".
+# "instant" skips extended reasoning for the lowest time-to-first-token,
+# which is usually the right trade-off on a live voice call.
+REASONING_EFFORT = "instant"
+
+MAX_OUTPUT_TOKENS = 300
+TEMPERATURE = 0.3
+
+SYSTEM_PROMPT = """You are the order-taker at Mercury Coffee, a quick-service coffee bar. \
+Keep the line moving: short, friendly, instant replies.
+
+MENU
+Drinks (small, medium, large): drip coffee, latte, cappuccino, cold brew, chai, hot chocolate.
+Milk options: whole, oat, almond. Extras: extra shot, vanilla syrup, caramel syrup.
+Food: butter croissant, blueberry muffin, bagel with cream cheese.
+
+HOW TO WORK THE ORDER
+- When the customer asks for something on the menu, call add_item with a complete description
+  (size, drink, milk, extras), then confirm it back in a few words.
+- If they change their mind, call remove_item for the old item and add_item for the new one.
+- If they ask for something not on the menu, say so and suggest the closest item.
+- When they say that's everything, call confirm_order, read the order back in one sentence,
+  and tell them the total number of items.
+- After they confirm, thank them and call end_call.
+
+VOICE RULES
+This is a phone call. Plain natural sentences only: no markdown, no lists, no special characters.
+One question at a time. Never mention the tools or your reasoning."""
+
+INTRODUCTION = "Hi, welcome to Mercury Coffee! What can I get started for you?"
+
+
+class OrderTools:
+    """Holds the in-progress order for a single call."""
+
+    def __init__(self):
+        self._items: List[str] = []
+
+    @loopback_tool
+    async def add_item(
+        self,
+        ctx: ToolEnv,
+        item: Annotated[str, "Complete item description, e.g. 'medium latte with oat milk'."],
+    ) -> str:
+        """Add one item to the customer's order. Call once per item."""
+        self._items.append(item)
+        logger.info(f"Added item: {item} (order size: {len(self._items)})")
+        return f"Added: {item}. Current order: {'; '.join(self._items)}."
+
+    @loopback_tool
+    async def remove_item(
+        self,
+        ctx: ToolEnv,
+        item: Annotated[str, "The item to remove, matching how it was added."],
+    ) -> str:
+        """Remove an item from the order when the customer changes their mind."""
+        for existing in self._items:
+            if item.lower() in existing.lower() or existing.lower() in item.lower():
+                self._items.remove(existing)
+                logger.info(f"Removed item: {existing} (order size: {len(self._items)})")
+                current = "; ".join(self._items) if self._items else "empty"
+                return f"Removed: {existing}. Current order: {current}."
+        return f"No item matching '{item}' found. Current order: {'; '.join(self._items)}."
+
+    @loopback_tool
+    async def confirm_order(self, ctx: ToolEnv) -> str:
+        """Finalize the order once the customer says they are done ordering."""
+        if not self._items:
+            return "The order is empty. Ask the customer what they would like."
+        logger.info(f"Order confirmed: {self._items}")
+        return f"Order confirmed with {len(self._items)} item(s): {'; '.join(self._items)}."
+
+
+async def get_agent(env: AgentEnv, call_request: CallRequest):
+    """Create a Mercury 2 ordering agent for this call."""
+    api_key = os.environ.get("INCEPTION_API_KEY")
+    if not api_key:
+        raise RuntimeError("INCEPTION_API_KEY is not set.")
+
+    order = OrderTools()
+    return LlmAgent(
+        model=MODEL_ID,
+        api_key=api_key,
+        tools=[order.add_item, order.remove_item, order.confirm_order, end_call],
+        config=LlmConfig(
+            system_prompt=SYSTEM_PROMPT,
+            introduction=INTRODUCTION,
+            temperature=TEMPERATURE,
+            max_tokens=MAX_OUTPUT_TOKENS,
+            extra={
+                # Point LiteLLM's OpenAI client at the Inception API.
+                "api_base": INCEPTION_API_BASE,
+                # Mercury-specific parameters go in extra_body so they are
+                # forwarded verbatim to the API.
+                "extra_body": {"reasoning_effort": REASONING_EFFORT},
+            },
+        ),
+    )
+
+
+app = VoiceAgentApp(get_agent=get_agent)
+
+if __name__ == "__main__":
+    app.run()

--- a/example_integrations/inception/pyproject.toml
+++ b/example_integrations/inception/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "inception-mercury-ordering"
+version = "0.1.0"
+description = "A quick-service ordering voice agent using Inception Mercury 2 and Cartesia Line SDK"
+requires-python = ">=3.10"
+dependencies = [
+    "cartesia-line==0.2.16",
+    "loguru>=0.7.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.scripts]
+mercury-ordering = "main:app.run"


### PR DESCRIPTION
## What does this PR do?

We add an example integration for **Mercury 2**, Inception Labs' diffusion LLM, under `example_integrations/inception/` — following the structure of the existing Cerebras (#114) and Tavily (#197) integration examples.

Mercury 2 generates 1,000+ tokens/sec by refining tokens in parallel, cutting both time-to-first-token and end-to-end response latency. This enables reasoning intelligence in a realtime response. The example is a quick-service coffee-ordering agent.

The [Inception API](https://docs.inceptionlabs.ai/) is OpenAI-compatible, so Mercury 2 runs on the SDK's existing HTTP/LiteLLM backend with no new dependencies:

```python
LlmAgent(
    model="openai/mercury-2",
    api_key=os.environ["INCEPTION_API_KEY"],
    config=LlmConfig(
        ...,
        extra={
            "api_base": "https://api.inceptionlabs.ai/v1",
            "extra_body": {"reasoning_effort": "medium", "realtime": True},
        },
    ),
)
```

Mercury's `reasoning_effort` levels (`instant`/`low`/`medium`/`high`) and `realtime` serving mode are passed via `extra_body`.

Decoding parameters follow Inception's [voice quickstart](https://docs.inceptionlabs.ai/usecases/voice/quickstart) recommendations for a standard voice agent — `reasoning_effort="medium"`, `realtime=True`, `temperature=0.75`, and `max_tokens=4096`. The README documents how to choose between reasoning efforts based on the use-case. 

The system prompt follows Inception's [prompt guide](https://docs.inceptionlabs.ai/resources/prompt-guide) for voice and tool-calling agents (few-shot tool routing, critical voice rules last).

**Files:**
- `main.py` — single-file agent: `OrderTools` class with `add_item` / `remove_item` / `confirm_order` loopback tools plus built-in `end_call`
- `README.md` — prerequisites, environment variables, file overview, Mercury 2 configuration notes, local run and Cartesia deploy instructions, links to Inception API docs
- `pyproject.toml` — pinned to `cartesia-line==0.2.16` like the other integrations
- `cartesia.toml` — empty placeholder, matching the Tavily/Exa examples

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Other: ___________

## Testing

- Drove the agent end-to-end against a local fake OpenAI-compatible server: the request lands on `{api_base}/v1/chat/completions` with `Authorization: Bearer $INCEPTION_API_KEY`, `model=mercury-2`, `reasoning_effort=medium`, `realtime=true`, and all four tools in OpenAI schema; the streamed response is yielded back as agent speech through `LlmAgent.process`.
- Confirmed `openai/mercury-2` routes to the HTTP/LiteLLM backend and that the SDK does not inject an unsupported top-level `reasoning_effort` param for this model.
- `make format` (pre-commit: ruff, ruff-format, pyright, whitespace/EOF/TOML checks) passes on all files.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works — no unit tests added, matching the existing `example_integrations/` examples (Cerebras, Tavily, Exa), which ship without tests; the agent was verified end-to-end as described above
- [x] I have formatted my code with `make format`