### PR TITLE
fix(history): filter AgentSendCustom from LLM history (#262)

### DIFF
--- a/line/llm_agent/history.py
+++ b/line/llm_agent/history.py
@@ -10,6 +10,7 @@ from line.events import (
     AgentDtmfSent,
     AgentEndCall,
     AgentHandedOff,
+    AgentSendCustom,
     AgentSendDtmf,
     AgentSendText,
     AgentTextSent,
@@ -501,8 +502,11 @@ def _to_history_event(event: object) -> Optional[HistoryEvent]:
         ),
     ):
         return event
-    # Non-history OutputEvents are filtered out
-    elif isinstance(event, (AgentTransferCall, LogMetric, LogMessage, AgentUpdateCall)):
+    # Non-history OutputEvents are filtered out. AgentSendCustom is a side channel
+    # to the harness (arbitrary metadata); it has no InputEvent counterpart and the
+    # LLM already sees the surrounding tool call/result pair, so it is not part of
+    # the model-visible history.
+    elif isinstance(event, (AgentTransferCall, LogMetric, LogMessage, AgentUpdateCall, AgentSendCustom)):
         return None
     else:
         raise ValueError(f"Unknown event type in history: {type(event).__name__}")

--- a/tests/test_llm_agent_history.py
+++ b/tests/test_llm_agent_history.py
@@ -8,6 +8,7 @@ import pytest
 
 from line.events import (
     AgentEndCall,
+    AgentSendCustom,
     AgentSendText,
     AgentTextSent,
     AgentToolCalled,
@@ -758,6 +759,61 @@ class TestBuildFullHistory:
         assert result[4].content == "All right, bye."
         assert isinstance(result[5], UserTextSent)
         assert result[5].content == "Bye."
+
+    # =========================================================================
+    # Tests: AgentSendCustom filtering (issue #262)
+    # =========================================================================
+
+    async def test_agent_send_custom_from_tool_current_turn_is_dropped(self):
+        """AgentSendCustom yielded by a tool must not crash the loopback completion.
+
+        Regression test for #262: a tool that yields AgentSendCustom followed by a
+        raw result gets [AgentSendCustom, AgentToolCalled, AgentToolReturned]
+        appended to local history. The loopback LLM call in the same turn then
+        rebuilds history — previously _to_history_event raised
+        ValueError("Unknown event type in history: AgentSendCustom").
+        """
+        local_history = self._annotate(
+            [
+                AgentSendCustom(metadata={"type": "show_form", "form_id": "contact"}),
+                AgentToolCalled(tool_call_id="1-0", tool_name="my_tool", tool_args={}),
+                AgentToolReturned(
+                    tool_call_id="1-0", tool_name="my_tool", tool_args={}, result="tool result"
+                ),
+            ],
+            event_id="current",
+        )
+
+        result = _build_full_history([], local_history, current_event_id="current")
+
+        # AgentSendCustom is filtered out; the tool call/result pair survives.
+        assert len(result) == 2
+        assert isinstance(result[0], AgentToolCalled)
+        assert isinstance(result[1], AgentToolReturned)
+        assert result[1].result == "tool result"
+
+    async def test_agent_send_custom_prior_turn_is_dropped(self):
+        """AgentSendCustom in a prior turn is drained with the slice and filtered out,
+        without disturbing matching of the surrounding events."""
+        user0 = UserTextSent(content="Show me the form")
+        input_history = [
+            user0,
+            AgentTextSent(content="Here you go."),
+        ]
+        local_history = self._annotate(
+            [
+                AgentSendCustom(metadata={"type": "show_form"}),
+                AgentSendText(text="Here you go."),
+            ],
+            event_id=user0.event_id,
+        )
+
+        result = _build_full_history(input_history, local_history, current_event_id="current")
+
+        assert len(result) == 2
+        assert isinstance(result[0], UserTextSent)
+        assert isinstance(result[1], AgentTextSent)
+        assert result[1].content == "Here you go."
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #262.

I was reading through the history merge logic and reproduced this with a unit test. What happens: when a tool yields AgentSendCustom, the passthrough branch in _generate_response appends it to local history like any other OutputEvent. But _to_history_event in history.py has no case for it, so the next time history gets rebuilt it falls into the final else and raises ValueError("Unknown event type in history: AgentSendCustom"). If the tool also yields a raw result, that rebuild is the loopback completion in the same turn, the reasoning session dies right there and the agent goes silent. Even history.add_entry() crashes after this, since everything goes through _ensure_merged.

The fix is one line: add AgentSendCustom to the drop tuple next to AgentTransferCall/LogMetric/LogMessage/AgentUpdateCall. I went with filtering in the converter instead of skipping the append, because tools aren't the only path, handoff tools and handoff targets append yielded events too, and they'd hit the same crash. After this the converter covers every member of the OutputEvent union.

I didn't try to map it into history. It's a side channel to the harness, there's no InputEvent counterpart to convert it to, and the model already sees the tool call/result pair. If you ever want the model to see its own outbound metadata that'd need something like an AgentCustomSent input event (inbound already has UserCustomSent), but that's your call, not a bugfix.