### PR TITLE
fix(history): resolve mutation anchors by content across rebuilds

### DIFF
--- a/line/llm_agent/history.py
+++ b/line/llm_agent/history.py
@@ -6,6 +6,8 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterator, List, Literal, Optional, Union
 
+from loguru import logger
+
 from line.events import (
     AgentDtmfSent,
     AgentEndCall,
@@ -70,6 +72,10 @@ class _InsertEntry:
     entry: CustomHistoryEntry
     anchor: _Anchor
     position: Literal["before", "after"]
+    # Index of the anchor among content-equal events at mutation time, used to
+    # re-locate it in rebuilt histories where object/event_id identity is not stable.
+    anchor_occurrence: int = 0
+    warned: bool = False
 
 
 @dataclass
@@ -79,9 +85,51 @@ class _ReplaceSegment:
     events: List[HistoryEvent]
     start: _Anchor
     end: _Anchor
+    start_occurrence: int = 0
+    end_occurrence: int = 0
+    warned: bool = False
 
 
 _Mutation = Union[_InsertEntry, _ReplaceSegment]
+
+# Fields excluded when comparing events for anchor resolution. event_id is excluded
+# because rebuilt histories do not preserve it: converted events (e.g. the
+# AgentTextSent produced from a local AgentSendText) get a fresh event_id on every
+# rebuild, and once the harness observes an event, the canonical input version
+# carries the harness's event_id rather than the local one.
+_ANCHOR_IDENTITY_FIELDS = {"event_id", "history"}
+
+
+def _content_equal(a: HistoryEvent, b: HistoryEvent) -> bool:
+    """Compare two history events by content, ignoring unstable identity fields."""
+    if type(a) is not type(b):
+        return False
+    return a.model_dump(exclude=_ANCHOR_IDENTITY_FIELDS) == b.model_dump(exclude=_ANCHOR_IDENTITY_FIELDS)
+
+
+def _anchor_occurrence(merged: List[HistoryEvent], anchor: HistoryEvent) -> int:
+    """Return the anchor's index among content-equal events in the merged history.
+
+    Recorded at mutation time so that duplicate content (e.g. two identical
+    "Okay." replies) resolves to the intended occurrence in rebuilt histories.
+    """
+    idx = merged.index(anchor)
+    return sum(1 for e in merged[:idx] if _content_equal(e, anchor))
+
+
+def _resolve_anchor(result: List[HistoryEvent], anchor: HistoryEvent, occurrence: int) -> Optional[int]:
+    """Locate an anchor in a rebuilt history by content.
+
+    Returns the index of the occurrence-th content-equal event, the last
+    content-equal event if fewer occurrences exist than recorded (best effort),
+    or None if the anchor's content is no longer present.
+    """
+    matches = [i for i, e in enumerate(result) if _content_equal(e, anchor)]
+    if not matches:
+        return None
+    if occurrence < len(matches):
+        return matches[occurrence]
+    return matches[-1]
 
 
 # ---------------------------------------------------------------------------
@@ -152,11 +200,20 @@ class History:
             position = "after"
 
         # Validate real anchors exist in the current history
+        anchor_occurrence = 0
         if anchor is not _SEQUENCE_START:
             if anchor not in merged:
                 raise ValueError(f"Anchor event not found in history: {anchor}")
+            anchor_occurrence = _anchor_occurrence(merged, anchor)
 
-        self._mutations.append(_InsertEntry(entry=entry, anchor=anchor, position=position))
+        self._mutations.append(
+            _InsertEntry(
+                entry=entry,
+                anchor=anchor,
+                position=position,
+                anchor_occurrence=anchor_occurrence,
+            )
+        )
         self._cache = None
 
     def update(
@@ -190,12 +247,16 @@ class History:
 
         # Validate real anchors exist in the current history
         merged = self._ensure_merged()
+        start_occurrence = 0
+        end_occurrence = 0
         if resolved_start is not _SEQUENCE_START:
             if resolved_start not in merged:
                 raise ValueError(f"Start event not found in history: {resolved_start}")
+            start_occurrence = _anchor_occurrence(merged, resolved_start)
         if resolved_end is not _SEQUENCE_START:
             if resolved_end not in merged:
                 raise ValueError(f"End event not found in history: {resolved_end}")
+            end_occurrence = _anchor_occurrence(merged, resolved_end)
 
         # Check ordering when both are real events
         if resolved_start is not _SEQUENCE_START and resolved_end is not _SEQUENCE_START:
@@ -206,7 +267,15 @@ class History:
                     f"End event (index {end_idx}) appears before start event (index {start_idx})"
                 )
 
-        self._mutations.append(_ReplaceSegment(events=events, start=resolved_start, end=resolved_end))
+        self._mutations.append(
+            _ReplaceSegment(
+                events=events,
+                start=resolved_start,
+                end=resolved_end,
+                start_occurrence=start_occurrence,
+                end_occurrence=end_occurrence,
+            )
+        )
         self._cache = None
 
     def __iter__(self) -> Iterator[HistoryEvent]:
@@ -248,20 +317,50 @@ class History:
                 if mutation.anchor is _SEQUENCE_START:
                     # "after" _SEQUENCE_START → insert at beginning
                     result.insert(0, mutation.entry)
+                    continue
+                idx = _resolve_anchor(result, mutation.anchor, mutation.anchor_occurrence)
+                if idx is None:
+                    self._warn_skipped_mutation(mutation, mutation.anchor)
+                    continue
+                if mutation.position == "before":
+                    result.insert(idx, mutation.entry)
                 else:
-                    idx = result.index(mutation.anchor)
-                    if mutation.position == "before":
-                        result.insert(idx, mutation.entry)
-                    else:
-                        result.insert(idx + 1, mutation.entry)
+                    result.insert(idx + 1, mutation.entry)
             elif isinstance(mutation, _ReplaceSegment):
                 # _SEQUENCE_START → virtual position before index 0
-                start_idx = 0 if mutation.start is _SEQUENCE_START else result.index(mutation.start)
-                end_excl = 0 if mutation.end is _SEQUENCE_START else result.index(mutation.end) + 1
+                start_idx = 0
+                if mutation.start is not _SEQUENCE_START:
+                    resolved = _resolve_anchor(result, mutation.start, mutation.start_occurrence)
+                    if resolved is None:
+                        self._warn_skipped_mutation(mutation, mutation.start)
+                        continue
+                    start_idx = resolved
+                end_excl = 0
+                if mutation.end is not _SEQUENCE_START:
+                    resolved = _resolve_anchor(result, mutation.end, mutation.end_occurrence)
+                    if resolved is None:
+                        self._warn_skipped_mutation(mutation, mutation.end)
+                        continue
+                    end_excl = resolved + 1
                 result[start_idx:end_excl] = mutation.events
 
         self._cache = result
         return result
+
+    @staticmethod
+    def _warn_skipped_mutation(mutation: _Mutation, anchor: _Anchor) -> None:
+        """Warn (once per mutation) that its anchor is missing from the rebuilt history.
+
+        The mutation stays queued: if the anchor's content reappears in a later
+        rebuild (e.g. the canonical input version of a still-streaming message
+        arrives), the mutation is applied again.
+        """
+        if not mutation.warned:
+            logger.warning(
+                f"History mutation skipped: anchor {type(anchor).__name__} no longer "
+                f"present in rebuilt history. It will be re-applied if the anchor reappears."
+            )
+            mutation.warned = True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_agent_history.py
+++ b/tests/test_llm_agent_history.py
@@ -1098,6 +1098,111 @@ class TestHistory:
         assert contents == ["a", "injected", "replaced", "c"]
 
     # ------------------------------------------------------------------
+    # Anchor stability across rebuilds (converted/canonicalized events)
+    # ------------------------------------------------------------------
+
+    async def test_add_entry_after_agents_own_message_survives_rebuild(self):
+        """add_entry anchored to the agent's own (converted) message must not crash.
+
+        Regression test: the AgentTextSent visible in history for a current-turn
+        AgentSendText is recreated with a fresh event_id on every rebuild, so
+        exact-equality anchor lookup raised
+        ValueError("... is not in list") on the first read after add_entry.
+        """
+        user = UserTextSent(content="hi")
+        h = History()
+        h._set_input([user], user.event_id)
+        h._append_local(AgentSendText(text="Hello there."))
+
+        merged = list(h)
+        assert isinstance(merged[-1], AgentTextSent)
+
+        h.add_entry("supervisor note", after=merged[-1])
+        result = list(h)  # previously raised ValueError here
+
+        assert len(result) == 3
+        assert isinstance(result[0], UserTextSent)
+        assert isinstance(result[1], AgentTextSent)
+        assert isinstance(result[2], CustomHistoryEntry)
+        assert result[2].content == "supervisor note"
+
+    async def test_add_entry_anchor_survives_canonical_replacement(self):
+        """A mutation anchored to a local conversion still applies once the harness
+        sends the canonical version of the same message on the next turn."""
+        user = UserTextSent(content="hi")
+        h = History()
+        h._set_input([user], user.event_id)
+        h._append_local(AgentSendText(text="Hello there."))
+
+        merged = list(h)
+        h.add_entry("supervisor note", after=merged[-1])
+
+        # Next turn: the harness observed the reply (its own event_id) plus new input.
+        canonical = AgentTextSent(content="Hello there.")
+        user2 = UserTextSent(content="how are you?")
+        h._set_input([user, canonical, user2], user2.event_id)
+
+        result = list(h)
+        assert len(result) == 4
+        assert isinstance(result[0], UserTextSent)
+        assert isinstance(result[1], AgentTextSent)
+        assert result[1].content == "Hello there."
+        assert isinstance(result[2], CustomHistoryEntry)
+        assert result[2].content == "supervisor note"
+        assert isinstance(result[3], UserTextSent)
+
+    async def test_add_entry_duplicate_content_targets_correct_occurrence(self):
+        """With two content-identical messages, the mutation lands on the anchored one."""
+        a1 = AgentTextSent(content="Okay.")
+        a2 = AgentTextSent(content="Okay.")
+        h = self._make_history([a1, a2])
+        merged = list(h)
+
+        h.add_entry("note", after=merged[1])
+        result = list(h)
+
+        assert len(result) == 3
+        assert isinstance(result[0], AgentTextSent)
+        assert isinstance(result[1], AgentTextSent)
+        assert isinstance(result[2], CustomHistoryEntry)
+
+    async def test_update_segment_anchored_to_converted_event(self):
+        """update() with start/end on a converted local event must not crash."""
+        user = UserTextSent(content="hi")
+        h = History()
+        h._set_input([user], user.event_id)
+        h._append_local(AgentSendText(text="Hello there."))
+
+        merged = list(h)
+        h.update([CustomHistoryEntry(content="redacted")], start=merged[1], end=merged[1])
+
+        result = list(h)  # previously raised ValueError here
+        assert len(result) == 2
+        assert isinstance(result[0], UserTextSent)
+        assert isinstance(result[1], CustomHistoryEntry)
+        assert result[1].content == "redacted"
+
+    async def test_mutation_skipped_gracefully_when_anchor_content_changes(self):
+        """If the anchor's content genuinely disappears (e.g. the anchored streaming
+        message grows), the mutation is skipped with a warning instead of crashing."""
+        user = UserTextSent(content="hi")
+        h = History()
+        h._set_input([user], user.event_id)
+        h._append_local(AgentSendText(text="Hello"))
+
+        merged = list(h)
+        h.add_entry("note", after=merged[-1])
+
+        # More streamed chunks arrive: concatenation changes the converted content.
+        h._append_local(AgentSendText(text=" there."))
+
+        result = list(h)  # no crash; the entry is simply not applied
+        assert len(result) == 2
+        assert isinstance(result[0], UserTextSent)
+        assert isinstance(result[1], AgentTextSent)
+        assert result[1].content == "Hello there."
+
+    # ------------------------------------------------------------------
     # Cache invalidation
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #268.

`History._ensure_merged` replays mutations with `result.index(mutation.anchor)`, which is full pydantic equality including `event_id`. That identity doesn't survive a rebuild for the agent's own messages: `_to_history_event` creates a fresh `AgentTextSent` with a new `event_id` every time, concatenation builds new objects while a message is still streaming, and once the harness observes the message, matching swaps in the canonical input version carrying the harness's id. So `add_entry(after=<agent's last message>)` passes validation and then the very next history read raises `ValueError(... is not in list)`. `update(start=..., end=...)` breaks the same way through `_ReplaceSegment` replay.

The fix resolves anchors by content instead of exact equality. At mutation time I record which occurrence of that content the anchor was, so two identical "Okay." replies stay distinguishable. At replay time the anchor is looked up by content with `event_id` and `history` excluded from the comparison. If the content is genuinely gone, for example the anchored message was still streaming and grew before the entry could be placed, the mutation is skipped with a one-time warning and retried on later rebuilds instead of crashing the call.

Added five tests: the exact crash from the issue, anchor surviving canonical replacement on the next turn, duplicate content landing on the right occurrence, `update()` with converted anchors, and the graceful skip when anchor content changes. Full suite passes (650 tests), ruff check and format clean.
