### PR TITLE
Anchor background tool results to history at drain time

### DIFF
--- a/line/llm_agent/llm_agent.py
+++ b/line/llm_agent/llm_agent.py
@@ -316,7 +316,7 @@ class LlmAgent:
             if is_first_iteration or should_loopback:
                 # Drain any immediately available events (non-blocking)
                 while (pair := self._get_background_event_queue().get_nowait()) is not None:
-                    called_evt, returned_evt = pair
+                    called_evt, returned_evt = self._anchor_background_pair(pair)
                     yield called_evt
                     yield returned_evt
             else:
@@ -326,7 +326,7 @@ class LlmAgent:
                     # All background sources completed with no more events
                     # this generation process is completed - exit loop
                     break
-                called_evt, returned_evt = result
+                called_evt, returned_evt = self._anchor_background_pair(result)
                 yield called_evt
                 yield returned_evt
 
@@ -659,6 +659,37 @@ class LlmAgent:
                 )
         return messages
 
+    def _anchor_background_pair(
+        self, pair: Tuple[AgentToolCalled, AgentToolReturned]
+    ) -> Tuple[AgentToolCalled, AgentToolReturned]:
+        """Append a drained background tool event pair to local history.
+
+        History is appended at drain time rather than when the background tool
+        yielded the result. A result can arrive while an LLM generation for the
+        current turn is still in flight; appending at yield time would place the
+        pair BEFORE the text that generation streams afterwards, so the merged
+        history would end with the agent's own speech and the loopback reaction
+        call would be skipped by the "conversation cannot end with assistant
+        message" validation — silently dropping the tool result. Anchoring at
+        drain time guarantees the pair is the last thing in history when the
+        reaction LLM call that immediately follows builds its messages.
+
+        Both appends happen synchronously before the events are yielded
+        downstream, so a cancellation delivered at the yield cannot leave a
+        dequeued pair missing from history.
+
+        Args:
+            pair: The (AgentToolCalled, AgentToolReturned) pair popped from the
+                background event queue.
+
+        Returns:
+            The same pair, for convenient unpacking at the call site.
+        """
+        called_evt, returned_evt = pair
+        self.history._append_local(called_evt)
+        self.history._append_local(returned_evt)
+        return pair
+
     def _execute_backgroundable_tool(
         self,
         normalized_func: Callable[..., AsyncIterable[Any]],
@@ -675,9 +706,10 @@ class LlmAgent:
         - AgentToolReturned with the same tool_call_id
 
         The source is subscribed to the background queue, which shields it
-        from cancellation. Events are tagged with the CURRENT event_id at
-        yield time so background tool results appear at the end of history
-        when yielded after a new process() call has started.
+        from cancellation. Events are only queued here — they enter local
+        history when a generation loop drains them (see
+        _anchor_background_pair), so they land after anything the agent
+        streamed while the result was waiting in the queue.
 
         responding_to is set to the triggering_event_id (captured at subscription
         time) so background results reference the event that originally triggered
@@ -692,8 +724,6 @@ class LlmAgent:
                     called, returned = _construct_tool_events(call_id, tc_name, tool_args, value)
                     called.responding_to = triggering_event_id
                     returned.responding_to = triggering_event_id
-                    self.history._append_local(called)
-                    self.history._append_local(returned)
                     yield (called, returned)
                     n += 1
             except Exception as e:
@@ -701,8 +731,6 @@ class LlmAgent:
                 called, returned = _construct_tool_events(f"{tc_id}-{n}", tc_name, tool_args, f"error: {e}")
                 called.responding_to = triggering_event_id
                 returned.responding_to = triggering_event_id
-                self.history._append_local(called)
-                self.history._append_local(returned)
                 yield (called, returned)
 
         self._get_background_event_queue().subscribe(generate_events())

--- a/tests/test_llm_agent_llm_agent.py
+++ b/tests/test_llm_agent_llm_agent.py
@@ -26,7 +26,14 @@ from line.events import (
 )
 from line.llm_agent.config import LlmConfig
 from line.llm_agent.llm_agent import LlmAgent
-from line.llm_agent.provider import Message, StreamChunk, ToolCall, _ModelConfig, parse_model_id
+from line.llm_agent.provider import (
+    Message,
+    StreamChunk,
+    ToolCall,
+    _ModelConfig,
+    _normalize_messages,
+    parse_model_id,
+)
 from line.llm_agent.tools.decorators import handoff_tool, loopback_tool, passthrough_tool
 from line.llm_agent.tools.system import web_search
 from line.llm_agent.tools.utils import FunctionTool
@@ -2230,3 +2237,169 @@ async def test_background_tool_responding_to_references_triggering_event(turn_en
         assert evt.responding_to == "evt-A", (
             f"AgentToolReturned responding_to should be 'evt-A', got '{evt.responding_to}'"
         )
+
+
+# =============================================================================
+# Background tool result anchoring (drain-time, not yield-time)
+# =============================================================================
+
+
+async def test_background_result_during_inflight_generation_anchors_after_streamed_text(turn_env):
+    """Background results arriving mid-generation must anchor AFTER the streamed text.
+
+    Regression test for a production incident:
+
+    1. Turn A: the LLM starts a background tool (an account lookup); the tool
+       yields a "pending" status and keeps running.
+    2. The user speaks again — turn B starts and its LLM request goes out.
+    3. While that request is in flight, the lookup fails and the background
+       tool yields an error result.
+    4. Turn B's response streams back ("Of course.").
+    5. Turn B's loop drains the error pair and makes the loopback reaction
+       call that should handle the error.
+
+    When the pair was appended to history at yield time (step 3), it landed
+    BEFORE the text streamed in step 4, so the reaction call's messages ended
+    with an assistant message. _normalize_messages then skipped the LLM call
+    entirely and the error was silently dropped — the agent went dead until
+    the caller spoke again. Anchoring at drain time places the pair after the
+    streamed text, so the reaction call sees the tool result last and proceeds.
+    """
+    import asyncio
+
+    tool_pending = asyncio.Event()
+    fail_now = asyncio.Event()
+    error_yielded = asyncio.Event()
+
+    @loopback_tool(is_background=True)
+    async def account_lookup(ctx):
+        """Look up the caller's account in the background."""
+        yield {"status": "pending"}
+        tool_pending.set()
+        await fail_now.wait()
+        yield "ERROR: lookup failed"
+        error_yielded.set()
+
+    responses = [
+        # Call 1 (turn A): LLM starts the background lookup
+        [
+            StreamChunk(text="Let me check."),
+            StreamChunk(
+                tool_calls=[ToolCall(id="tc1", name="account_lookup", arguments="{}", is_complete=True)]
+            ),
+            StreamChunk(is_final=True),
+        ],
+        # Call 2 (turn A): reaction to the "pending" status
+        [
+            StreamChunk(text="I'm pulling up your account."),
+            StreamChunk(is_final=True),
+        ],
+        # Call 3 (turn B): response to the user's interjection. The error
+        # result lands in the queue while this response is in flight (gated
+        # below), reproducing the race.
+        [
+            StreamChunk(text="Of course."),
+            StreamChunk(is_final=True),
+        ],
+        # Call 4 (turn B): loopback reaction to the error result
+        [
+            StreamChunk(text="Sorry, I couldn't pull up the account."),
+            StreamChunk(is_final=True),
+        ],
+    ]
+
+    class MidStreamFailureLLM(MockLLM):
+        """MockLLM whose third response streams only after the background
+        tool has yielded its error, simulating a result arriving while the
+        generation is in flight."""
+
+        def chat(self, messages: List[Message], tools=None, **kwargs) -> MockStream:
+            call_index = self._call_count
+            stream = super().chat(messages, tools, **kwargs)
+            if call_index != 2:
+                return stream
+
+            async def gated():
+                fail_now.set()
+                # Wait until the error pair has been queued (the tool only
+                # resumes past its yield once the queue consumed the item).
+                await asyncio.wait_for(error_yielded.wait(), timeout=5.0)
+                async for chunk in stream:
+                    yield chunk
+
+            return gated()
+
+    mock_llm = MidStreamFailureLLM(responses)
+    agent = LlmAgent(model="gpt-4o", api_key="test-key", tools=[account_lookup])
+    agent._llm = mock_llm
+
+    # Turn A — starts the background lookup
+    first_event = UserTextSent(
+        content="I need help with my account",
+        history=[UserTextSent(content="I need help with my account")],
+    )
+
+    async def run_first_process():
+        async for _ in agent.process(turn_env, first_event):
+            pass
+
+    first_task = asyncio.create_task(run_first_process())
+    await asyncio.wait_for(tool_pending.wait(), timeout=5.0)
+    for _ in range(100):
+        if mock_llm._call_count >= 2:
+            break
+        await asyncio.sleep(0)
+    assert mock_llm._call_count >= 2, f"Expected >= 2 LLM calls, got {mock_llm._call_count}"
+
+    # User speaks again — turn A is cancelled, turn B begins
+    first_task.cancel()
+    try:
+        await first_task
+    except asyncio.CancelledError:
+        pass
+
+    second_event = UserTextSent(
+        content="Stop.",
+        history=[
+            UserTextSent(content="I need help with my account"),
+            AgentTextSent(content="Let me check."),
+            AgentTextSent(content="I'm pulling up your account."),
+            UserTextSent(content="Stop."),
+        ],
+    )
+    second_outputs = await collect_outputs(agent, turn_env, second_event)
+
+    # The error result must have been drained and reacted to within turn B
+    error_returned = [
+        o for o in second_outputs if isinstance(o, AgentToolReturned) and "ERROR" in str(o.result)
+    ]
+    assert len(error_returned) == 1, (
+        f"Expected the error tool result to be drained in turn B, got: "
+        f"{[o.result for o in second_outputs if isinstance(o, AgentToolReturned)]}"
+    )
+    assert mock_llm._call_count == 4, (
+        f"Expected the loopback reaction call to happen, got {mock_llm._call_count} LLM calls"
+    )
+
+    # The reaction call's messages must end with the tool result, not with the
+    # assistant text streamed while the result was waiting in the queue.
+    reaction_messages = mock_llm._recorded_messages[3]
+    assert reaction_messages[-1].role == "tool", (
+        f"Reaction call must end with the tool result, got role="
+        f"'{reaction_messages[-1].role}' content={reaction_messages[-1].content!r}"
+    )
+    assistant_text_idx = next(
+        i for i, m in enumerate(reaction_messages) if m.role == "assistant" and m.content == "Of course."
+    )
+    tool_result_idx = next(
+        i for i, m in enumerate(reaction_messages) if m.role == "tool" and "ERROR" in (m.content or "")
+    )
+    assert assistant_text_idx < tool_result_idx, (
+        "The error tool result must be anchored after the text streamed while it was waiting in the queue"
+    )
+
+    # And a real provider would not skip the reaction call
+    assert _normalize_messages(reaction_messages) is not None, (
+        "Reaction call would be skipped by _normalize_messages "
+        "(conversation must not end with an assistant message)"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a race where a background tool (`is_background=True`) result is silently dropped when it arrives while an LLM generation for the current turn is in flight.

**The race.** Background results were appended to local history at *yield* time, inside `generate_events()`. If the current turn's LLM request is already in flight when the result lands, the text that response streams afterwards is appended *after* the pair. When the generation loop then drains the pair and makes the loopback reaction call, `_build_messages` produces a conversation ending with the agent's own assistant text — and `_normalize_messages` skips the LLM call entirely ("conversation cannot end with assistant message"). The result is consumed but never reacted to: the agent goes silent until the next user utterance, whose turn finally sees the result in history.

We hit this in production: a caller interjected while an account lookup was running in the background; the lookup's error result raced the in-flight response, the escalation loopback was skipped, and the agent sat through an inactivity re-prompt before recovering a full turn later.

**The fix.** Append the pair to history at *drain* time (new `_anchor_background_pair`, called at both drain sites in `_generate_response`) instead of yield time. The pair is then by construction the last thing in history when the reaction call that immediately follows builds its messages. Both appends happen synchronously before the pair events are yielded downstream, so a cancellation delivered at the yield cannot leave a dequeued pair missing from history.

This also subsumes the yield-time current-event tagging introduced in #173 for the "result arrives after a new process() started" case: a pair drained by a later turn is now anchored at that turn's end by construction. `responding_to` attribution is unchanged.

One deliberate behavior change: a result that is never drained (e.g. the call ends first) no longer appears in history. This matches the transcript, which also only ever saw drained pairs — previously such a result was in history but invisible in the transcript.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- New regression test `test_background_result_during_inflight_generation_anchors_after_streamed_text` reproduces the production race: a background tool yields its error while the mock LLM's response for the interjecting turn is gated mid-flight. On `main` it fails with the exact production signature (reaction call's messages end with `role='assistant'`, which `_normalize_messages` would skip); with the fix the messages end with the tool result and `_normalize_messages` accepts them.
- Full suite: 613 passed; the 4 failures in `test_llm_agent_provider.py` (gpt-5-mini reasoning-effort coercion) pre-exist on clean `main` and are unrelated.
- `pre-commit run` (ruff, ruff-format, pyright, hygiene hooks) passes on the changed files.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent turn loop and conversation history ordering for background tools; wrong ordering could still drop loopback reactions, but scope is narrow and covered by a targeted regression test.
> 
> **Overview**
> Fixes a race where **background tool** (`is_background=True`) results could be **silently dropped** when they arrived while the current turn’s LLM stream was still in flight.
> 
> **Before:** `AgentToolCalled` / `AgentToolReturned` pairs were written to local history when the background tool **yielded**, so a late result could sit **above** assistant text streamed afterward. The next loopback reaction then built messages ending on an assistant turn, and `_normalize_messages` **skipped** the LLM call—so the agent stopped reacting until the user spoke again.
> 
> **After:** New `_anchor_background_pair` appends pairs when the generation loop **drains** the background queue (both blocking and non-blocking paths). History ordering keeps the tool result last for the reaction call; appends happen before yielding so cancellation can’t dequeue without recording history. Yield-time history writes in `_execute_backgroundable_tool` are removed.
> 
> Adds regression test `test_background_result_during_inflight_generation_anchors_after_streamed_text` for the mid-generation failure scenario. **Behavior change:** results never drained (e.g. call ends first) no longer appear in history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f460a1042a8919890ceec3a04e75f9a22a048862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->