### PR TITLE
http_responses: opt-in speech-leak guard (tool-call payloads in spoken text)

### DIFF
--- a/line/llm_agent/README.md
+++ b/line/llm_agent/README.md
@@ -129,7 +129,7 @@ speech_leak_guard = SpeechLeakGuardConfig(
 )
 ```
 
-Detection, holdback size, guarded message phases, and the retry note are all configurable — see the `SpeechLeakGuardConfig` docstring.
+Every spoken message item is guarded unless it is explicitly labeled with a `phase` in `skip_phases` (default: `{"final_answer"}`). Items with a missing or unrecognized phase label are always guarded — this covers models that predate the Responses API `phase` field (e.g. `gpt-5-mini`, `gpt-4.1`), which never label their messages. Detection pattern, holdback size, the skip set, and the retry note are all configurable — see the `SpeechLeakGuardConfig` docstring.
 
 ## Built-in Tools
 

--- a/line/llm_agent/README.md
+++ b/line/llm_agent/README.md
@@ -97,6 +97,40 @@ config = LlmConfig.from_call_request(
 - `system_prompt=""` is treated as None and falls back to defaults (a valid system prompt is always required)
 - `introduction=""` is preserved (agent waits for user to speak first rather than using a default)
 
+### Speech-Leak Guard (`http_responses` backend)
+
+Some reasoning models occasionally write a tool call's payload into the spoken message — bare JSON arguments (`{"summary": ...}`) or the whole call expression (`record_call_summary({...})`) — instead of, or in addition to, the proper function-call item. Without a guard, the caller hears raw JSON read out loud by TTS.
+
+`SpeechLeakGuardConfig` (opt-in, read only by the `http_responses` backend) buffers streamed spoken text with a small holdback window and scans it for tool-call signatures. On a hit, the LLM invocation is aborted before any tool calls execute or history commits, then retried with a corrective note; if the caller already heard part of the bad attempt, a bridge line is spoken first, and if every attempt leaks, a fallback line is spoken and the turn ends.
+
+```python
+from line.llm_agent import LlmConfig, SpeechLeakGuardConfig
+
+config = LlmConfig(
+    system_prompt="...",
+    speech_leak_guard=SpeechLeakGuardConfig(
+        enabled=True,
+        # Optional tuning (defaults shown in the dataclass):
+        # max_retries=1,
+        # retry_reasoning_effort="medium",  # decorrelate the retry
+        # bridge_text="Sorry, let me try that again.",
+        # fallback_text="I'm having technical difficulties. Should I try again?",
+    ),
+)
+```
+
+For agents whose spoken language can change mid-call, `bridge_text` and `fallback_text` also accept zero-arg callables, invoked at speak time:
+
+```python
+speech_leak_guard = SpeechLeakGuardConfig(
+    enabled=True,
+    bridge_text=lambda: BRIDGE_LINES[current_language()],
+    fallback_text=lambda: FALLBACK_LINES[current_language()],
+)
+```
+
+Detection, holdback size, guarded message phases, and the retry note are all configurable — see the `SpeechLeakGuardConfig` docstring.
+
 ## Built-in Tools
 
 The SDK provides commonly-used tools out of the box:

--- a/line/llm_agent/__init__.py
+++ b/line/llm_agent/__init__.py
@@ -9,7 +9,12 @@ See README.md for examples and detailed documentation.
 """
 
 # Configuration
-from line.llm_agent.config import FALLBACK_INTRODUCTION, FALLBACK_SYSTEM_PROMPT, LlmConfig
+from line.llm_agent.config import (
+    FALLBACK_INTRODUCTION,
+    FALLBACK_SYSTEM_PROMPT,
+    LlmConfig,
+    SpeechLeakGuardConfig,
+)
 
 # History
 from line.llm_agent.history import History
@@ -59,6 +64,7 @@ __all__ = [
     "LLMProvider",
     # Configuration
     "LlmConfig",
+    "SpeechLeakGuardConfig",
     "FALLBACK_SYSTEM_PROMPT",
     "FALLBACK_INTRODUCTION",
     # Tool decorators

--- a/line/llm_agent/config.py
+++ b/line/llm_agent/config.py
@@ -2,12 +2,116 @@
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, FrozenSet, List, Literal, Optional, Union
 
 from line.voice_agent_app import CallRequest
 
 # Sentinel to distinguish "field not passed" from "field explicitly set to None/default".
 _UNSET: Any = object()
+
+
+# Default detection pattern for SpeechLeakGuardConfig. Five alternatives, all safe
+# to search mid-text (natural TTS speech contains none of them):
+#   - ``{\s*"``            — a JSON object opening onto a quoted key
+#   - ``ident\s*(\s*[{"]`` — a snake_case identifier called with a JSON/str
+#     arg, e.g. ``record_call_summary({``. Requiring ``{`` or ``"`` right after
+#     the paren keeps spoken oddities like ``name(at)domain`` from matching.
+#   - ``to=\w+\.``          — the harmony tool-call recipient marker
+#     (``to=functions.record_call_summary``); pure protocol syntax that
+#     survives header corruption and appears well before the JSON payload.
+#   - ``functions.<ident>``  — the harmony tool-namespace prefix glued to an
+#     identifier (no space after the dot, so prose like "it functions. Also"
+#     cannot match).
+#   - ``<|``                 — harmony special-token delimiters leaking
+#     literally (``<|constrain|>`` etc.); unambiguous non-speech.
+# The header-artifact alternatives matter for the observed degraded form
+# ``record_call_summary <glitch tokens> json {"summary":...`` where neither a
+# paren nor a leading ``{`` exists — they pull detection to (near) offset 0 so
+# nothing escapes the holdback window.
+DEFAULT_SPEECH_LEAK_PATTERN = (
+    r'\{\s*"'
+    r"|[a-z_][a-z0-9_]*\s*\(\s*[{\"]"
+    r"|to=\w+\."
+    r"|\bfunctions\.[a-z_]"
+    r"|<\|"
+)
+
+DEFAULT_SPEECH_LEAK_RETRY_NOTE = (
+    "Your previous reply was discarded: it wrote a tool call (JSON arguments "
+    "or a function-call expression) into the spoken message text. Tool calls "
+    "must be made ONLY through the function-calling channel; the spoken "
+    "message must contain only natural language for the caller (or nothing). "
+    "Produce your reply again now: make any tool calls properly, and never "
+    "include JSON, braces, field names, or tool syntax in the spoken text."
+)
+
+DEFAULT_SPEECH_LEAK_BRIDGE_TEXT = "Sorry, I'm having some technical issues. Let me try that again."
+
+DEFAULT_SPEECH_LEAK_FALLBACK_TEXT = (
+    "I'm sorry, I'm having some technical difficulties right now. Would you like me to try again?"
+)
+
+
+@dataclass
+class SpeechLeakGuardConfig:
+    """Guard spoken text against tool-call payloads leaking into TTS.
+
+    Some reasoning models (observed: ``gpt-5.4-mini``) occasionally write a
+    tool call's JSON arguments — or the whole call expression,
+    ``record_call_summary({...})`` — into a user-visible ``message`` item
+    instead of (or in addition to) the proper ``function_call`` item. Without
+    a guard the caller hears raw JSON read out loud.
+
+    When enabled, the ``http_responses`` provider buffers each spoken message
+    item with ``lookahead_chars`` of holdback and scans the accumulated text
+    for ``detection_pattern`` (``re.search``, so a leak is caught anywhere in
+    the item, not just at its head). On a hit the current LLM invocation is
+    aborted before any of its tool calls execute or its output is committed
+    to history, and the whole invocation is retried up to ``max_retries``
+    times with ``retry_note`` injected (via ``retry_note_channel``) and an
+    optional ``retry_reasoning_effort`` override to decorrelate the retry
+    from the failed attempt. If the caller already heard part of the failed
+    attempt, ``bridge_text`` is spoken before the retry; if every attempt
+    leaks, ``fallback_text`` is spoken and the turn ends with no tool calls.
+
+    ``bridge_text`` and ``fallback_text`` are caller-audible, so they may be
+    given as zero-arg callables instead of strings for agents whose spoken
+    language isn't fixed at config time: the callable is invoked at speak
+    time (each time it is needed) and returns the line to speak — return
+    ``""`` to speak nothing. If the callable raises, the English default is
+    spoken and the error logged; leak recovery must not crash. ``retry_note``
+    stays a plain string — it is model-facing, and models follow English
+    instructions regardless of the conversation language.
+
+    Off by default; enable per agent/model. Only the ``http_responses``
+    backend reads it.
+    """
+
+    enabled: bool = False
+    # Which message-item phases are guarded. Leaks have only been observed on
+    # ``commentary`` items; add ``"final_answer"`` to guard those too.
+    phases: FrozenSet[str] = frozenset({"commentary"})
+    # Chars of holdback between what has streamed in and what is released to
+    # TTS. Must comfortably exceed the distance from a leak's start to its
+    # first pattern-matchable signature. The degraded-header form (tool name +
+    # unbounded glitch-token run + ``json {"``) put that signature at offset
+    # ~67 in production, so 64 let 3 chars slip out; 128 covers every shape
+    # observed so far. Cost is negligible: release lags generation (which far
+    # outpaces speech), and clean items shorter than the window are flushed
+    # whole the moment the item completes.
+    lookahead_chars: int = 128
+    detection_pattern: str = DEFAULT_SPEECH_LEAK_PATTERN
+    max_retries: int = 1
+    retry_note: str = DEFAULT_SPEECH_LEAK_RETRY_NOTE
+    # "developer": append a developer-role input item (privileged, most
+    # recent instruction). "instructions": append to the system instructions
+    # for the retry request only.
+    retry_note_channel: Literal["developer", "instructions"] = "developer"
+    # Reasoning effort override for retry requests (e.g. "medium" when the
+    # base config runs "minimal"). None keeps the original effort.
+    retry_reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high"]] = None
+    bridge_text: Union[str, Callable[[], str]] = DEFAULT_SPEECH_LEAK_BRIDGE_TEXT
+    fallback_text: Union[str, Callable[[], str]] = DEFAULT_SPEECH_LEAK_FALLBACK_TEXT
 
 
 @dataclass
@@ -57,6 +161,10 @@ class LlmConfig:
     # on every turn. Only used by the WebSocket and ``http_responses``
     # backends; the ``http`` backend ignores it.
     zdr_enabled: bool = _UNSET
+
+    # Spoken-text tool-call-leak guard (http_responses backend only).
+    # None = disabled. See :class:`SpeechLeakGuardConfig`.
+    speech_leak_guard: Optional[SpeechLeakGuardConfig] = _UNSET
 
     @classmethod
     def from_call_request(
@@ -145,6 +253,7 @@ _FIELD_DEFAULTS: Dict[str, Any] = {
     "extra": dict,  # callable → invoked each time
     "strict_tool_schemas": True,
     "zdr_enabled": False,
+    "speech_leak_guard": None,
 }
 
 

--- a/line/llm_agent/config.py
+++ b/line/llm_agent/config.py
@@ -63,9 +63,10 @@ class SpeechLeakGuardConfig:
     a guard the caller hears raw JSON read out loud.
 
     When enabled, the ``http_responses`` provider buffers each spoken message
-    item with ``lookahead_chars`` of holdback and scans the accumulated text
-    for ``detection_pattern`` (``re.search``, so a leak is caught anywhere in
-    the item, not just at its head). On a hit the current LLM invocation is
+    item — except those explicitly labeled with a ``phase`` in
+    ``skip_phases`` — with ``lookahead_chars`` of holdback and scans the
+    accumulated text for ``detection_pattern`` (``re.search``, so a leak is
+    caught anywhere in the item, not just at its head). On a hit the current LLM invocation is
     aborted before any of its tool calls execute or its output is committed
     to history, and the whole invocation is retried up to ``max_retries``
     times with ``retry_note`` injected (via ``retry_note_channel``) and an
@@ -88,9 +89,14 @@ class SpeechLeakGuardConfig:
     """
 
     enabled: bool = False
-    # Which message-item phases are guarded. Leaks have only been observed on
-    # ``commentary`` items; add ``"final_answer"`` to guard those too.
-    phases: FrozenSet[str] = frozenset({"commentary"})
+    # Phase labels the guard SKIPS. A spoken message item is guarded unless
+    # its ``phase`` is explicitly one of these — items with a missing or
+    # unknown label are always guarded, because absence of a label is not
+    # evidence of safety (models predating the ``phase`` field, e.g.
+    # ``gpt-5-mini`` / ``gpt-4.1``, never send one). Leaks have only been
+    # observed on ``commentary`` items, so ``final_answer`` is exempt by
+    # default; pass ``frozenset()`` to guard every spoken item.
+    skip_phases: FrozenSet[str] = frozenset({"final_answer"})
     # Chars of holdback between what has streamed in and what is released to
     # TTS. Must comfortably exceed the distance from a leak's start to its
     # first pattern-matchable signature. The degraded-header form (tool name +

--- a/line/llm_agent/http_responses_provider.py
+++ b/line/llm_agent/http_responses_provider.py
@@ -39,9 +39,6 @@ single-message responses are unaffected. Phase does not influence which
 item streams; it feeds the logs and the speech-leak guard's skip
 decision (below).
 
-See the consumer repo's ``cartesia-examples/`` for standalone
-reproductions of the duplicate-text and preamble-before-tool patterns.
-
 Speech-leak guard (opt-in)
 --------------------------
 Some reasoning models (observed: ``gpt-5.4-mini``) occasionally write a tool

--- a/line/llm_agent/http_responses_provider.py
+++ b/line/llm_agent/http_responses_provider.py
@@ -40,15 +40,40 @@ log clarity.
 
 See the consumer repo's ``cartesia-examples/`` for standalone
 reproductions of the duplicate-text and preamble-before-tool patterns.
+
+Speech-leak guard (opt-in)
+--------------------------
+Some reasoning models (observed: ``gpt-5.4-mini``) occasionally write a tool
+call's payload into the streamed ``message`` item — either the bare JSON
+arguments (``{"summary": ...}``) or the whole call expression
+(``record_call_summary({...})``) — instead of, or in addition to, the proper
+``function_call`` item. Streamed as-is, the caller hears raw JSON read out
+loud; when the proper ``function_call`` item is missing, the intended call is
+silently lost as well.
+
+With :class:`~line.llm_agent.config.SpeechLeakGuardConfig` enabled on the
+``LlmConfig``, the streamed message item is buffered with a bounded holdback
+(``lookahead_chars``) and the accumulated text is scanned for
+``detection_pattern``. On a hit the response is aborted *before* its tool
+calls are surfaced or its output committed to history, and the whole
+invocation is retried with a corrective note (and optional reasoning-effort
+override) injected into the retry request only. See ``SpeechLeakGuardConfig``
+for the retry / bridge / fallback semantics.
 """
 
 import asyncio
+import re
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional
 
 from litellm import aresponses
 from loguru import logger
 
-from line.llm_agent.config import LlmConfig
+from line.llm_agent.config import (
+    DEFAULT_SPEECH_LEAK_BRIDGE_TEXT,
+    DEFAULT_SPEECH_LEAK_FALLBACK_TEXT,
+    LlmConfig,
+    SpeechLeakGuardConfig,
+)
 from line.llm_agent.provider import Message, ParsedModelId, StreamChunk, ToolCall
 from line.llm_agent.provider_utils import (
     ConversationEntry,
@@ -67,6 +92,33 @@ _TERMINAL_EVENTS = frozenset(
 )
 
 
+class _SpeechLeakDetected(Exception):
+    """A guarded message item matched the speech-leak detection pattern.
+
+    Raised by :class:`_HttpResponseEventStream` mid-stream, before the
+    response's tool calls are surfaced and before ``on_response_done`` runs —
+    so the aborted attempt executes nothing and leaves no trace in history.
+    Caught by ``_HttpResponsesProvider.chat()`` which decides retry /
+    bridge / fallback per the :class:`SpeechLeakGuardConfig` policy.
+    """
+
+    def __init__(
+        self,
+        *,
+        released_any: bool,
+        phase: str,
+        output_index: int,
+        released_chars: int,
+        suppressed_chars: int,
+    ):
+        super().__init__("speech leak detected in spoken message item")
+        self.released_any = released_any
+        self.phase = phase
+        self.output_index = output_index
+        self.released_chars = released_chars
+        self.suppressed_chars = suppressed_chars
+
+
 class _HttpResponseEventStream:
     """Reads Responses-API streaming events from ``litellm.aresponses`` and
     yields :class:`StreamChunk` objects.
@@ -79,16 +131,26 @@ class _HttpResponseEventStream:
 
     On terminal events the ``on_response_done`` callback is invoked
     with the response dict so the provider can update its history.
+
+    When ``speech_leak_guard`` is an enabled :class:`SpeechLeakGuardConfig`, the
+    streamed message item (if its phase is in ``speech_leak_guard.phases``) is
+    buffered with ``lookahead_chars`` of holdback and scanned for
+    ``detection_pattern``; a hit raises :class:`_SpeechLeakDetected`
+    instead of streaming the payload to TTS.
     """
 
     def __init__(
         self,
         iterator: AsyncIterator[Any],
         on_response_done: Callable[[Dict[str, Any]], None],
+        speech_leak_guard: Optional[SpeechLeakGuardConfig] = None,
     ):
         self._iter = iterator
         self._on_response_done = on_response_done
         self.done = False
+        self._guard = speech_leak_guard if (speech_leak_guard and speech_leak_guard.enabled) else None
+        # re.compile caches internally, so per-stream compilation is cheap.
+        self._guard_re = re.compile(self._guard.detection_pattern) if self._guard else None
 
     async def __aiter__(self) -> AsyncIterator[StreamChunk]:
         tool_calls: Dict[str, ToolCall] = {}
@@ -101,6 +163,14 @@ class _HttpResponseEventStream:
         streaming_index: Optional[int] = None
         dropped_indices_logged: set[int] = set()
         received_content = False
+        # Speech-guard state for the streaming item. guard_active is decided
+        # when the streaming index is claimed (phase in scope?); guard_buf
+        # accumulates the item's full text; guard_released counts chars
+        # already yielded (the tail beyond it is the holdback window).
+        guard_active = False
+        guard_buf = ""
+        guard_released = 0
+        released_any = False  # any text yielded to TTS this response
 
         async for event in self._iter:
             event_type = _event_type(event)
@@ -128,14 +198,48 @@ class _HttpResponseEventStream:
                     continue
                 if streaming_index is None:
                     streaming_index = output_index
+                    phase = message_phases.get(output_index, "(unknown)")
+                    guard_active = self._guard is not None and phase in self._guard.phases
                     logger.debug(
-                        "Responses HTTP: streaming text from output_index={i} phase={p}",
+                        "Responses HTTP: streaming text from output_index={i} phase={p} guarded={g}",
                         i=output_index,
-                        p=message_phases.get(output_index, "(unknown)"),
+                        p=phase,
+                        g=guard_active,
                     )
                 if output_index == streaming_index:
                     received_content = True
-                    yield StreamChunk(text=delta)
+                    if guard_active:
+                        guard_buf += delta
+                        match = self._guard_re.search(guard_buf)
+                        if match:
+                            phase = message_phases.get(output_index, "(unknown)")
+                            suppressed = len(guard_buf) - guard_released
+                            logger.warning(
+                                "Speech-leak guard: tool-call payload detected in spoken "
+                                "text (phase={p}, output_index={i}, match_offset={o}, "
+                                "released_chars={r}, suppressed_chars={s})",
+                                p=phase,
+                                i=output_index,
+                                o=match.start(),
+                                r=guard_released,
+                                s=suppressed,
+                            )
+                            raise _SpeechLeakDetected(
+                                released_any=released_any,
+                                phase=phase,
+                                output_index=output_index,
+                                released_chars=guard_released,
+                                suppressed_chars=suppressed,
+                            )
+                        release_upto = len(guard_buf) - self._guard.lookahead_chars
+                        if release_upto > guard_released:
+                            out = guard_buf[guard_released:release_upto]
+                            guard_released = release_upto
+                            released_any = True
+                            yield StreamChunk(text=out)
+                    else:
+                        released_any = True
+                        yield StreamChunk(text=delta)
                 elif output_index not in dropped_indices_logged:
                     # A second message item is producing text in this response —
                     # log once per dropped index, then silently swallow its
@@ -171,6 +275,18 @@ class _HttpResponseEventStream:
 
             elif event_type == "response.output_item.done":
                 item = event.item
+                if (
+                    item.type == "message"
+                    and guard_active
+                    and int(getattr(event, "output_index", -1)) == streaming_index
+                    and len(guard_buf) > guard_released
+                ):
+                    # Clean item ended with text still in the holdback window —
+                    # flush it. (A leak would have raised before this point.)
+                    out = guard_buf[guard_released:]
+                    guard_released = len(guard_buf)
+                    released_any = True
+                    yield StreamChunk(text=out)
                 if item.type == "function_call":
                     call_id = item.call_id
                     name = item.name
@@ -190,6 +306,13 @@ class _HttpResponseEventStream:
                         tool_calls[call_id] = tc
 
             elif event_type in _TERMINAL_EVENTS:
+                if guard_active and len(guard_buf) > guard_released:
+                    # Defensive: the streaming item never got its
+                    # output_item.done — don't swallow the held tail.
+                    out = guard_buf[guard_released:]
+                    guard_released = len(guard_buf)
+                    released_any = True
+                    yield StreamChunk(text=out)
                 self.done = True
                 response = event.response
                 response_dict = _to_dict(response)
@@ -276,6 +399,63 @@ def _to_dict(obj: Any) -> Dict[str, Any]:
     return dict(getattr(obj, "__dict__", {}) or {})
 
 
+def _apply_speech_leak_retry(body: Dict[str, Any], guard: SpeechLeakGuardConfig) -> None:
+    """Mutate a planned request body into its speech-leak-retry form.
+
+    Applied only to retry requests, after ``_plan_responses_chat`` — so the
+    corrective note is never part of the planner's history bookkeeping and is
+    not re-sent on later turns. (Caveat: with ``store=true`` chaining, the
+    note becomes part of the server-side conversation the accepted response
+    chains from; the default note is harmless-if-persisted by design.)
+    """
+    if guard.retry_note:
+        if guard.retry_note_channel == "instructions":
+            base = body.get("instructions") or ""
+            body["instructions"] = (base + "\n\n" if base else "") + guard.retry_note
+        else:
+            body.setdefault("input", []).append(
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": guard.retry_note}],
+                }
+            )
+    if guard.retry_reasoning_effort:
+        body["reasoning"] = {"effort": guard.retry_reasoning_effort}
+
+
+def _resolve_guard_text(value: Any, *, default: str, what: str) -> str:
+    """Resolve a guard text field that may be a zero-arg callable.
+
+    Callables support language-dynamic agents: the line to speak is computed
+    at speak time, not frozen at config time. A raising callable must not
+    take down leak recovery, so on error the English ``default`` is spoken
+    and the exception logged.
+    """
+    if not callable(value):
+        return value
+    try:
+        return value()
+    except Exception:
+        logger.exception("Speech-leak guard: {w} callable raised; speaking the default line", w=what)
+        return default
+
+
+async def _close_stream_iterator(iterator: Any) -> None:
+    """Best-effort early abort of a litellm ``aresponses`` stream.
+
+    Called when a speech leak is detected mid-stream: the rest of the
+    response is garbage we will never use, so don't wait for it.
+    """
+    aclose = getattr(iterator, "aclose", None)
+    if aclose is None:
+        return
+    try:
+        await aclose()
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
 # ---------------------------------------------------------------------------
 # _HttpResponsesProvider
 # ---------------------------------------------------------------------------
@@ -317,13 +497,27 @@ class _HttpResponsesProvider:
 
         Retries once when the server has forgotten a
         ``previous_response_id`` before any content was emitted.
+
+        When ``config.speech_leak_guard`` is enabled and a spoken tool-call leak
+        is detected, the invocation is aborted (nothing executed, nothing
+        committed) and retried up to ``speech_leak_guard.max_retries`` times with
+        the corrective note / reasoning override applied; on exhaustion the
+        configured fallback line is yielded and the turn ends with no tool
+        calls.
         """
         web_search_options = kwargs.get("web_search_options")
+        guard = (
+            config.speech_leak_guard if isinstance(config.speech_leak_guard, SpeechLeakGuardConfig) else None
+        )
+        if guard is not None and not guard.enabled:
+            guard = None
 
         async def _iter():
             attempt = 0
+            leak_attempts = 0
             while True:
                 emitted_any = False
+                iterator = None
                 try:
                     lock = self._get_lock()
                     await lock.acquire()
@@ -336,6 +530,8 @@ class _HttpResponsesProvider:
                             config=config,
                             web_search_options=web_search_options,
                         )
+                        if guard is not None and leak_attempts:
+                            _apply_speech_leak_retry(body, guard)
 
                         request_kwargs: Dict[str, Any] = dict(body)
                         request_kwargs["model"] = str(self._model_id)
@@ -352,7 +548,7 @@ class _HttpResponsesProvider:
                                 return
                             self._history = _update(self._history, response_dict)
 
-                        stream = _HttpResponseEventStream(iterator, on_response_done)
+                        stream = _HttpResponseEventStream(iterator, on_response_done, speech_leak_guard=guard)
 
                         async for chunk in stream:
                             emitted_any = True
@@ -360,6 +556,47 @@ class _HttpResponsesProvider:
                     finally:
                         lock.release()
                     return
+                except _SpeechLeakDetected as leak:
+                    # The aborted response executed nothing: tool calls only
+                    # surface on the terminal chunk and history only commits
+                    # via on_response_done, neither of which was reached.
+                    if iterator is not None:
+                        await _close_stream_iterator(iterator)
+                    if leak_attempts >= guard.max_retries:
+                        logger.error(
+                            "Speech-leak guard: retry {n} leaked again "
+                            "(suppressed_chars={s}); speaking fallback and ending turn",
+                            n=leak_attempts,
+                            s=leak.suppressed_chars,
+                        )
+                        fallback = _resolve_guard_text(
+                            guard.fallback_text,
+                            default=DEFAULT_SPEECH_LEAK_FALLBACK_TEXT,
+                            what="fallback_text",
+                        )
+                        if fallback:
+                            yield StreamChunk(text=fallback)
+                        yield StreamChunk(tool_calls=[], is_final=True)
+                        return
+                    leak_attempts += 1
+                    logger.warning(
+                        "Speech-leak guard: retrying LLM invocation "
+                        "(retry {n}/{m}, note_channel={c}, reasoning_effort={e}, "
+                        "caller_heard_partial={h})",
+                        n=leak_attempts,
+                        m=guard.max_retries,
+                        c=guard.retry_note_channel,
+                        e=guard.retry_reasoning_effort or "(unchanged)",
+                        h=leak.released_any,
+                    )
+                    if leak.released_any:
+                        bridge = _resolve_guard_text(
+                            guard.bridge_text,
+                            default=DEFAULT_SPEECH_LEAK_BRIDGE_TEXT,
+                            what="bridge_text",
+                        )
+                        if bridge:
+                            yield StreamChunk(text=bridge)
                 except RuntimeError as exc:
                     if "previous_response_not_found" not in str(exc) or emitted_any or attempt >= 1:
                         raise

--- a/line/llm_agent/http_responses_provider.py
+++ b/line/llm_agent/http_responses_provider.py
@@ -35,8 +35,9 @@ Strategy: phase-blind, "first textual message item wins". The first
 non-empty ``output_text.delta`` claims an ``output_index``; all deltas
 for that index stream as they arrive, and deltas from any later
 message item in the same response are dropped. Tool calls and
-single-message responses are unaffected. Phase is recorded only for
-log clarity.
+single-message responses are unaffected. Phase does not influence which
+item streams; it feeds the logs and the speech-leak guard's skip
+decision (below).
 
 See the consumer repo's ``cartesia-examples/`` for standalone
 reproductions of the duplicate-text and preamble-before-tool patterns.
@@ -106,7 +107,7 @@ class _SpeechLeakDetected(Exception):
         self,
         *,
         released_any: bool,
-        phase: str,
+        phase: Optional[str],
         output_index: int,
         released_chars: int,
         suppressed_chars: int,
@@ -132,11 +133,13 @@ class _HttpResponseEventStream:
     On terminal events the ``on_response_done`` callback is invoked
     with the response dict so the provider can update its history.
 
-    When ``speech_leak_guard`` is an enabled :class:`SpeechLeakGuardConfig`, the
-    streamed message item (if its phase is in ``speech_leak_guard.phases``) is
-    buffered with ``lookahead_chars`` of holdback and scanned for
-    ``detection_pattern``; a hit raises :class:`_SpeechLeakDetected`
-    instead of streaming the payload to TTS.
+    When ``speech_leak_guard`` is an enabled :class:`SpeechLeakGuardConfig`,
+    the streamed message item is buffered with ``lookahead_chars`` of
+    holdback and scanned for ``detection_pattern``; a hit raises
+    :class:`_SpeechLeakDetected` instead of streaming the payload to TTS.
+    Only items explicitly labeled with a ``phase`` in
+    ``speech_leak_guard.skip_phases`` are exempt — an item with a missing or
+    unknown phase label is always guarded.
     """
 
     def __init__(
@@ -154,19 +157,22 @@ class _HttpResponseEventStream:
 
     async def __aiter__(self) -> AsyncIterator[StreamChunk]:
         tool_calls: Dict[str, ToolCall] = {}
-        # output_index -> phase tag, kept for log clarity only. The streaming
-        # decision below is phase-blind — first textual message item in a
+        # output_index -> raw ``phase`` label as the API sent it (None when
+        # the item carries none — models predating the phase field never send
+        # one). Feeds the guard's skip decision and the logs; the *streaming*
+        # decision below stays phase-blind — first textual message item in a
         # response wins; subsequent textual items are dropped.
-        message_phases: Dict[int, str] = {}
+        message_phases: Dict[int, Optional[str]] = {}
         # output_index whose deltas are being streamed this response. Set on
         # the first non-empty delta of any message item.
         streaming_index: Optional[int] = None
         dropped_indices_logged: set[int] = set()
         received_content = False
         # Speech-guard state for the streaming item. guard_active is decided
-        # when the streaming index is claimed (phase in scope?); guard_buf
-        # accumulates the item's full text; guard_released counts chars
-        # already yielded (the tail beyond it is the holdback window).
+        # when the streaming index is claimed (guarded unless the item's
+        # phase label is explicitly in skip_phases); guard_buf accumulates
+        # the item's full text; guard_released counts chars already yielded
+        # (the tail beyond it is the holdback window).
         guard_active = False
         guard_buf = ""
         guard_released = 0
@@ -183,8 +189,7 @@ class _HttpResponseEventStream:
                 output_index = event.output_index
                 item_type = item.type
                 if item_type == "message":
-                    phase = getattr(item, "phase", None) or "final_answer"
-                    message_phases[int(output_index)] = phase
+                    message_phases[int(output_index)] = getattr(item, "phase", None)
                 elif item_type == "function_call":
                     call_id = item.call_id
                     name = item.name
@@ -198,10 +203,13 @@ class _HttpResponseEventStream:
                     continue
                 if streaming_index is None:
                     streaming_index = output_index
-                    phase = message_phases.get(output_index, "(unknown)")
-                    guard_active = self._guard is not None and phase in self._guard.phases
+                    # None covers both an unlabeled item and an item whose
+                    # output_item.added was never seen; neither is in
+                    # skip_phases, so both are guarded (fail closed).
+                    phase = message_phases.get(output_index)
+                    guard_active = self._guard is not None and phase not in self._guard.skip_phases
                     logger.debug(
-                        "Responses HTTP: streaming text from output_index={i} phase={p} guarded={g}",
+                        "Responses HTTP: streaming text from output_index={i} phase={p!r} guarded={g}",
                         i=output_index,
                         p=phase,
                         g=guard_active,
@@ -212,11 +220,11 @@ class _HttpResponseEventStream:
                         guard_buf += delta
                         match = self._guard_re.search(guard_buf)
                         if match:
-                            phase = message_phases.get(output_index, "(unknown)")
+                            phase = message_phases.get(output_index)
                             suppressed = len(guard_buf) - guard_released
                             logger.warning(
                                 "Speech-leak guard: tool-call payload detected in spoken "
-                                "text (phase={p}, output_index={i}, match_offset={o}, "
+                                "text (phase={p!r}, output_index={i}, match_offset={o}, "
                                 "released_chars={r}, suppressed_chars={s})",
                                 p=phase,
                                 i=output_index,
@@ -248,12 +256,12 @@ class _HttpResponseEventStream:
                     # text) and respects "one reply per turn".
                     dropped_indices_logged.add(output_index)
                     logger.debug(
-                        "Responses HTTP: dropping text from output_index={i} phase={p} "
-                        "(already streaming output_index={s} phase={sp})",
+                        "Responses HTTP: dropping text from output_index={i} phase={p!r} "
+                        "(already streaming output_index={s} phase={sp!r})",
                         i=output_index,
-                        p=message_phases.get(output_index, "(unknown)"),
+                        p=message_phases.get(output_index),
                         s=streaming_index,
-                        sp=message_phases.get(streaming_index, "(unknown)"),
+                        sp=message_phases.get(streaming_index),
                     )
 
             elif event_type == "response.function_call_arguments.delta":

--- a/tests/test_speech_leak_guard.py
+++ b/tests/test_speech_leak_guard.py
@@ -1,0 +1,656 @@
+"""Tests for the speech-leak guard in the HTTPS Responses-API provider.
+
+Some reasoning models (observed in production: ``gpt-5.4-mini``) sometimes
+write a tool call's payload into the user-visible ``commentary`` message item
+— as bare JSON arguments or as a whole spoken call expression
+(``record_call_summary({...})``) — instead of, or in addition to, the proper
+``function_call`` item. The delta sequences in these fixtures replay the
+shapes captured from four production calls.
+
+Two layers under test:
+
+- ``_HttpResponseEventStream`` + ``SpeechLeakGuardConfig``: bounded-lookahead
+  buffering, search-mode detection anywhere in the item, holdback flush on
+  clean items, phase scoping, released-any tracking.
+- ``_HttpResponsesProvider.chat()``: abort + retry-once with the corrective
+  note / reasoning override applied to the retry request only, bridge text
+  when the caller heard part of the failed attempt, fallback text when the
+  retry leaks too, and history committed only for the accepted attempt.
+"""
+
+import asyncio
+from typing import Any, AsyncIterator, Dict, List
+
+from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
+import pytest
+
+from line.llm_agent.config import (
+    DEFAULT_SPEECH_LEAK_FALLBACK_TEXT,
+    LlmConfig,
+    SpeechLeakGuardConfig,
+    _normalize_config,
+)
+from line.llm_agent.http_responses_provider import (
+    _HttpResponseEventStream,
+    _HttpResponsesProvider,
+    _SpeechLeakDetected,
+)
+from line.llm_agent.provider import Message, ParsedModelId, StreamChunk
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _pydantify(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return BaseLiteLLMOpenAIResponseObject(**{k: _pydantify(v) for k, v in obj.items()})
+    if isinstance(obj, list):
+        return [_pydantify(x) for x in obj]
+    return obj
+
+
+async def _aiter(events: List[Dict[str, Any]]) -> AsyncIterator[Any]:
+    for event in events:
+        yield _pydantify(event)
+
+
+async def _drive(events: List[Dict[str, Any]], guard: SpeechLeakGuardConfig) -> List[StreamChunk]:
+    stream = _HttpResponseEventStream(_aiter(events), lambda response: None, speech_leak_guard=guard)
+    chunks: List[StreamChunk] = []
+    async for chunk in stream:
+        chunks.append(chunk)
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _msg_added(idx: int, phase: str, item_id: str) -> Dict[str, Any]:
+    return {
+        "type": "response.output_item.added",
+        "output_index": idx,
+        "item": {"type": "message", "phase": phase, "id": item_id},
+    }
+
+
+def _delta(idx: int, item_id: str, text: str) -> Dict[str, Any]:
+    return {
+        "type": "response.output_text.delta",
+        "output_index": idx,
+        "item_id": item_id,
+        "content_index": 0,
+        "delta": text,
+    }
+
+
+def _msg_done(idx: int, phase: str, item_id: str, text: str) -> Dict[str, Any]:
+    return {
+        "type": "response.output_item.done",
+        "output_index": idx,
+        "item": {
+            "type": "message",
+            "phase": phase,
+            "id": item_id,
+            "content": [{"type": "output_text", "text": text}],
+        },
+    }
+
+
+def _completed(response_id: str = "resp_1") -> Dict[str, Any]:
+    return {
+        "type": "response.completed",
+        "response": {"id": response_id, "status": "completed", "output": []},
+    }
+
+
+def _message_events(
+    deltas: List[str], *, idx: int = 0, phase: str = "commentary", item_id: str = "msg_0"
+) -> List[Dict[str, Any]]:
+    """A full clean single-message response from its delta sequence."""
+    text = "".join(deltas)
+    return [
+        _msg_added(idx, phase, item_id),
+        *[_delta(idx, item_id, d) for d in deltas],
+        _msg_done(idx, phase, item_id, text),
+        _completed(),
+    ]
+
+
+# Production leak, first observed shape:
+# bare record_call_summary arguments streamed as 1-5 char commentary deltas
+# on output_index=1 (a reasoning item held index 0).
+_BARE_JSON_LEAK_DELTAS = [
+    '{"',
+    "summary",
+    '":"',
+    "The",
+    " caller",
+    " called",
+    " about",
+    " getting",
+    " more",
+    " information",
+    '.","',
+    "property",
+    "_address",
+    "_out",
+    "come",
+    '":"',
+    "not",
+    "_est",
+    "ablished",
+    '"}',
+]
+
+# Production leak, second observed shape:
+# the model verbalized the whole call expression, tool name included.
+_SPOKEN_CALL_LEAK_DELTAS = [
+    "record",
+    "_call",
+    "_summary",
+    "({\n",
+    " ",
+    ' "',
+    "summary",
+    '":"',
+    "Caller",
+    " called",
+    " for",
+    " more",
+    " information",
+    '."',
+    " })",
+]
+
+
+def _leak_events(deltas: List[str], *, idx: int = 1, phase: str = "commentary") -> List[Dict[str, Any]]:
+    """A response whose streamed message item is a leak. No done/completed
+    events follow the deltas — detection must abort before the stream ends,
+    exactly as the provider does in production (early abort)."""
+    return [
+        _msg_added(idx, phase, f"msg_{idx}"),
+        *[_delta(idx, f"msg_{idx}", d) for d in deltas],
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Stream-level: detection
+# ---------------------------------------------------------------------------
+
+
+def test_bare_json_leak_detected_before_anything_released():
+    """Call-1 shape: `{"summary":...}` as commentary. The very first delta
+    matches the JSON-object alternative; nothing reaches TTS."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+
+    async def drive():
+        return await _drive(_leak_events(_BARE_JSON_LEAK_DELTAS), guard)
+
+    with pytest.raises(_SpeechLeakDetected) as exc_info:
+        _run(drive())
+    leak = exc_info.value
+    assert leak.released_any is False
+    assert leak.released_chars == 0
+    assert leak.phase == "commentary"
+
+
+def test_spoken_call_expression_leak_detected():
+    """Call-2 shape: `record_call_summary({. "summary":...})` — the tool-name
+    form, only detectable once `({`/`("` arrives. The identifier sits inside
+    the holdback window until then, so nothing is released."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+
+    async def drive():
+        return await _drive(_leak_events(_SPOKEN_CALL_LEAK_DELTAS), guard)
+
+    with pytest.raises(_SpeechLeakDetected) as exc_info:
+        _run(drive())
+    assert exc_info.value.released_any is False
+
+
+def test_pattern_straddling_delta_boundary_is_detected():
+    """`{` and `"` arriving in separate deltas must still match — the scan
+    runs over the accumulated item text, not per-delta."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+
+    async def drive():
+        return await _drive(_leak_events(["{", '"summary": "x"}']), guard)
+
+    with pytest.raises(_SpeechLeakDetected):
+        _run(drive())
+
+
+def test_leak_after_released_prefix_reports_released_any():
+    """Tripwire: a natural prefix longer than the holdback window streams
+    out, then the JSON starts. The leak is still caught (search mode), and
+    released_any tells the provider a bridge line is needed."""
+    guard = SpeechLeakGuardConfig(enabled=True, lookahead_chars=16)
+    prefix = "Thank you for holding, I have noted everything down now. "
+    events = _leak_events([prefix, '{"summary": "x"}'])
+
+    released: List[str] = []
+
+    async def drive():
+        stream = _HttpResponseEventStream(_aiter(events), lambda response: None, speech_leak_guard=guard)
+        async for chunk in stream:
+            if chunk.text:
+                released.append(chunk.text)
+
+    with pytest.raises(_SpeechLeakDetected) as exc_info:
+        _run(drive())
+    leak = exc_info.value
+    assert leak.released_any is True
+    assert leak.released_chars > 0
+    spoken = "".join(released)
+    assert "{" not in spoken, f"leak content must never reach TTS; got {spoken!r}"
+    assert prefix.startswith(spoken.split("{")[0][:8])
+
+
+# ---------------------------------------------------------------------------
+# Stream-level: clean traffic is unharmed
+# ---------------------------------------------------------------------------
+
+
+def test_clean_short_item_flushes_full_text_on_item_done():
+    """An item shorter than the holdback window is held entirely, then
+    flushed intact when the item completes. No text is lost."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+    text = "Your code is on the way."
+    chunks = _run(_drive(_message_events([text]), guard))
+    assert "".join(c.text for c in chunks if c.text) == text
+    assert chunks[-1].is_final is True
+
+
+def test_clean_long_item_streams_with_holdback_and_loses_nothing():
+    """A long clean item releases text as it accumulates (all but the last
+    lookahead_chars), and the item-done flush delivers the tail."""
+    guard = SpeechLeakGuardConfig(enabled=True, lookahead_chars=16)
+    deltas = [
+        "Sorry — I want to make sure I have this right. ",
+        "Is your property address 35 North Green Bay Road, ",
+        "Lake Forest, IL 60045?",
+    ]
+    events = _message_events(deltas)
+
+    async def drive():
+        stream = _HttpResponseEventStream(_aiter(events), lambda response: None, speech_leak_guard=guard)
+        collected: List[StreamChunk] = []
+        pre_done_text_len = 0
+        seen_done = False
+        async for chunk in stream:
+            collected.append(chunk)
+            if chunk.text and not seen_done:
+                pre_done_text_len += len(chunk.text)
+        return collected, pre_done_text_len
+
+    chunks, _ = _run(drive())
+    assert "".join(c.text for c in chunks if c.text) == "".join(deltas)
+    # More than one text chunk proves streaming happened before the flush.
+    assert len([c for c in chunks if c.text]) > 1
+
+
+def test_email_style_readback_is_not_flagged():
+    """`name(at)domain` spoken read-backs must not match the call-expression
+    alternative (it requires `{` or `"` right after the paren)."""
+    guard = SpeechLeakGuardConfig(enabled=True, lookahead_chars=8)
+    text = "I have your email as john_doe(at)example.com. Is that right?"
+    chunks = _run(_drive(_message_events([text]), guard))
+    assert "".join(c.text for c in chunks if c.text) == text
+
+
+def test_final_answer_phase_not_guarded_by_default():
+    """Default scope is commentary-only: a JSON-looking final_answer item
+    streams through untouched (leaks have only been observed on commentary)."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+    text = '{"summary": "x"}'
+    chunks = _run(_drive(_message_events([text], phase="final_answer"), guard))
+    assert "".join(c.text for c in chunks if c.text) == text
+
+
+def test_final_answer_guarded_when_scoped_in():
+    guard = SpeechLeakGuardConfig(enabled=True, phases=frozenset({"commentary", "final_answer"}))
+
+    async def drive():
+        return await _drive(_leak_events(['{"a": 1}'], phase="final_answer"), guard)
+
+    with pytest.raises(_SpeechLeakDetected):
+        _run(drive())
+
+
+def test_disabled_guard_streams_leak_verbatim():
+    """Regression pin for default-off behavior: without the guard the leak
+    streams to TTS exactly as before (this is the production bug)."""
+    guard = SpeechLeakGuardConfig(enabled=False)
+    events = _leak_events(_BARE_JSON_LEAK_DELTAS) + [
+        _msg_done(1, "commentary", "msg_1", "".join(_BARE_JSON_LEAK_DELTAS)),
+        _completed(),
+    ]
+    chunks = _run(_drive(events, guard))
+    assert "".join(c.text for c in chunks if c.text) == "".join(_BARE_JSON_LEAK_DELTAS)
+
+
+# ---------------------------------------------------------------------------
+# Provider-level: retry / bridge / fallback via chat()
+# ---------------------------------------------------------------------------
+
+_CLEAN_TEXT = "Let me get you to one of our team members now."
+
+
+def _clean_response_events(response_id: str = "resp_clean") -> List[Dict[str, Any]]:
+    return [
+        _msg_added(0, "commentary", "msg_c"),
+        _delta(0, "msg_c", _CLEAN_TEXT),
+        _msg_done(0, "commentary", "msg_c", _CLEAN_TEXT),
+        {
+            "type": "response.completed",
+            "response": {"id": response_id, "status": "completed", "output": []},
+        },
+    ]
+
+
+class _FakeAresponses:
+    """Stands in for litellm.aresponses: returns scripted event streams and
+    records each request's kwargs for assertions."""
+
+    def __init__(self, scripts: List[List[Dict[str, Any]]]):
+        self._scripts = list(scripts)
+        self.requests: List[Dict[str, Any]] = []
+
+    async def __call__(self, **request_kwargs: Any) -> AsyncIterator[Any]:
+        self.requests.append(request_kwargs)
+        if not self._scripts:
+            raise AssertionError("aresponses called more times than scripted")
+        return _aiter(self._scripts.pop(0))
+
+
+def _make_provider_and_config(guard: SpeechLeakGuardConfig):
+    # zdr_enabled=False so history commits are observable: the ZDR planner's
+    # per-turn history update is deliberately a no-op (full input each turn),
+    # which would make "was this attempt committed?" unobservable.
+    provider = _HttpResponsesProvider(ParsedModelId("openai", "gpt-5.4-mini"), api_key="test")
+    config = _normalize_config(
+        LlmConfig(
+            system_prompt="You are a test agent.",
+            zdr_enabled=False,
+            speech_leak_guard=guard,
+        )
+    )
+    return provider, config
+
+
+async def _collect_chat(provider, config) -> List[StreamChunk]:
+    chunks: List[StreamChunk] = []
+    async with provider.chat([Message(role="user", content="hello")], config=config) as stream:
+        async for chunk in stream:
+            chunks.append(chunk)
+    return chunks
+
+
+def test_chat_retries_once_and_streams_clean_second_attempt(monkeypatch):
+    guard = SpeechLeakGuardConfig(enabled=True, retry_reasoning_effort="medium")
+    fake = _FakeAresponses([_leak_events(_BARE_JSON_LEAK_DELTAS), _clean_response_events()])
+    monkeypatch.setattr("line.llm_agent.http_responses_provider.aresponses", fake)
+    provider, config = _make_provider_and_config(guard)
+
+    chunks = _run(_collect_chat(provider, config))
+
+    assert "".join(c.text for c in chunks if c.text) == _CLEAN_TEXT
+    assert chunks[-1].is_final is True
+    assert len(fake.requests) == 2
+
+    # The retry request — and only the retry request — carries the
+    # corrective developer note and the reasoning-effort override.
+    first, second = fake.requests
+    assert not any(item.get("role") == "developer" for item in first.get("input", []))
+    dev_items = [item for item in second["input"] if item.get("role") == "developer"]
+    assert len(dev_items) == 1
+    assert "discarded" in dev_items[0]["content"][0]["text"]
+    assert second["reasoning"] == {"effort": "medium"}
+
+    # Only the accepted attempt was committed to history (non-ZDR mode, so
+    # a successful commit is visible as populated history).
+    assert len(provider._history) > 0
+
+
+def test_chat_double_leak_speaks_fallback_and_ends_turn(monkeypatch):
+    guard = SpeechLeakGuardConfig(enabled=True)
+    fake = _FakeAresponses([_leak_events(_BARE_JSON_LEAK_DELTAS), _leak_events(_SPOKEN_CALL_LEAK_DELTAS)])
+    monkeypatch.setattr("line.llm_agent.http_responses_provider.aresponses", fake)
+    provider, config = _make_provider_and_config(guard)
+
+    chunks = _run(_collect_chat(provider, config))
+
+    texts = [c.text for c in chunks if c.text]
+    assert texts == [guard.fallback_text]
+    assert chunks[-1].is_final is True
+    assert chunks[-1].tool_calls == []
+    assert len(fake.requests) == 2  # initial + max_retries(1), then gave up
+    assert provider._history == []  # neither leaked attempt was committed
+
+
+def test_chat_speaks_bridge_when_caller_heard_part_of_failed_attempt(monkeypatch):
+    guard = SpeechLeakGuardConfig(enabled=True, lookahead_chars=16)
+    prefix = "Thank you for holding, I have everything I need from you now. "
+    leak_attempt = _leak_events([prefix, '{"summary": "x"}'])
+    fake = _FakeAresponses([leak_attempt, _clean_response_events()])
+    monkeypatch.setattr("line.llm_agent.http_responses_provider.aresponses", fake)
+    provider, config = _make_provider_and_config(guard)
+
+    chunks = _run(_collect_chat(provider, config))
+
+    texts = [c.text for c in chunks if c.text]
+    assert guard.bridge_text in texts
+    bridge_pos = texts.index(guard.bridge_text)
+    # Some prefix speech precedes the bridge; the clean reply follows it.
+    assert bridge_pos > 0
+    assert "".join(texts[bridge_pos + 1 :]) == _CLEAN_TEXT
+
+
+def test_chat_retry_note_via_instructions_channel(monkeypatch):
+    guard = SpeechLeakGuardConfig(enabled=True, retry_note_channel="instructions")
+    fake = _FakeAresponses([_leak_events(_BARE_JSON_LEAK_DELTAS), _clean_response_events()])
+    monkeypatch.setattr("line.llm_agent.http_responses_provider.aresponses", fake)
+    provider, config = _make_provider_and_config(guard)
+
+    _run(_collect_chat(provider, config))
+
+    first, second = fake.requests
+    assert guard.retry_note not in (first.get("instructions") or "")
+    assert (second.get("instructions") or "").endswith(guard.retry_note)
+    assert not any(item.get("role") == "developer" for item in second.get("input", []))
+
+
+def test_chat_without_guard_streams_leak_as_before(monkeypatch):
+    """No guard configured → single request, leak streams to TTS (pins the
+    pre-guard behavior so enabling is a strict opt-in)."""
+    leak_text = "".join(_BARE_JSON_LEAK_DELTAS)
+    events = _leak_events(_BARE_JSON_LEAK_DELTAS) + [
+        _msg_done(1, "commentary", "msg_1", leak_text),
+        _completed(),
+    ]
+    fake = _FakeAresponses([events])
+    monkeypatch.setattr("line.llm_agent.http_responses_provider.aresponses", fake)
+    provider = _HttpResponsesProvider(ParsedModelId("openai", "gpt-5.4-mini"), api_key="test")
+    config = _normalize_config(LlmConfig(system_prompt="x", zdr_enabled=True))
+
+    chunks = _run(_collect_chat(provider, config))
+
+    assert "".join(c.text for c in chunks if c.text) == leak_text
+    assert len(fake.requests) == 1
+
+
+def test_chat_callable_texts_resolved_at_speak_time(monkeypatch):
+    """bridge_text / fallback_text may be zero-arg callables (multilingual
+    agents pick the line by current language at speak time, not config time)."""
+    lines_spoken: List[str] = []
+
+    def bridge() -> str:
+        lines_spoken.append("bridge")
+        return "Un instant, je reprends."
+
+    def fallback() -> str:
+        lines_spoken.append("fallback")
+        return "Désolé, un souci technique. Voulez-vous que je réessaie ?"
+
+    guard = SpeechLeakGuardConfig(
+        enabled=True, lookahead_chars=16, bridge_text=bridge, fallback_text=fallback
+    )
+    prefix = "Merci de patienter, j'ai tout ce qu'il me faut. "
+    fake = _FakeAresponses(
+        [
+            _leak_events([prefix, '{"summary": "x"}']),  # heard prefix → bridge
+            _leak_events(_BARE_JSON_LEAK_DELTAS),  # leaks again → fallback
+        ]
+    )
+    monkeypatch.setattr("line.llm_agent.http_responses_provider.aresponses", fake)
+    provider, config = _make_provider_and_config(guard)
+
+    chunks = _run(_collect_chat(provider, config))
+
+    texts = [c.text for c in chunks if c.text]
+    assert "Un instant, je reprends." in texts
+    assert texts[-1] == "Désolé, un souci technique. Voulez-vous que je réessaie ?"
+    assert lines_spoken == ["bridge", "fallback"]  # each invoked exactly once, on demand
+
+
+def test_chat_callable_text_returning_empty_speaks_nothing(monkeypatch):
+    guard = SpeechLeakGuardConfig(enabled=True, fallback_text=lambda: "")
+    fake = _FakeAresponses([_leak_events(_BARE_JSON_LEAK_DELTAS), _leak_events(_BARE_JSON_LEAK_DELTAS)])
+    monkeypatch.setattr("line.llm_agent.http_responses_provider.aresponses", fake)
+    provider, config = _make_provider_and_config(guard)
+
+    chunks = _run(_collect_chat(provider, config))
+
+    assert [c.text for c in chunks if c.text] == []
+    assert chunks[-1].is_final is True
+
+
+def test_chat_crashing_text_callable_falls_back_to_default(monkeypatch):
+    """A raising callable must not take down leak recovery: the English
+    default line is spoken and the turn still ends cleanly."""
+
+    def boom() -> str:
+        raise RuntimeError("translation service down")
+
+    guard = SpeechLeakGuardConfig(enabled=True, max_retries=0, fallback_text=boom)
+    fake = _FakeAresponses([_leak_events(_BARE_JSON_LEAK_DELTAS)])
+    monkeypatch.setattr("line.llm_agent.http_responses_provider.aresponses", fake)
+    provider, config = _make_provider_and_config(guard)
+
+    chunks = _run(_collect_chat(provider, config))
+
+    texts = [c.text for c in chunks if c.text]
+    assert texts == [DEFAULT_SPEECH_LEAK_FALLBACK_TEXT]
+    assert chunks[-1].is_final is True
+
+
+# ---------------------------------------------------------------------------
+# Degraded harmony-header leak shapes (no paren, no leading brace) — observed
+# in production calls and replay sampling: the tool-call header corrupts into
+# visible text as tool name + glitch-token run + `json {…`, sometimes with
+# `to=functions.…` / `functions.…` markers.
+# ---------------------------------------------------------------------------
+
+_GLITCH_HEADER_LEAK_DELTAS = [
+    "record",
+    "_call",
+    "_summary",
+    "  彩",
+    "神争",
+    "霸大发",
+    "json",
+    ' {"',
+    "summary",
+    '":"',
+    "Caller",
+    " asked",
+    " for",
+    " a",
+    " repeat",
+    '."}',
+]
+
+_TO_FUNCTIONS_LEAK_DELTAS = [
+    "record",
+    "_call",
+    "_summary",
+    " to",
+    "=functions",
+    ".record",
+    "_call",
+    "_summary",
+    "  天天中",
+    "彩票出票",
+    "json",
+    ' {"summary":"x"}',
+]
+
+
+def test_glitch_header_leak_detected_with_nothing_released():
+    """Tool name + glitch tokens + `json {"` — no paren, no leading brace.
+    Detection lands on the JSON-object alternative at offset ~30; the default
+    128-char holdback must keep every character inaudible (with the previous
+    64-char default and a longer glitch run, 3 chars escaped in production)."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+
+    async def drive():
+        return await _drive(_leak_events(_GLITCH_HEADER_LEAK_DELTAS), guard)
+
+    with pytest.raises(_SpeechLeakDetected) as exc_info:
+        _run(drive())
+    leak = exc_info.value
+    assert leak.released_any is False
+    assert leak.released_chars == 0
+
+
+def test_to_functions_marker_detected_before_json_arrives():
+    """The `to=functions.` recipient marker is pure protocol syntax and fires
+    on its own — detection must not have to wait for the `{"` payload."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+    # Only the deltas up to and including the marker (`to=functions.`);
+    # no JSON ever arrives.
+    deltas = _TO_FUNCTIONS_LEAK_DELTAS[:6]
+
+    async def drive():
+        return await _drive(_leak_events(deltas), guard)
+
+    with pytest.raises(_SpeechLeakDetected) as exc_info:
+        _run(drive())
+    assert exc_info.value.released_chars == 0
+
+
+def test_functions_namespace_prefix_detected():
+    guard = SpeechLeakGuardConfig(enabled=True)
+
+    async def drive():
+        return await _drive(_leak_events(["functions", ".record_call", "_summary  xyz"]), guard)
+
+    with pytest.raises(_SpeechLeakDetected):
+        _run(drive())
+
+
+def test_harmony_special_token_delimiter_detected():
+    guard = SpeechLeakGuardConfig(enabled=True)
+
+    async def drive():
+        return await _drive(_leak_events(["<|", "constrain|>json"]), guard)
+
+    with pytest.raises(_SpeechLeakDetected):
+        _run(drive())
+
+
+def test_prose_containing_functions_word_streams_clean():
+    """`functions` as an ordinary English word (followed by space or sentence
+    punctuation) must not trip the namespace-prefix alternative, and text
+    longer than the 128-char holdback still streams and flushes losslessly."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+    text = (
+        "Everything functions normally on your account. This tool functions. "
+        "Also, I want to make sure I have this right — is your property "
+        "address 35 North Green Bay Road, Lake Forest, IL 60045?"
+    )
+    chunks = _run(_drive(_message_events([text[:80], text[80:]]), guard))
+    assert "".join(c.text for c in chunks if c.text) == text

--- a/tests/test_speech_leak_guard.py
+++ b/tests/test_speech_leak_guard.py
@@ -19,7 +19,7 @@ Two layers under test:
 """
 
 import asyncio
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict, List, Optional
 
 from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
 import pytest
@@ -68,7 +68,7 @@ async def _drive(events: List[Dict[str, Any]], guard: SpeechLeakGuardConfig) -> 
 # ---------------------------------------------------------------------------
 
 
-def _msg_added(idx: int, phase: str, item_id: str) -> Dict[str, Any]:
+def _msg_added(idx: int, phase: Optional[str], item_id: str) -> Dict[str, Any]:
     return {
         "type": "response.output_item.added",
         "output_index": idx,
@@ -301,23 +301,105 @@ def test_email_style_readback_is_not_flagged():
     assert "".join(c.text for c in chunks if c.text) == text
 
 
-def test_final_answer_phase_not_guarded_by_default():
-    """Default scope is commentary-only: a JSON-looking final_answer item
-    streams through untouched (leaks have only been observed on commentary)."""
+def test_final_answer_phase_skipped_by_default():
+    """final_answer is in the default skip set: a JSON-looking final_answer
+    item streams through untouched (leaks have only been observed on
+    commentary)."""
     guard = SpeechLeakGuardConfig(enabled=True)
     text = '{"summary": "x"}'
     chunks = _run(_drive(_message_events([text], phase="final_answer"), guard))
     assert "".join(c.text for c in chunks if c.text) == text
 
 
-def test_final_answer_guarded_when_scoped_in():
-    guard = SpeechLeakGuardConfig(enabled=True, phases=frozenset({"commentary", "final_answer"}))
+def test_final_answer_guarded_with_empty_skip_set():
+    """skip_phases=frozenset() guards every spoken item, final_answer included."""
+    guard = SpeechLeakGuardConfig(enabled=True, skip_phases=frozenset())
 
     async def drive():
         return await _drive(_leak_events(['{"a": 1}'], phase="final_answer"), guard)
 
     with pytest.raises(_SpeechLeakDetected):
         _run(drive())
+
+
+# ---------------------------------------------------------------------------
+# Stream-level: unlabeled / unknown phases are guarded (fail closed)
+# ---------------------------------------------------------------------------
+
+
+def _msg_added_no_phase(idx: int, item_id: str) -> Dict[str, Any]:
+    """An output_item.added whose message item carries NO phase attribute —
+    the wire shape of models predating the phase field (gpt-5-mini, gpt-4.1)."""
+    return {
+        "type": "response.output_item.added",
+        "output_index": idx,
+        "item": {"type": "message", "id": item_id},
+    }
+
+
+def test_leak_in_item_without_phase_attribute_is_guarded():
+    """Models that never send ``phase`` must still be protected: absence of a
+    label is not evidence of safety."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+    events = [
+        _msg_added_no_phase(0, "msg_0"),
+        _delta(0, "msg_0", '{"summary": "x"}'),
+    ]
+
+    with pytest.raises(_SpeechLeakDetected) as exc_info:
+        _run(_drive(events, guard))
+    assert exc_info.value.phase is None
+
+
+def test_leak_in_item_with_none_phase_is_guarded():
+    """litellm's typed objects may materialize an absent wire field as an
+    explicit ``phase=None`` — must be treated the same as attr-missing."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+    events = [
+        _msg_added(0, None, "msg_0"),
+        _delta(0, "msg_0", '{"summary": "x"}'),
+    ]
+
+    with pytest.raises(_SpeechLeakDetected):
+        _run(_drive(events, guard))
+
+
+def test_leak_in_unregistered_item_is_guarded():
+    """Deltas arriving for an output_index with no output_item.added at all
+    (degraded stream) must be guarded, not silently exempted."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+    events = [_delta(2, "msg_2", '{"summary": "x"}')]
+
+    with pytest.raises(_SpeechLeakDetected) as exc_info:
+        _run(_drive(events, guard))
+    assert exc_info.value.phase is None
+
+
+def test_leak_in_unrecognized_phase_label_is_guarded():
+    """A future/unknown phase label is not in the skip set → guarded."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+
+    async def drive():
+        return await _drive(_leak_events(['{"a": 1}'], phase="plan"), guard)
+
+    with pytest.raises(_SpeechLeakDetected):
+        _run(drive())
+
+
+def test_clean_unlabeled_item_streams_in_full():
+    """The guard on unlabeled items must not cost any text: a clean item from
+    a phase-less model is held back, then flushed intact."""
+    guard = SpeechLeakGuardConfig(enabled=True)
+    text = "Your appointment is confirmed for Tuesday at three."
+    events = [
+        _msg_added_no_phase(0, "msg_0"),
+        _delta(0, "msg_0", text),
+        _msg_done(0, "commentary", "msg_0", text),
+        _completed(),
+    ]
+    chunks = _run(_drive(events, guard))
+    assert "".join(c.text for c in chunks if c.text) == text
+    assert chunks[-1].is_final is True
 
 
 def test_disabled_guard_streams_leak_verbatim():


### PR DESCRIPTION
## What does this PR do?

Adds an **opt-in speech-leak guard** to the `http_responses` backend that stops tool-call payloads from being read out loud by TTS.

**The problem:** some reasoning models (observed in production with `gpt-5.4-mini`) occasionally write a tool call's payload into the user-visible `message` item — as bare JSON arguments (`{"summary": ...}`), as the whole call expression (`record_call_summary({...})`), or as a corrupted harmony tool-call header (tool name + glitch tokens + `json {"...`) — instead of, or in addition to, the proper `function_call` item. Streamed as-is, the caller hears raw JSON read out loud; when the `function_call` item is missing, the intended call is silently lost as well.

**The guard** (`SpeechLeakGuardConfig`, enabled via `LlmConfig(speech_leak_guard=...)`):

- Buffers each streamed spoken message item with a bounded holdback window (128 chars) and scans the accumulated text for tool-call signatures: JSON-object opens, call expressions, and harmony protocol artifacts (`to=functions.`, `functions.<ident>`, `<|` tokens). Clean items flush their held tail the moment the item completes, so short replies are not delayed.
- On a hit, the LLM invocation is aborted **before any tool calls surface or history commits**, and retried (default: once) with a corrective developer note and an optional reasoning-effort override to decorrelate the retry from the failed attempt.
- If the caller already heard part of the bad attempt, a configurable bridge line is spoken before the retry; if every attempt leaks, a configurable fallback line is spoken and the turn ends with no tool calls.
- `bridge_text` / `fallback_text` also accept zero-arg callables resolved at speak time, for agents whose spoken language can change mid-call. A raising callable logs and falls back to the English default.

Design notes:

- **Zero behavior change when unset** — the guard is off by default; a test pins the pre-guard streaming behavior.
- A detected leak discards the *entire* attempt, including any valid `function_call` items it carried. This is safe (nothing executed — tool calls only surface on the terminal chunk, history only commits on `response.completed`) and the retry re-decides what to call.
- Scoped to the `http_responses` backend where the leak was observed; wiring the same guard into the WS provider is a possible follow-up if it shows up there.
- Detection pattern, holdback size, guarded message phases, retry count/note/channel, and all spoken lines are configurable.

Documentation added to `line/llm_agent/README.md` (new "Speech-Leak Guard" section under Configuration).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Other: ___________

## Testing

23 unit tests in `tests/test_speech_leak_guard.py`, covering both layers:

- **Stream-level**: detection of all observed leak shapes (bare JSON, spoken call expression, degraded harmony headers, `to=functions.` markers, `<|` delimiters), pattern matches straddling delta boundaries, holdback flush on clean items (nothing lost, short items not delayed), phase scoping, false-positive checks (email-style readbacks, prose containing "functions."), and disabled-guard passthrough.
- **Provider-level** (`chat()` with a scripted `aresponses` stand-in): retry with the corrective note applied to the retry request only (both developer-item and instructions channels), reasoning-effort override, bridge line when the caller heard part of the failed attempt, fallback on exhausted retries, history committed only for the accepted attempt, and callable text resolution (invoked at speak time, empty return speaks nothing, raising callable falls back to the default).

The leak fixtures replay delta sequences captured from four production calls. Full suite (639 tests) passes on Python 3.10 and 3.14; `pre-commit run --all-files` (ruff, ruff format, pyright) is clean.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
