### PR TITLE
Add TTS generation controls (speed, volume, emotion) to TTSConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,7 @@ from line import PreCallResult, TTSConfig, VoiceAgentApp
 
 async def pre_call(call_request):
     return PreCallResult(
-        config={
-            "tts": TTSConfig(speed=1.2, volume=0.9, emotion="calm").model_dump(exclude_none=True),
-        }
+        config={"tts": TTSConfig(speed=1.2, volume=0.9, emotion="calm").model_dump()},
     )
 
 app = VoiceAgentApp(get_agent=get_agent, pre_call_handler=pre_call)
@@ -138,7 +136,7 @@ You can also pick controls per call, e.g. slow down speech for a support line:
 ```python
 async def pre_call(call_request):
     if call_request.to == SUPPORT_LINE_NUMBER:
-        return PreCallResult(config={"tts": TTSConfig(speed=0.8).model_dump(exclude_none=True)})
+        return PreCallResult(config={"tts": TTSConfig(speed=0.8).model_dump()})
     return PreCallResult()
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,34 @@ async def get_agent(env: AgentEnv, call_request: CallRequest):
 
 ---
 
+## Configure the Voice (Speed, Volume, Emotion)
+
+Set TTS generation controls for a call with a `pre_call_handler`. The `tts` config mirrors `generation_config` on the [Cartesia TTS API](https://docs.cartesia.ai/api-reference/tts/tts): `speed` (0.6–1.5), `volume` (0.5–2.0), and `emotion` (e.g. `"calm"`, `"excited"`). Values apply for the duration of the call; omitted fields keep the agent's configured defaults.
+
+```python
+from line import PreCallResult, TTSConfig, VoiceAgentApp
+
+async def pre_call(call_request):
+    return PreCallResult(
+        config={
+            "tts": TTSConfig(speed=1.2, volume=0.9, emotion="calm").model_dump(exclude_none=True),
+        }
+    )
+
+app = VoiceAgentApp(get_agent=get_agent, pre_call_handler=pre_call)
+```
+
+You can also pick controls per call, e.g. slow down speech for a support line:
+
+```python
+async def pre_call(call_request):
+    if call_request.to == SUPPORT_LINE_NUMBER:
+        return PreCallResult(config={"tts": TTSConfig(speed=0.8).model_dump(exclude_none=True)})
+    return PreCallResult()
+```
+
+---
+
 ## Add Tools to Your Agent
 
 ### Built-in Tools

--- a/line/__init__.py
+++ b/line/__init__.py
@@ -1,5 +1,6 @@
 # Core voice agent components
 # Agent types
+from line._harness_types import TTSConfig
 from line.agent import (
     Agent,
     AgentCallable,
@@ -61,6 +62,7 @@ __all__ = [
     "CallRequest",
     "AgentConfig",
     "PreCallResult",
+    "TTSConfig",
     # Agent types
     "Agent",
     "AgentCallable",

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -133,6 +133,13 @@ class TTSConfig(BaseModel):
     voice_id: Optional[str] = None
     pronunciation_dict_id: Optional[str] = None
     language: Optional[str] = None
+    # Generation controls, mirroring `generation_config` on the Cartesia TTS API.
+    # Bounds match the platform's validation (speed 0.6-1.5, volume 0.5-2.0).
+    # Applied at call start via the pre-call config; mid-call updates are not
+    # supported yet, so these are intentionally absent from AgentUpdateCall.
+    speed: Optional[float] = Field(default=None, ge=0.6, le=1.5)
+    volume: Optional[float] = Field(default=None, ge=0.5, le=2.0)
+    emotion: Optional[str] = Field(default=None, min_length=1)
 
 
 class STTConfig(BaseModel):

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -133,10 +133,6 @@ class TTSConfig(BaseModel):
     voice_id: Optional[str] = None
     pronunciation_dict_id: Optional[str] = None
     language: Optional[str] = None
-    # Generation controls, mirroring `generation_config` on the Cartesia TTS API.
-    # Bounds match the platform's validation (speed 0.6-1.5, volume 0.5-2.0).
-    # Applied at call start via the pre-call config; mid-call updates are not
-    # supported yet, so these are intentionally absent from AgentUpdateCall.
     speed: Optional[float] = Field(default=None, ge=0.6, le=1.5)
     volume: Optional[float] = Field(default=None, ge=0.5, le=2.0)
     emotion: Optional[str] = Field(default=None, min_length=1)

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -482,10 +482,8 @@ class ConversationRunner:
                         break
                     if mapped is None:
                         continue
-                    # exclude_none keeps unset optional fields off the wire —
-                    # the harness treats absent keys as "not provided", so e.g.
-                    # a mid-call ConfigOutput must not emit null generation
-                    # controls (speed/volume/emotion) as explicit overrides.
+                    # exclude_none keeps unset optional fields off the wire, so
+                    # the harness treats absent keys as "not provided".
                     await self.websocket.send_json(mapped.model_dump(exclude_none=True))
             except asyncio.CancelledError:
                 pass

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -79,7 +79,20 @@ from line.events import (
 
 # Call request types
 class PreCallResult(BaseModel):
-    """Result from pre_call_handler containing metadata and config."""
+    """Result from pre_call_handler containing metadata and config.
+
+    ``config`` follows the harness call-config shape, e.g.::
+
+        PreCallResult(
+            config={
+                "tts": TTSConfig(voice_id="...", speed=1.2, emotion="calm").model_dump(exclude_none=True),
+            }
+        )
+
+    The ``tts`` entry mirrors :class:`line.TTSConfig`; its ``speed`` / ``volume`` /
+    ``emotion`` generation controls match ``generation_config`` on the Cartesia
+    TTS API and apply for the duration of the call.
+    """
 
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Metadata to include with the call")
     config: Dict[str, Any] = Field(default_factory=dict, description="Configuration for the call")

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -482,7 +482,11 @@ class ConversationRunner:
                         break
                     if mapped is None:
                         continue
-                    await self.websocket.send_json(mapped.model_dump())
+                    # exclude_none keeps unset optional fields off the wire —
+                    # the harness treats absent keys as "not provided", so e.g.
+                    # a mid-call ConfigOutput must not emit null generation
+                    # controls (speed/volume/emotion) as explicit overrides.
+                    await self.websocket.send_json(mapped.model_dump(exclude_none=True))
             except asyncio.CancelledError:
                 pass
             except Exception:

--- a/tests/test_harness_types.py
+++ b/tests/test_harness_types.py
@@ -47,3 +47,22 @@ def test_tts_config_generation_controls_default_to_none():
     # exclude_none keeps unset controls off the wire, so the harness treats
     # them as "not provided" rather than explicit overrides.
     assert config.model_dump(exclude_none=True) == {"voice_id": "voice-123"}
+
+
+def test_config_output_omits_unset_generation_controls_on_the_wire():
+    """Mirrors the websocket send path (model_dump(exclude_none=True)):
+    an AgentUpdateCall-style ConfigOutput must not emit null speed/volume/
+    emotion keys, which the harness would otherwise treat as explicit
+    overrides once mid-call generation-control updates are supported."""
+    from line._harness_types import ConfigOutput, STTConfig
+
+    message = ConfigOutput(
+        tts=TTSConfig(voice_id="voice-123", language="en"),
+        stt=STTConfig(language="en"),
+        language="en",
+    )
+    payload = message.model_dump(exclude_none=True)
+    assert payload["tts"] == {"voice_id": "voice-123", "language": "en"}
+    assert "speed" not in payload["tts"]
+    assert "volume" not in payload["tts"]
+    assert "emotion" not in payload["tts"]

--- a/tests/test_harness_types.py
+++ b/tests/test_harness_types.py
@@ -1,0 +1,49 @@
+"""Tests for the wire-format models in line._harness_types."""
+
+from pydantic import ValidationError
+import pytest
+
+from line._harness_types import TTSConfig
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"speed": 0.6},
+        {"speed": 1.5},
+        {"volume": 0.5},
+        {"volume": 2.0},
+        {"emotion": "cheerful"},
+        {"voice_id": "voice-123", "speed": 1.2, "volume": 0.8, "emotion": "calm"},
+    ],
+)
+def test_tts_config_accepts_valid_generation_controls(kwargs):
+    config = TTSConfig(**kwargs)
+    for key, value in kwargs.items():
+        assert getattr(config, key) == value
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"speed": 0.59},
+        {"speed": 1.51},
+        {"volume": 0.49},
+        {"volume": 2.01},
+        {"emotion": ""},
+    ],
+)
+def test_tts_config_rejects_out_of_bounds_generation_controls(kwargs):
+    with pytest.raises(ValidationError):
+        TTSConfig(**kwargs)
+
+
+def test_tts_config_generation_controls_default_to_none():
+    config = TTSConfig(voice_id="voice-123")
+    assert config.speed is None
+    assert config.volume is None
+    assert config.emotion is None
+    # exclude_none keeps unset controls off the wire, so the harness treats
+    # them as "not provided" rather than explicit overrides.
+    assert config.model_dump(exclude_none=True) == {"voice_id": "voice-123"}


### PR DESCRIPTION
## What does this PR do?

Adds support for TTS generation controls (`speed`, `volume`, and `emotion`) to the `TTSConfig` model. These controls mirror the `generation_config` parameters on the Cartesia TTS API and can be configured at call start via the pre-call config.

- Adds `speed` (0.6–1.5), `volume` (0.5–2.0), and `emotion` (non-empty string) fields to `TTSConfig` with appropriate validation bounds
- Exports `TTSConfig` from the main `line` module for public use
- Updates `PreCallResult` docstring to document the expected config shape and generation control behavior
- All fields default to `None` and are excluded from wire format when unset, allowing the harness to treat them as "not provided" rather than explicit overrides

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing

Added comprehensive unit tests in `tests/test_harness_types.py`:
- `test_tts_config_accepts_valid_generation_controls`: Validates that valid speed (0.6–1.5), volume (0.5–2.0), and emotion values are accepted
- `test_tts_config_rejects_out_of_bounds_generation_controls`: Validates that out-of-bounds values are rejected with `ValidationError`
- `test_tts_config_generation_controls_default_to_none`: Confirms defaults are `None` and `model_dump(exclude_none=True)` excludes unset controls

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that prove my feature works
- [x] I have formatted my code with `make format`

https://claude.ai/code/session_01Y1jTDcaXJogpQNJvFaQnV8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and serialization tweak with validation tests; no auth or data-path changes, though wire-format behavior affects all agent websocket outputs.
> 
> **Overview**
> Adds **Cartesia-style TTS generation controls** to the wire `TTSConfig` model: optional `speed` (0.6–1.5), `volume` (0.5–2.0), and non-empty `emotion`, with Pydantic bounds validation. **`TTSConfig` is re-exported** from `line` so callers can build `PreCallResult(config={"tts": ...})` without reaching into internal modules.
> 
> Documents how to set per-call voice via `pre_call_handler` in the README and expands `PreCallResult`’s docstring to describe the `tts` config shape and that unset fields should use agent defaults.
> 
> **Websocket outbound messages** now use `model_dump(exclude_none=True)` so optional TTS fields are omitted when unset—avoiding null keys the harness might treat as explicit overrides. New unit tests cover validation, defaults, and wire serialization for `ConfigOutput`/`TTSConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd93482179b44bd640a998e2a9049f960b5bd71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->