### PR TITLE
feat: support direct SIP URI transfer destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ agent = LlmAgent(
 |------|--------------|
 | `end_call` | Ends the call |
 | `send_dtmf` | Presses phone buttons (0-9, *, #) |
-| `transfer_call` | Transfers to a phone number (E.164). LLM-supplied by default, or pin a fixed destination with `transfer_call(target_phone_number="+1...")` |
+| `transfer_call` | Transfers to an E.164 phone number (LLM-supplied by default) or a pinned destination. Pin a phone with `transfer_call(target_phone_number="+1...")` or a SIP URI with `transfer_call(target_sip_uri="sip:7500@pbx.example.com")`. |
 | `voicemail` | Ends the call when you reach a voicemail, optionally leaving a message first. Configure with `voicemail(message="…")`. See [Voicemail detection](#voicemail-detection-outbound-calls). |
 | `web_search` | Searches the web (native LLM search or DuckDuckGo fallback) |
 | `knowledge_base` | Looks up information from the agent's knowledge base via natural-language query. Call `knowledge_base(filters={...}, top_k=10)` to pre-filter retrievals or override `top_k` |

--- a/README.md
+++ b/README.md
@@ -260,7 +260,9 @@ from line.llm_agent import passthrough_tool
 async def transfer_to_support(ctx, reason: Annotated[str, "Why they need support"]):
     """Transfer to support team."""
     yield AgentSendText(text="Transferring you to support now.")
-    yield AgentTransferCall(target_phone_number="+18005551234")
+    yield AgentTransferCall(
+        transfer_destination={"type": "phone", "value": "+18005551234"}
+    )
 
 agent = LlmAgent(tools=[transfer_to_support, end_call], ...)
 ```

--- a/README.md
+++ b/README.md
@@ -260,9 +260,7 @@ from line.llm_agent import passthrough_tool
 async def transfer_to_support(ctx, reason: Annotated[str, "Why they need support"]):
     """Transfer to support team."""
     yield AgentSendText(text="Transferring you to support now.")
-    yield AgentTransferCall(
-        transfer_destination={"type": "phone", "value": "+18005551234"}
-    )
+    yield AgentTransferCall(target_phone_number="+18005551234")
 
 agent = LlmAgent(tools=[transfer_to_support, end_call], ...)
 ```

--- a/examples/transfer_phone_call/README.md
+++ b/examples/transfer_phone_call/README.md
@@ -27,12 +27,14 @@ send_dtmf(button="1")
 ```
 
 ### `transfer_call`
-Transfers the call to another phone number. Validates E.164 format.
+Transfers the call to another phone number, or to a configured SIP URI.
 
 ```python
 # Optional spoken line before transfer is fixed when you build the tool (not chosen by the model):
 tools=[transfer_call(message="Transferring you now..."), send_dtmf]
 # The model only passes the destination: transfer_call(target_phone_number="+14155551234")
+# SIP destinations must be pinned by the application; the model cannot supply one:
+transfer_to_extension = transfer_call(target_sip_uri="sip:7500@pbx.example.com")
 ```
 
 ### `end_call`
@@ -58,5 +60,5 @@ Agent: I'll transfer you to that number now.
 ## Key Concepts
 
 - **`send_dtmf`**: Passthrough tool that yields `AgentSendDtmf` event
-- **`transfer_call`**: Passthrough tool with phone number validation using `phonenumbers` library
+- **`transfer_call`**: Passthrough tool with E.164 phone validation and pinned SIP URI support
 - **`end_call`**: Passthrough tool to gracefully end the conversation

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -8,8 +8,6 @@ from typing import Any, Dict, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from line.events import TransferDestination
-
 ########################################################
 #  Wire message types for the Cartesia voice-agent websocket protocol.
 ########################################################
@@ -99,6 +97,16 @@ class ToolCallOutput(BaseModel):
     result: Optional[str] = None
     id: Optional[str] = None
     responding_to: Optional[str] = None
+
+
+TransferDestinationType = Literal["phone", "sip_uri"]
+
+
+class TransferDestination(BaseModel):
+    """One typed transfer target on the Line-to-harness wire protocol."""
+
+    type: TransferDestinationType
+    value: str
 
 
 class TransferOutput(BaseModel):

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from line.events import TransferDestination
+
 ########################################################
 #  Wire message types for the Cartesia voice-agent websocket protocol.
 ########################################################
@@ -101,10 +103,19 @@ class ToolCallOutput(BaseModel):
 
 class TransferOutput(BaseModel):
     type: Literal["transfer"] = "transfer"
-    target_phone_number: Optional[str] = None
-    target_sip_uri: Optional[str] = None
+    transfer_destination: TransferDestination
     responding_to: Optional[str] = None
     interruptible: bool = True
+
+    @property
+    def target_phone_number(self) -> Optional[str]:
+        """Compatibility accessor; consumers should use transfer_destination."""
+        return self.transfer_destination.value if self.transfer_destination.type == "phone" else None
+
+    @property
+    def target_sip_uri(self) -> Optional[str]:
+        """Compatibility accessor; consumers should use transfer_destination."""
+        return self.transfer_destination.value if self.transfer_destination.type == "sip_uri" else None
 
 
 class EndCallOutput(BaseModel):

--- a/line/_harness_types.py
+++ b/line/_harness_types.py
@@ -101,7 +101,8 @@ class ToolCallOutput(BaseModel):
 
 class TransferOutput(BaseModel):
     type: Literal["transfer"] = "transfer"
-    target_phone_number: str
+    target_phone_number: Optional[str] = None
+    target_sip_uri: Optional[str] = None
     responding_to: Optional[str] = None
     interruptible: bool = True
 

--- a/line/events.py
+++ b/line/events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 import uuid
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 
 def _generate_event_id() -> str:
@@ -55,18 +55,31 @@ class AgentEndCall(BaseModel):
     interruptible: bool = True
 
 
+TransferDestinationType = Literal["phone", "sip_uri"]
+
+
+class TransferDestination(BaseModel):
+    """One typed transfer target; type determines how value is rendered downstream."""
+
+    type: TransferDestinationType
+    value: str
+
+
 class AgentTransferCall(BaseModel):
     type: Literal["agent_transfer_call"] = "agent_transfer_call"
-    target_phone_number: Optional[str] = None
-    target_sip_uri: Optional[str] = None
+    transfer_destination: TransferDestination
     responding_to: Optional[str] = None
     interruptible: bool = True
 
-    @model_validator(mode="after")
-    def has_exactly_one_destination(self) -> "AgentTransferCall":
-        if (self.target_phone_number is None) == (self.target_sip_uri is None):
-            raise ValueError("AgentTransferCall requires exactly one transfer destination")
-        return self
+    @property
+    def target_phone_number(self) -> Optional[str]:
+        """Compatibility accessor; consumers should use transfer_destination."""
+        return self.transfer_destination.value if self.transfer_destination.type == "phone" else None
+
+    @property
+    def target_sip_uri(self) -> Optional[str]:
+        """Compatibility accessor; consumers should use transfer_destination."""
+        return self.transfer_destination.value if self.transfer_destination.type == "sip_uri" else None
 
 
 class AgentSendDtmf(BaseModel):
@@ -262,6 +275,7 @@ __all__ = [
     "AgentSendText",
     "AgentSendDtmf",
     "AgentEndCall",
+    "TransferDestination",
     "AgentTransferCall",
     "AgentToolCalled",
     "AgentToolReturned",

--- a/line/events.py
+++ b/line/events.py
@@ -55,50 +55,18 @@ class AgentEndCall(BaseModel):
     interruptible: bool = True
 
 
-TransferDestinationType = Literal["phone", "sip_uri"]
-
-
-class TransferDestination(BaseModel):
-    """One typed transfer target; type determines how value is rendered downstream."""
-
-    type: TransferDestinationType
-    value: str
-
-
 class AgentTransferCall(BaseModel):
     type: Literal["agent_transfer_call"] = "agent_transfer_call"
-    transfer_destination: TransferDestination
+    target_phone_number: Optional[str] = None
+    target_sip_uri: Optional[str] = None
     responding_to: Optional[str] = None
     interruptible: bool = True
 
-    @model_validator(mode="before")
-    @classmethod
-    def _upgrade_legacy_destination_fields(cls, values: Any) -> Any:
-        """Accept the pre-typed constructor shape while emitting only the new shape."""
-        if not isinstance(values, dict) or "transfer_destination" in values:
-            return values
-
-        phone_number = values.get("target_phone_number")
-        sip_uri = values.get("target_sip_uri")
-        if (phone_number is None) == (sip_uri is None):
-            return values
-
-        upgraded = dict(values)
-        upgraded["transfer_destination"] = {
-            "type": "phone" if phone_number is not None else "sip_uri",
-            "value": phone_number if phone_number is not None else sip_uri,
-        }
-        return upgraded
-
-    @property
-    def target_phone_number(self) -> Optional[str]:
-        """Compatibility accessor; consumers should use transfer_destination."""
-        return self.transfer_destination.value if self.transfer_destination.type == "phone" else None
-
-    @property
-    def target_sip_uri(self) -> Optional[str]:
-        """Compatibility accessor; consumers should use transfer_destination."""
-        return self.transfer_destination.value if self.transfer_destination.type == "sip_uri" else None
+    @model_validator(mode="after")
+    def has_exactly_one_destination(self) -> "AgentTransferCall":
+        if (self.target_phone_number is None) == (self.target_sip_uri is None):
+            raise ValueError("AgentTransferCall requires exactly one transfer destination")
+        return self
 
 
 class AgentSendDtmf(BaseModel):
@@ -294,7 +262,6 @@ __all__ = [
     "AgentSendText",
     "AgentSendDtmf",
     "AgentEndCall",
-    "TransferDestination",
     "AgentTransferCall",
     "AgentToolCalled",
     "AgentToolReturned",

--- a/line/events.py
+++ b/line/events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 import uuid
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 def _generate_event_id() -> str:
@@ -57,9 +57,16 @@ class AgentEndCall(BaseModel):
 
 class AgentTransferCall(BaseModel):
     type: Literal["agent_transfer_call"] = "agent_transfer_call"
-    target_phone_number: str
+    target_phone_number: Optional[str] = None
+    target_sip_uri: Optional[str] = None
     responding_to: Optional[str] = None
     interruptible: bool = True
+
+    @model_validator(mode="after")
+    def has_exactly_one_destination(self) -> "AgentTransferCall":
+        if (self.target_phone_number is None) == (self.target_sip_uri is None):
+            raise ValueError("AgentTransferCall requires exactly one transfer destination")
+        return self
 
 
 class AgentSendDtmf(BaseModel):

--- a/line/events.py
+++ b/line/events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 import uuid
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 def _generate_event_id() -> str:
@@ -70,6 +70,25 @@ class AgentTransferCall(BaseModel):
     transfer_destination: TransferDestination
     responding_to: Optional[str] = None
     interruptible: bool = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def _upgrade_legacy_destination_fields(cls, values: Any) -> Any:
+        """Accept the pre-typed constructor shape while emitting only the new shape."""
+        if not isinstance(values, dict) or "transfer_destination" in values:
+            return values
+
+        phone_number = values.get("target_phone_number")
+        sip_uri = values.get("target_sip_uri")
+        if (phone_number is None) == (sip_uri is None):
+            return values
+
+        upgraded = dict(values)
+        upgraded["transfer_destination"] = {
+            "type": "phone" if phone_number is not None else "sip_uri",
+            "value": phone_number if phone_number is not None else sip_uri,
+        }
+        return upgraded
 
     @property
     def target_phone_number(self) -> Optional[str]:

--- a/line/llm_agent/README.md
+++ b/line/llm_agent/README.md
@@ -143,7 +143,7 @@ from line.llm_agent import end_call, send_dtmf, transfer_call, web_search, http_
 |------|------|-------------|
 | `end_call` | passthrough | End the call |
 | `send_dtmf` | passthrough | Send DTMF tones (0-9, *, #) |
-| `transfer_call` | passthrough | Transfer to a phone number (E.164 format) |
+| `transfer_call` | passthrough | Transfer to an E.164 phone number, or a pinned SIP URI such as `sip:7500@pbx.example.com` |
 | `web_search` | loopback | Web search with native LLM support or DuckDuckGo fallback |
 | `http_server_tool` | factory | Create HTTP webhook tools from JSON schemas |
 | `agent_as_handoff` | handoff | Create a handoff tool from another agent |

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -333,7 +333,7 @@ class TransferCallTool:
         self.target_phone_number = (
             self._normalize_number(target_phone_number) if target_phone_number is not None else None
         )
-        self.target_sip_uri = self._validate_sip_uri(target_sip_uri) if target_sip_uri is not None else None
+        self.target_sip_uri = self._normalize_sip_uri(target_sip_uri) if target_sip_uri is not None else None
         self.message = message
         self.interruptible = interruptible
         # User turns this tool stays available before LlmAgent drops it (None = whole call).
@@ -361,8 +361,8 @@ class TransferCallTool:
         return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
 
     @staticmethod
-    def _validate_sip_uri(uri: str) -> str:
-        """Validate the minimum safe shape for a pinned SIP transfer destination."""
+    def _normalize_sip_uri(uri: str) -> str:
+        """Strip surrounding whitespace and validate a pinned SIP transfer destination."""
         value = uri.strip()
         if not _SIP_URI_PATTERN.fullmatch(value):
             raise ValueError(f"TransferCallTool: target_sip_uri {uri!r} is not a SIP URI.")

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -23,7 +23,6 @@ from line.events import (
     AgentTransferCall,
     AgentUpdateCall,
     CallStarted,
-    TransferDestination,
 )
 from line.knowledge_base import DEFAULT_TOP_K, KnowledgeBaseError, _warn_if_long_timeout
 from line.llm_agent.tools import http_server_tool_utils
@@ -393,12 +392,11 @@ class TransferCallTool:
             """
             if self.message:
                 yield AgentSendText(text=self.message, interruptible=self.interruptible)
-            destination = (
-                TransferDestination(type="phone", value=fixed_number)
-                if fixed_number is not None
-                else TransferDestination(type="sip_uri", value=fixed_sip_uri)
+            yield AgentTransferCall(
+                target_phone_number=fixed_number,
+                target_sip_uri=fixed_sip_uri,
+                interruptible=self.interruptible,
             )
-            yield AgentTransferCall(transfer_destination=destination, interruptible=self.interruptible)
 
         return construct_function_tool(
             _transfer_call_fixed_impl,
@@ -437,10 +435,7 @@ class TransferCallTool:
 
             if self.message:
                 yield AgentSendText(text=self.message, interruptible=self.interruptible)
-            yield AgentTransferCall(
-                transfer_destination=TransferDestination(type="phone", value=normalized_number),
-                interruptible=self.interruptible,
-            )
+            yield AgentTransferCall(target_phone_number=normalized_number, interruptible=self.interruptible)
 
         return construct_function_tool(
             _transfer_call_impl,

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -35,18 +35,9 @@ DtmfButton = Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "#"]
 # Logger for system tools
 logger = logging.getLogger(__name__)
 
-# Keep this grammar aligned with Product's SIPURI schema. It deliberately omits
-# credentials, URI parameters, and headers: transfer tools name destinations,
-# not general-purpose SIP requests.
-_SIP_HOST_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
-_SIP_IPV4_OCTET = r"(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]?|0)"
-_SIP_PORT = r"(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])"
-_SIP_HOST = (
-    rf"(?:{_SIP_IPV4_OCTET}(?:\.{_SIP_IPV4_OCTET}){{3}}|"
-    rf"(?![0-9]+(?:\.[0-9]+){{3}}(?::|$)){_SIP_HOST_LABEL}(?:\.{_SIP_HOST_LABEL})*)"
-)
-_SIP_USER = r"[A-Za-z0-9!$&'()*+,._~%=-]+"
-_SIP_URI_PATTERN = re.compile(rf"^sips?:{_SIP_USER}@{_SIP_HOST}(?::{_SIP_PORT})?$", re.IGNORECASE)
+# Keep this grammar aligned with Product's SIPURI schema. It deliberately checks
+# only the minimum `sip[s]:user@host` shape, not the complete SIP URI grammar.
+_SIP_URI_PATTERN = re.compile(r"^sips?:[^@\s]+@[^@\s]+$")
 
 # Sentinel for chainable ``__call__`` configs: distinguishes "argument omitted
 # (inherit the current value)" from "explicitly passed None". Needed for
@@ -373,7 +364,7 @@ class TransferCallTool:
 
     @staticmethod
     def _normalize_sip_uri(uri: str) -> str:
-        """Strip surrounding whitespace and validate a pinned SIP transfer destination."""
+        """Trim and validate a pinned SIP URI in the supported Product format."""
         value = uri.strip()
         if not _SIP_URI_PATTERN.fullmatch(value):
             raise ValueError(f"TransferCallTool: target_sip_uri {uri!r} is not a SIP URI.")

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -8,6 +8,7 @@ import asyncio
 from dataclasses import dataclass, field
 import json
 import logging
+import re
 from typing import Annotated, Any, Dict, Literal, Optional
 from urllib.parse import quote as _url_quote
 
@@ -33,6 +34,8 @@ DtmfButton = Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "#"]
 
 # Logger for system tools
 logger = logging.getLogger(__name__)
+
+_SIP_URI_PATTERN = re.compile(r"^sips?:[^\s<>@]+@[^\s<>@]+$", re.IGNORECASE)
 
 # Sentinel for chainable ``__call__`` configs: distinguishes "argument omitted
 # (inherit the current value)" from "explicitly passed None". Needed for
@@ -288,11 +291,10 @@ class TransferCallTool:
 
     - **Dynamic** (default): the LLM provides ``target_phone_number`` at call
       time. It is validated and normalized to E.164 on each call.
-    - **Pinned**: pass ``target_phone_number`` at construction
-      (``transfer_call(target_phone_number="+14155551234")``). The number is
-      validated once at construction and hidden from the LLM, which then only
-      decides *whether* to transfer. This matches the common "escalate to a
-      fixed support/human line" pattern.
+    - **Pinned**: pass ``target_phone_number`` or ``target_sip_uri`` at
+      construction. The destination is validated once at construction and hidden
+      from the LLM, which then only decides *whether* to transfer. This matches
+      the common "escalate to a fixed support/human line" pattern.
 
     The optional fixed ``message`` and ``interruptible`` flag are set at
     construction in both modes, not by the LLM at tool-call time.
@@ -317,15 +319,21 @@ class TransferCallTool:
     def __init__(
         self,
         target_phone_number: Optional[str] = None,
+        target_sip_uri: Optional[str] = None,
         message: Optional[str] = None,
         interruptible: bool = True,
         active_turns: Optional[int] = None,
     ):
+        if target_phone_number is not None and target_sip_uri is not None:
+            raise ValueError(
+                "TransferCallTool accepts either target_phone_number or target_sip_uri, not both."
+            )
         # When pinned, validate/normalize once at construction so a bad config
         # fails fast rather than at call time.
         self.target_phone_number = (
             self._normalize_number(target_phone_number) if target_phone_number is not None else None
         )
+        self.target_sip_uri = self._validate_sip_uri(target_sip_uri) if target_sip_uri is not None else None
         self.message = message
         self.interruptible = interruptible
         # User turns this tool stays available before LlmAgent drops it (None = whole call).
@@ -352,30 +360,43 @@ class TransferCallTool:
             raise ValueError(f"TransferCallTool: target_phone_number {number!r} is not a valid phone number.")
         return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
 
+    @staticmethod
+    def _validate_sip_uri(uri: str) -> str:
+        """Validate the minimum safe shape for a pinned SIP transfer destination."""
+        value = uri.strip()
+        if not _SIP_URI_PATTERN.fullmatch(value):
+            raise ValueError(f"TransferCallTool: target_sip_uri {uri!r} is not a SIP URI.")
+        return value
+
     def _create_function_tool(self) -> FunctionTool:
         """Create the underlying FunctionTool for the configured mode."""
         ft = (
-            self._create_fixed_number_tool()
-            if self.target_phone_number is not None
+            self._create_fixed_destination_tool()
+            if self.target_phone_number is not None or self.target_sip_uri is not None
             else self._create_dynamic_number_tool()
         )
         ft.active_turns = self.active_turns
         return ft
 
-    def _create_fixed_number_tool(self) -> FunctionTool:
-        """Pinned destination: no LLM-facing parameter; transfer to the preset number."""
+    def _create_fixed_destination_tool(self) -> FunctionTool:
+        """Pinned destination: no LLM-facing parameter; transfer to the preset target."""
         fixed_number = self.target_phone_number
+        fixed_sip_uri = self.target_sip_uri
 
         async def _transfer_call_fixed_impl(ctx: ToolEnv):
             """Transfer the call to the preconfigured destination number.
 
             Exposes no LLM-facing parameter: the destination is pinned at
             construction and hidden from the model, so the schema carries no
-            ``target_phone_number`` for it to supply.
+            destination for it to supply.
             """
             if self.message:
                 yield AgentSendText(text=self.message, interruptible=self.interruptible)
-            yield AgentTransferCall(target_phone_number=fixed_number, interruptible=self.interruptible)
+            yield AgentTransferCall(
+                target_phone_number=fixed_number,
+                target_sip_uri=fixed_sip_uri,
+                interruptible=self.interruptible,
+            )
 
         return construct_function_tool(
             _transfer_call_fixed_impl,
@@ -430,6 +451,7 @@ class TransferCallTool:
     def __call__(
         self,
         target_phone_number: Optional[str] = None,
+        target_sip_uri: Optional[str] = None,
         message: Optional[str] = None,
         interruptible: Optional[bool] = None,
         active_turns: Any = _INHERIT,
@@ -444,15 +466,26 @@ class TransferCallTool:
         Args:
             target_phone_number: Optional pinned destination (E.164). When set,
                 the number is hidden from the LLM and validated at construction.
+            target_sip_uri: Optional pinned SIP destination. When set, the URI is
+                hidden from the LLM and validated at construction.
             message: Optional message spoken before transfer.
             interruptible: Whether the transfer_call tool is interruptible.
             active_turns: User turns the tool stays available before the agent drops it
                 (``None`` = whole call). Omit to inherit the current value.
         """
+        resolved_phone_number = (
+            target_phone_number
+            if target_phone_number is not None
+            else (None if target_sip_uri is not None else self.target_phone_number)
+        )
+        resolved_sip_uri = (
+            target_sip_uri
+            if target_sip_uri is not None
+            else (None if target_phone_number is not None else self.target_sip_uri)
+        )
         return TransferCallTool(
-            target_phone_number=(
-                target_phone_number if target_phone_number is not None else self.target_phone_number
-            ),
+            target_phone_number=resolved_phone_number,
+            target_sip_uri=resolved_sip_uri,
             message=message if message is not None else self.message,
             interruptible=interruptible if interruptible is not None else self.interruptible,
             active_turns=self.active_turns if active_turns is _INHERIT else active_turns,

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -23,6 +23,7 @@ from line.events import (
     AgentTransferCall,
     AgentUpdateCall,
     CallStarted,
+    TransferDestination,
 )
 from line.knowledge_base import DEFAULT_TOP_K, KnowledgeBaseError, _warn_if_long_timeout
 from line.llm_agent.tools import http_server_tool_utils
@@ -392,11 +393,12 @@ class TransferCallTool:
             """
             if self.message:
                 yield AgentSendText(text=self.message, interruptible=self.interruptible)
-            yield AgentTransferCall(
-                target_phone_number=fixed_number,
-                target_sip_uri=fixed_sip_uri,
-                interruptible=self.interruptible,
+            destination = (
+                TransferDestination(type="phone", value=fixed_number)
+                if fixed_number is not None
+                else TransferDestination(type="sip_uri", value=fixed_sip_uri)
             )
+            yield AgentTransferCall(transfer_destination=destination, interruptible=self.interruptible)
 
         return construct_function_tool(
             _transfer_call_fixed_impl,
@@ -435,7 +437,10 @@ class TransferCallTool:
 
             if self.message:
                 yield AgentSendText(text=self.message, interruptible=self.interruptible)
-            yield AgentTransferCall(target_phone_number=normalized_number, interruptible=self.interruptible)
+            yield AgentTransferCall(
+                transfer_destination=TransferDestination(type="phone", value=normalized_number),
+                interruptible=self.interruptible,
+            )
 
         return construct_function_tool(
             _transfer_call_impl,

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -335,7 +335,7 @@ class TransferCallTool:
         self.target_phone_number = (
             self._normalize_number(target_phone_number) if target_phone_number is not None else None
         )
-        self.target_sip_uri = self._normalize_sip_uri(target_sip_uri) if target_sip_uri is not None else None
+        self.target_sip_uri = self._validate_sip_uri(target_sip_uri) if target_sip_uri is not None else None
         self.message = message
         self.interruptible = interruptible
         # User turns this tool stays available before LlmAgent drops it (None = whole call).
@@ -363,12 +363,11 @@ class TransferCallTool:
         return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
 
     @staticmethod
-    def _normalize_sip_uri(uri: str) -> str:
-        """Trim and validate a pinned SIP URI in the supported Product format."""
-        value = uri.strip()
-        if not _SIP_URI_PATTERN.fullmatch(value):
+    def _validate_sip_uri(uri: str) -> str:
+        """Validate a pinned SIP URI in the supported Product format."""
+        if not _SIP_URI_PATTERN.fullmatch(uri):
             raise ValueError(f"TransferCallTool: target_sip_uri {uri!r} is not a SIP URI.")
-        return value
+        return uri
 
     def _create_function_tool(self) -> FunctionTool:
         """Create the underlying FunctionTool for the configured mode."""

--- a/line/llm_agent/tools/system.py
+++ b/line/llm_agent/tools/system.py
@@ -35,7 +35,18 @@ DtmfButton = Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "#"]
 # Logger for system tools
 logger = logging.getLogger(__name__)
 
-_SIP_URI_PATTERN = re.compile(r"^sips?:[^\s<>@]+@[^\s<>@]+$", re.IGNORECASE)
+# Keep this grammar aligned with Product's SIPURI schema. It deliberately omits
+# credentials, URI parameters, and headers: transfer tools name destinations,
+# not general-purpose SIP requests.
+_SIP_HOST_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+_SIP_IPV4_OCTET = r"(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]?|0)"
+_SIP_PORT = r"(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])"
+_SIP_HOST = (
+    rf"(?:{_SIP_IPV4_OCTET}(?:\.{_SIP_IPV4_OCTET}){{3}}|"
+    rf"(?![0-9]+(?:\.[0-9]+){{3}}(?::|$)){_SIP_HOST_LABEL}(?:\.{_SIP_HOST_LABEL})*)"
+)
+_SIP_USER = r"[A-Za-z0-9!$&'()*+,._~%=-]+"
+_SIP_URI_PATTERN = re.compile(rf"^sips?:{_SIP_USER}@{_SIP_HOST}(?::{_SIP_PORT})?$", re.IGNORECASE)
 
 # Sentinel for chainable ``__call__`` configs: distinguishes "argument omitted
 # (inherit the current value)" from "explicitly passed None". Needed for

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -684,11 +684,11 @@ class ConversationRunner:
                 interruptible=event.interruptible,
             )
         if isinstance(event, AgentTransferCall):
-            logger.info(
-                f"<- 📱 Transfer to: {event.target_phone_number} (interruptible={event.interruptible})"
-            )
+            destination = event.target_phone_number or event.target_sip_uri
+            logger.info(f"<- 📱 Transfer to: {destination} (interruptible={event.interruptible})")
             return TransferOutput(
                 target_phone_number=event.target_phone_number,
+                target_sip_uri=event.target_sip_uri,
                 responding_to=event.responding_to,
                 interruptible=event.interruptible,
             )

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -684,11 +684,12 @@ class ConversationRunner:
                 interruptible=event.interruptible,
             )
         if isinstance(event, AgentTransferCall):
-            destination = event.target_phone_number or event.target_sip_uri
-            logger.info(f"<- 📱 Transfer to: {destination} (interruptible={event.interruptible})")
+            logger.info(
+                f"<- 📱 Transfer to {event.transfer_destination.type}: "
+                f"{event.transfer_destination.value} (interruptible={event.interruptible})"
+            )
             return TransferOutput(
-                target_phone_number=event.target_phone_number,
-                target_sip_uri=event.target_sip_uri,
+                transfer_destination=event.transfer_destination,
                 responding_to=event.responding_to,
                 interruptible=event.interruptible,
             )

--- a/line/voice_agent_app.py
+++ b/line/voice_agent_app.py
@@ -44,6 +44,7 @@ from line._harness_types import (
     STTConfig,
     ToolCallOutput,
     TranscriptionInput,
+    TransferDestination,
     TransferOutput,
     TTSConfig,
     UserStateInput,
@@ -684,12 +685,20 @@ class ConversationRunner:
                 interruptible=event.interruptible,
             )
         if isinstance(event, AgentTransferCall):
+            destination = TransferDestination(
+                type="phone" if event.target_phone_number is not None else "sip_uri",
+                value=(
+                    event.target_phone_number
+                    if event.target_phone_number is not None
+                    else event.target_sip_uri
+                ),
+            )
             logger.info(
-                f"<- 📱 Transfer to {event.transfer_destination.type}: "
-                f"{event.transfer_destination.value} (interruptible={event.interruptible})"
+                f"<- 📱 Transfer to {destination.type}: {destination.value} "
+                f"(interruptible={event.interruptible})"
             )
             return TransferOutput(
-                transfer_destination=event.transfer_destination,
+                transfer_destination=destination,
                 responding_to=event.responding_to,
                 interruptible=event.interruptible,
             )

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -219,6 +219,24 @@ async def test_transfer_call_valid_number(mock_ctx, anyio_backend):
     assert events[0].target_phone_number == "+14155551234"
 
 
+async def test_transfer_call_pinned_sip_uri(mock_ctx, anyio_backend):
+    tool = transfer_call(target_sip_uri="sip:7500@pbx.example.com")
+    events = await collect_events(tool.as_function_tool().func(mock_ctx))
+
+    assert len(events) == 1
+    assert isinstance(events[0], AgentTransferCall)
+    assert events[0].target_phone_number is None
+    assert events[0].target_sip_uri == "sip:7500@pbx.example.com"
+
+
+async def test_transfer_call_rejects_phone_and_sip_destinations(anyio_backend):
+    with pytest.raises(ValueError, match="either target_phone_number or target_sip_uri"):
+        transfer_call(
+            target_phone_number="+14155551234",
+            target_sip_uri="sip:7500@pbx.example.com",
+        )
+
+
 async def test_transfer_call_valid_number_with_message(mock_ctx, anyio_backend):
     """Test that a tool configured with message= sends it before transfer."""
     tool = transfer_call(message="Transferring you now")

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -229,6 +229,12 @@ async def test_transfer_call_pinned_sip_uri(mock_ctx, anyio_backend):
     assert events[0].target_sip_uri == "sip:7500@pbx.example.com"
 
 
+async def test_transfer_call_pinned_sip_uri_is_trimmed(anyio_backend):
+    tool = transfer_call(target_sip_uri="  sip:7500@pbx.example.com  ")
+
+    assert tool.target_sip_uri == "sip:7500@pbx.example.com"
+
+
 async def test_transfer_call_rejects_phone_and_sip_destinations(anyio_backend):
     with pytest.raises(ValueError, match="either target_phone_number or target_sip_uri"):
         transfer_call(

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -229,10 +229,9 @@ async def test_transfer_call_pinned_sip_uri(mock_ctx, anyio_backend):
     assert events[0].target_sip_uri == "sip:7500@pbx.example.com"
 
 
-async def test_transfer_call_pinned_sip_uri_is_trimmed(anyio_backend):
-    tool = transfer_call(target_sip_uri="  sip:7500@pbx.example.com  ")
-
-    assert tool.target_sip_uri == "sip:7500@pbx.example.com"
+async def test_transfer_call_rejects_sip_uri_with_surrounding_whitespace(anyio_backend):
+    with pytest.raises(ValueError, match="not a SIP URI"):
+        transfer_call(target_sip_uri="  sip:7500@pbx.example.com  ")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -238,14 +238,28 @@ async def test_transfer_call_pinned_sip_uri_is_trimmed(anyio_backend):
 @pytest.mark.parametrize(
     "sip_uri",
     [
+        "7500@pbx.example.com",
+        "sip:@pbx.example.com",
+        "sip:7500@",
+        "SIP:7500@pbx.example.com",
+        "sips:7500@pbx.example.com invalid",
+    ],
+)
+async def test_transfer_call_rejects_invalid_sip_uris(sip_uri, anyio_backend):
+    with pytest.raises(ValueError, match="not a SIP URI"):
+        transfer_call(target_sip_uri=sip_uri)
+
+
+@pytest.mark.parametrize(
+    "sip_uri",
+    [
         "sip:7500@999.999.999.999",
         "sip:7500@pbx.example.com:99999",
         "sip:7500@pbx.example.com;transport=tcp",
     ],
 )
-async def test_transfer_call_rejects_sip_uris_outside_product_grammar(sip_uri, anyio_backend):
-    with pytest.raises(ValueError, match="not a SIP URI"):
-        transfer_call(target_sip_uri=sip_uri)
+async def test_transfer_call_accepts_basic_product_sip_uri_shape(sip_uri, anyio_backend):
+    assert transfer_call(target_sip_uri=sip_uri).target_sip_uri == sip_uri
 
 
 async def test_transfer_call_rejects_phone_and_sip_destinations(anyio_backend):

--- a/tests/test_llm_agent_tools_system.py
+++ b/tests/test_llm_agent_tools_system.py
@@ -235,6 +235,19 @@ async def test_transfer_call_pinned_sip_uri_is_trimmed(anyio_backend):
     assert tool.target_sip_uri == "sip:7500@pbx.example.com"
 
 
+@pytest.mark.parametrize(
+    "sip_uri",
+    [
+        "sip:7500@999.999.999.999",
+        "sip:7500@pbx.example.com:99999",
+        "sip:7500@pbx.example.com;transport=tcp",
+    ],
+)
+async def test_transfer_call_rejects_sip_uris_outside_product_grammar(sip_uri, anyio_backend):
+    with pytest.raises(ValueError, match="not a SIP URI"):
+        transfer_call(target_sip_uri=sip_uri)
+
+
 async def test_transfer_call_rejects_phone_and_sip_destinations(anyio_backend):
     with pytest.raises(ValueError, match="either target_phone_number or target_sip_uri"):
         transfer_call(

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -1181,7 +1181,7 @@ class TestEndCallAndTransferCallMapping:
         """AgentTransferCall(interruptible=False) maps to TransferOutput(interruptible=False)."""
         result = self._map(
             AgentTransferCall(
-                transfer_destination={"type": "phone", "value": "+14155551234"},
+                target_phone_number="+14155551234",
                 interruptible=False,
             )
         )
@@ -1191,25 +1191,23 @@ class TestEndCallAndTransferCallMapping:
 
     def test_transfer_call_interruptible_true_by_default(self):
         """AgentTransferCall() defaults to interruptible=True."""
-        result = self._map(AgentTransferCall(transfer_destination={"type": "phone", "value": "+14155551234"}))
+        result = self._map(AgentTransferCall(target_phone_number="+14155551234"))
         assert isinstance(result, TransferOutput)
         assert result.interruptible is True
 
     def test_sip_transfer_forwards_sip_uri(self):
-        result = self._map(
-            AgentTransferCall(transfer_destination={"type": "sip_uri", "value": "sip:7500@pbx.example.com"})
-        )
+        result = self._map(AgentTransferCall(target_sip_uri="sip:7500@pbx.example.com"))
         assert isinstance(result, TransferOutput)
         assert result.target_phone_number is None
         assert result.target_sip_uri == "sip:7500@pbx.example.com"
 
-    def test_legacy_phone_transfer_constructor_is_upgraded(self):
+    def test_phone_transfer_is_typed_for_the_harness(self):
         result = self._map(AgentTransferCall(target_phone_number="+14155551234"))
         assert isinstance(result, TransferOutput)
         assert result.transfer_destination.type == "phone"
         assert result.transfer_destination.value == "+14155551234"
 
-    def test_legacy_sip_transfer_constructor_is_upgraded(self):
+    def test_sip_transfer_is_typed_for_the_harness(self):
         result = self._map(AgentTransferCall(target_sip_uri="sip:7500@pbx.example.com"))
         assert isinstance(result, TransferOutput)
         assert result.transfer_destination.type == "sip_uri"

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -1203,6 +1203,18 @@ class TestEndCallAndTransferCallMapping:
         assert result.target_phone_number is None
         assert result.target_sip_uri == "sip:7500@pbx.example.com"
 
+    def test_legacy_phone_transfer_constructor_is_upgraded(self):
+        result = self._map(AgentTransferCall(target_phone_number="+14155551234"))
+        assert isinstance(result, TransferOutput)
+        assert result.transfer_destination.type == "phone"
+        assert result.transfer_destination.value == "+14155551234"
+
+    def test_legacy_sip_transfer_constructor_is_upgraded(self):
+        result = self._map(AgentTransferCall(target_sip_uri="sip:7500@pbx.example.com"))
+        assert isinstance(result, TransferOutput)
+        assert result.transfer_destination.type == "sip_uri"
+        assert result.transfer_destination.value == "sip:7500@pbx.example.com"
+
 
 # ============================================================
 # AgentUpdateCall -> ConfigOutput mapping tests

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -1190,6 +1190,12 @@ class TestEndCallAndTransferCallMapping:
         assert isinstance(result, TransferOutput)
         assert result.interruptible is True
 
+    def test_sip_transfer_forwards_sip_uri(self):
+        result = self._map(AgentTransferCall(target_sip_uri="sip:7500@pbx.example.com"))
+        assert isinstance(result, TransferOutput)
+        assert result.target_phone_number is None
+        assert result.target_sip_uri == "sip:7500@pbx.example.com"
+
 
 # ============================================================
 # AgentUpdateCall -> ConfigOutput mapping tests

--- a/tests/test_voice_agent_app.py
+++ b/tests/test_voice_agent_app.py
@@ -1179,19 +1179,26 @@ class TestEndCallAndTransferCallMapping:
 
     def test_transfer_call_interruptible_false(self):
         """AgentTransferCall(interruptible=False) maps to TransferOutput(interruptible=False)."""
-        result = self._map(AgentTransferCall(target_phone_number="+14155551234", interruptible=False))
+        result = self._map(
+            AgentTransferCall(
+                transfer_destination={"type": "phone", "value": "+14155551234"},
+                interruptible=False,
+            )
+        )
         assert isinstance(result, TransferOutput)
         assert result.target_phone_number == "+14155551234"
         assert result.interruptible is False
 
     def test_transfer_call_interruptible_true_by_default(self):
         """AgentTransferCall() defaults to interruptible=True."""
-        result = self._map(AgentTransferCall(target_phone_number="+14155551234"))
+        result = self._map(AgentTransferCall(transfer_destination={"type": "phone", "value": "+14155551234"}))
         assert isinstance(result, TransferOutput)
         assert result.interruptible is True
 
     def test_sip_transfer_forwards_sip_uri(self):
-        result = self._map(AgentTransferCall(target_sip_uri="sip:7500@pbx.example.com"))
+        result = self._map(
+            AgentTransferCall(transfer_destination={"type": "sip_uri", "value": "sip:7500@pbx.example.com"})
+        )
         assert isinstance(result, TransferOutput)
         assert result.target_phone_number is None
         assert result.target_sip_uri == "sip:7500@pbx.example.com"


### PR DESCRIPTION
## What does this PR do?

Adds a `target_sip_uri` alternative to `AgentTransferCall` and the harness transfer payload. `transfer_call(target_sip_uri="sip:7500@pbx.example.com")` creates a pinned SIP transfer target; dynamic LLM-selected transfers remain phone-number-only.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Other

## Testing

- `uv run --extra dev ruff check line/events.py line/_harness_types.py line/voice_agent_app.py line/llm_agent/tools/system.py tests/test_llm_agent_tools_system.py tests/test_voice_agent_app.py`
- `uv run --extra dev pytest tests/test_llm_agent_tools_system.py tests/test_voice_agent_app.py` (224 passed)

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted my code with the repository formatter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes call-transfer events and harness JSON shape (depends on Bifrost runtime); misconfigured pinned SIP URIs fail at startup but runtime transfer behavior is call-critical.
> 
> **Overview**
> Adds **pinned SIP transfer** alongside existing E.164 phone transfers: apps can use `transfer_call(target_sip_uri="sip:7500@pbx.example.com")` so the model only decides *whether* to transfer, not the PBX target. **Dynamic** `transfer_call` behavior is unchanged—the LLM still supplies only phone numbers at runtime.
> 
> **Events and harness wire format** now carry either a phone or SIP destination: `AgentTransferCall` accepts optional `target_phone_number` or `target_sip_uri` (exactly one required), and harness `TransferOutput` uses a typed `transfer_destination` (`phone` | `sip_uri`) instead of a bare phone string, with compatibility accessors on `TransferOutput` for older Python consumers.
> 
> SIP values are validated at tool construction with a minimal `sip[s]:user@host` regex aligned with Product’s schema. Docs and tests cover pinned SIP flows, invalid URIs, and mapping through `voice_agent_app`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd869a84b5ae5757c075d47ea521f5284bcc204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->