### PR TITLE
Bump version to 0.2.17

### DIFF
--- a/example_integrations/browserbase/pyproject.toml
+++ b/example_integrations/browserbase/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Voice agent that fills web forms using Stagehand browser automation (Line SDK)"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
     "stagehand>=3.0.0",
     "google-genai>=1.26.0",
     "loguru>=0.7.0",

--- a/example_integrations/cerebras/pyproject.toml
+++ b/example_integrations/cerebras/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "An interviewer agent using Cerebras via LiteLLM with Line SDK v0.2"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
     "python-dotenv>=1.0.0",
     "loguru>=0.7.0",
     "pydantic>=2.0.0",

--- a/example_integrations/exa/pyproject.toml
+++ b/example_integrations/exa/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A web research voice agent using Exa API and Cartesia Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
     "exa-py>=1.0.0",
     "loguru>=0.7.0",
     "python-dotenv>=1.0.0",

--- a/example_integrations/tavily/pyproject.toml
+++ b/example_integrations/tavily/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A web research voice agent using Tavily API and Cartesia Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
     "tavily-python>=0.7.23",
     "loguru>=0.7.3",
     "python-dotenv>=1.2.2",

--- a/examples/basic_chat/pyproject.toml
+++ b/examples/basic_chat/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Basic chat example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
     "loguru>=0.7.0",
 ]
 

--- a/examples/chat_supervisor/pyproject.toml
+++ b/examples/chat_supervisor/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Chat/Supervisor example: A fast Haiku agent that consults Opus for complex questions"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
 ]
 
 [tool.setuptools]

--- a/examples/echo/pyproject.toml
+++ b/examples/echo/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Handoff echo example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
     "loguru>=0.7.0",
 ]
 

--- a/examples/form_filler/pyproject.toml
+++ b/examples/form_filler/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Voice agent that helps patients schedule doctor appointments and complete intake forms."
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
     "loguru>=0.7.0",
 ]
 

--- a/examples/guardrails_wrapper/pyproject.toml
+++ b/examples/guardrails_wrapper/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Guardrails wrapper example - LLM agent with preprocessing/postprocessing for content filtering"
 requires-python = ">=3.10"
 dependencies = [
-   "cartesia-line==0.2.16",
+   "cartesia-line==0.2.17",
 ]
 
 [tool.setuptools]

--- a/examples/sales_with_leads/pyproject.toml
+++ b/examples/sales_with_leads/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Sales agent with stateful leads extraction and company research"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
     "loguru>=0.7.0",
 ]
 

--- a/examples/transfer_agent/pyproject.toml
+++ b/examples/transfer_agent/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Multi-agent handoff example demonstrating agent-to-agent transfers using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
 ]
 
 [tool.setuptools]

--- a/examples/transfer_phone_call/pyproject.toml
+++ b/examples/transfer_phone_call/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Phone transfer example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.16",
+    "cartesia-line==0.2.17",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cartesia-line"
-version = "0.2.16"
+version = "0.2.17"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps `cartesia-line` from 0.2.16 to 0.2.17 and re-pins the version in all 12 example and integration `pyproject.toml` files.

## Changes since the last version bump

* Anchor background tool results to history at drain time (#263) (62f2fd4)
* http_responses: opt-in speech-leak guard (tool-call payloads in spoken text) (#264) (2b06532)

### Anchor background tool results to history at drain time (#263)

A bug fix. Before this change, a background tool result went into local history the moment the tool yielded it. If the result arrived while an LLM generation for the current turn was still in flight, the streamed text landed after the pair in history. The loopback reaction call then built a message list that ended with the agent's own assistant text, and `_normalize_messages` skipped the LLM call. The tool result was dropped, and the agent stayed silent until the user spoke again.

The fix appends the pair to history when a generation loop drains it from the background queue, so the result is always the last message the reaction LLM sees. This also subsumes the yield-time current-event tagging from #173. `responding_to` attribution does not change.

### Opt-in speech-leak guard for the http_responses backend (#264)

A new opt-in feature. Some reasoning models sometimes write a tool call's payload into the user-visible message item, so TTS reads raw JSON to the caller. When the proper `function_call` item is absent, the intended call is also lost.

`SpeechLeakGuardConfig` (set through `LlmConfig.speech_leak_guard`, read only by the `http_responses` backend) buffers the streamed message item behind a bounded holdback window and scans the text for tool-call signatures. On a hit it aborts the invocation before any tool call or history commit, then retries with a corrective developer note. It speaks a bridge line if the caller already heard part of the bad attempt, and a fallback line if every attempt leaks.

The default is unset, so there is no behavior change for existing agents.

## Version type

Both changes keep the public API backward compatible, so this is a patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no code modifications; risk is limited to consumers picking up 0.2.17 behavior from the prior release’s fixes and opt-in features.
> 
> **Overview**
> **Releases `cartesia-line` 0.2.17** by updating the package version in the root `pyproject.toml` and pinning `cartesia-line==0.2.17` in all example and integration projects (browserbase, cerebras, exa, tavily, and the standard examples).
> 
> There are no runtime or library code changes in this diff—only dependency version alignment so examples install the new patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e59dea039cc86e2e6f8bc5a590a5b6ab0c8e34da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->