### PR TITLE
Add Parallel Free Search voice agent example

### DIFF
--- a/example_integrations/parallel/README.md
+++ b/example_integrations/parallel/README.md
@@ -1,0 +1,46 @@
+# Voice Research Agent with Parallel Free Search
+
+A deployable Cartesia Line voice agent that searches the live web through the hosted [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) endpoint.
+
+## Prerequisites
+
+- Python 3.10 or later
+- An [OpenAI API key](https://platform.openai.com/api-keys) for the voice agent model
+- A Cartesia Line project
+
+Parallel Free Search does not require an API key.
+
+## Environment Variables
+
+Set only the model credential:
+
+```bash
+OPENAI_API_KEY=your-openai-key
+```
+
+Search objectives and search queries are sent to `https://search.parallel.ai/mcp` when the agent invokes `web_search`. Do not include private or sensitive information in requests. No URLs are fetched by this search-only integration.
+
+## Installation and Running
+
+```bash
+uv sync
+uv run python main.py
+```
+
+In another terminal, connect to the running Line agent:
+
+```bash
+cartesia chat 8000
+```
+
+The same directory can be connected to the Line platform through the [Cartesia GitHub integration](https://docs.cartesia.ai/line/integrations/github).
+
+## File Overview
+
+- `main.py` registers a `@loopback_tool` on `LlmAgent`, calls the hosted MCP `web_search` tool with its supported `objective` and `search_queries` fields, and returns at most five structured results to the model. Text content is used only when structured content is absent.
+- `cartesia.toml` marks the directory as a Line deployment.
+- `pyproject.toml` declares the Line SDK and official MCP client dependencies.
+
+## Configuration
+
+The agent keeps the standard OpenAI model used by the existing search examples. Change its model settings in `get_agent` if needed. The hosted search endpoint needs no Parallel credential and the integration adds no custom request headers.

--- a/example_integrations/parallel/main.py
+++ b/example_integrations/parallel/main.py
@@ -1,0 +1,83 @@
+"""Voice research agent powered by Parallel Free Search MCP."""
+
+import json
+import os
+from typing import Annotated, Any
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+from line.llm_agent import LlmAgent, LlmConfig, ToolEnv, end_call, loopback_tool
+from line.voice_agent_app import AgentEnv, CallRequest, VoiceAgentApp
+
+PARALLEL_MCP_URL = "https://search.parallel.ai/mcp"
+MAX_RESULTS = 5
+SYSTEM_PROMPT = (
+    "You are a concise voice research assistant. Use web_search whenever a user asks for "
+    "current or factual web information. Base the answer on the returned sources and name "
+    "sources naturally. If the search is inconclusive, say so. Speak in plain sentences "
+    "without markdown. Use end_call when the user wants to finish."
+)
+INTRODUCTION = "Hello! I can search the web for current information. What would you like to know?"
+
+
+def _limit_results(value: Any) -> Any:
+    """Limit result collections before returning MCP data to the model."""
+    if isinstance(value, dict):
+        return {
+            key: _limit_results(item[:MAX_RESULTS] if key == "results" and isinstance(item, list) else item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_limit_results(item) for item in value]
+    return value
+
+
+def _result_text(result: Any) -> str:
+    """Render structured MCP output, falling back to text when it is absent."""
+    structured = getattr(result, "structuredContent", None)
+    if structured is not None:
+        return json.dumps(_limit_results(structured), ensure_ascii=False)
+
+    text_parts = [item.text for item in getattr(result, "content", []) if hasattr(item, "text")]
+    if not text_parts:
+        return "No relevant information found."
+    return "\n".join(text_parts)
+
+
+@loopback_tool
+async def web_search(
+    ctx: ToolEnv,
+    objective: Annotated[str, "A concise description of the information needed."],
+    search_queries: Annotated[list[str], "One or more focused web search queries."],
+) -> str:
+    """Search the web for current information and return up to five results."""
+    async with streamablehttp_client(PARALLEL_MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(
+                "web_search",
+                arguments={"objective": objective, "search_queries": search_queries},
+            )
+    return _result_text(result)
+
+
+async def get_agent(env: AgentEnv, call_request: CallRequest) -> LlmAgent:
+    """Create the voice agent with the Parallel search loopback tool."""
+    return LlmAgent(
+        model="openai/gpt-4o-mini",
+        api_key=os.getenv("OPENAI_API_KEY"),
+        tools=[web_search, end_call],
+        config=LlmConfig(
+            system_prompt=SYSTEM_PROMPT,
+            introduction=INTRODUCTION,
+            max_tokens=400,
+            temperature=0.5,
+        ),
+    )
+
+
+app = VoiceAgentApp(get_agent=get_agent)
+
+if __name__ == "__main__":
+    app.run()

--- a/example_integrations/parallel/pyproject.toml
+++ b/example_integrations/parallel/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "parallel-web-search"
+version = "0.1.0"
+description = "A web research voice agent using Parallel Free Search MCP and Cartesia Line SDK"
+requires-python = ">=3.10"
+dependencies = [
+    "cartesia-line==0.2.17",
+    "mcp>=1.0.0,<2",
+]
+
+[project.scripts]
+parallel-search = "main:app.run"

--- a/tests/test_parallel_integration.py
+++ b/tests/test_parallel_integration.py
@@ -1,0 +1,113 @@
+"""Runtime tests for the Parallel example integration."""
+
+from contextlib import asynccontextmanager
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from line.agent import AgentEnv, TurnEnv
+from line.llm_agent.tools.utils import FunctionTool, ToolEnv
+from line.voice_agent_app import AgentConfig, CallRequest
+
+MODULE_PATH = Path(__file__).parents[1] / "example_integrations" / "parallel" / "main.py"
+SPEC = importlib.util.spec_from_file_location("parallel_example", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+main = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(main)
+
+
+class FakeSession:
+    """Records the exact hosted MCP tool call."""
+
+    calls = []
+    result = None
+
+    def __init__(self, read, write):
+        del read, write
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def initialize(self):
+        return None
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return self.result
+
+
+@asynccontextmanager
+async def fake_transport(url):
+    assert url == main.PARALLEL_MCP_URL
+    yield object(), object(), None
+
+
+@pytest.fixture(autouse=True)
+def patch_mcp(monkeypatch):
+    FakeSession.calls = []
+    monkeypatch.setattr(main, "ClientSession", FakeSession)
+    monkeypatch.setattr(main, "streamablehttp_client", fake_transport)
+
+
+@pytest.mark.asyncio
+async def test_voice_agent_registers_and_invokes_schema_faithful_search(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "line.llm_agent.llm_agent._get_model_config",
+        lambda *args, **kwargs: SimpleNamespace(
+            backend="http", supports_reasoning_effort=False, default_reasoning_effort=None
+        ),
+    )
+    FakeSession.result = SimpleNamespace(
+        structuredContent={"results": [{"title": str(index)} for index in range(8)]},
+        content=[SimpleNamespace(text="duplicate mirrored payload")],
+    )
+    request = CallRequest(
+        call_id="call",
+        from_="caller",
+        to="agent",
+        agent_call_id="agent-call",
+        agent=AgentConfig(),
+    )
+
+    agent = await main.get_agent(AgentEnv(), request)
+    search_tool = next(tool for tool in agent._tools if tool.name == "web_search")
+    assert isinstance(search_tool, FunctionTool)
+    result = await search_tool.func(
+        ToolEnv(TurnEnv(AgentEnv())),
+        objective="Find current launch details",
+        search_queries=["Parallel latest launch"],
+    )
+
+    assert FakeSession.calls == [
+        (
+            "web_search",
+            {
+                "objective": "Find current launch details",
+                "search_queries": ["Parallel latest launch"],
+            },
+        )
+    ]
+    assert "duplicate mirrored payload" not in result
+    assert '"title": "4"' in result
+    assert '"title": "5"' not in result
+
+
+@pytest.mark.asyncio
+async def test_search_uses_text_only_when_structured_content_absent():
+    FakeSession.result = SimpleNamespace(
+        structuredContent=None,
+        content=[SimpleNamespace(text="first"), SimpleNamespace(text="second")],
+    )
+
+    result = await main.web_search.func(
+        ToolEnv(TurnEnv(AgentEnv())), objective="objective", search_queries=["query"]
+    )
+
+    assert result == "first\nsecond"
+    assert FakeSession.calls[0][1] == {"objective": "objective", "search_queries": ["query"]}


### PR DESCRIPTION
## What does this PR do?
Adds a deployable voice research agent under `example_integrations/parallel`. The agent registers a Line `@loopback_tool` that connects to `https://search.parallel.ai/mcp` with the official MCP streamable HTTP client and calls `web_search` using only `objective` and `search_queries`.

The integration needs no Parallel API key. It prefers structured MCP output, falls back to text only when structured output is absent, and limits structured search results locally to five. It does not add custom request headers or change any existing provider, default, or user setting.

Search objectives and search queries are sent to Parallel, a third-party hosted endpoint when the tool is invoked. Requested URLs are never sent because this search-only example has no URL-fetching tool; returned result URLs are only included in search output. The README advises users not to include private or sensitive information.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Other: ___________

## Testing
- `pytest -q tests/test_parallel_integration.py`
- `make test`
- `pre-commit run --all-files`

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/cartesia-ai/line/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works (`pytest -q tests/test_parallel_integration.py`)
- [x] I have formatted my code with `make format` (run as `make format`)

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.