### PR TITLE
Bump version to 0.2.18

### DIFF
--- a/example_integrations/browserbase/pyproject.toml
+++ b/example_integrations/browserbase/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Voice agent that fills web forms using Stagehand browser automation (Line SDK)"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
     "stagehand>=3.0.0",
     "google-genai>=1.26.0",
     "loguru>=0.7.0",

--- a/example_integrations/cerebras/pyproject.toml
+++ b/example_integrations/cerebras/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "An interviewer agent using Cerebras via LiteLLM with Line SDK v0.2"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
     "python-dotenv>=1.0.0",
     "loguru>=0.7.0",
     "pydantic>=2.0.0",

--- a/example_integrations/exa/pyproject.toml
+++ b/example_integrations/exa/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A web research voice agent using Exa API and Cartesia Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
     "exa-py>=1.0.0",
     "loguru>=0.7.0",
     "python-dotenv>=1.0.0",

--- a/example_integrations/tavily/pyproject.toml
+++ b/example_integrations/tavily/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A web research voice agent using Tavily API and Cartesia Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
     "tavily-python>=0.7.23",
     "loguru>=0.7.3",
     "python-dotenv>=1.2.2",

--- a/examples/basic_chat/pyproject.toml
+++ b/examples/basic_chat/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Basic chat example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
     "loguru>=0.7.0",
 ]
 

--- a/examples/chat_supervisor/pyproject.toml
+++ b/examples/chat_supervisor/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Chat/Supervisor example: A fast Haiku agent that consults Opus for complex questions"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
 ]
 
 [tool.setuptools]

--- a/examples/echo/pyproject.toml
+++ b/examples/echo/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Handoff echo example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
     "loguru>=0.7.0",
 ]
 

--- a/examples/form_filler/pyproject.toml
+++ b/examples/form_filler/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Voice agent that helps patients schedule doctor appointments and complete intake forms."
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
     "loguru>=0.7.0",
 ]
 

--- a/examples/guardrails_wrapper/pyproject.toml
+++ b/examples/guardrails_wrapper/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Guardrails wrapper example - LLM agent with preprocessing/postprocessing for content filtering"
 requires-python = ">=3.10"
 dependencies = [
-   "cartesia-line==0.2.17",
+   "cartesia-line==0.2.18",
 ]
 
 [tool.setuptools]

--- a/examples/sales_with_leads/pyproject.toml
+++ b/examples/sales_with_leads/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Sales agent with stateful leads extraction and company research"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
     "loguru>=0.7.0",
 ]
 

--- a/examples/transfer_agent/pyproject.toml
+++ b/examples/transfer_agent/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Multi-agent handoff example demonstrating agent-to-agent transfers using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
 ]
 
 [tool.setuptools]

--- a/examples/transfer_phone_call/pyproject.toml
+++ b/examples/transfer_phone_call/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Phone transfer example using Line SDK"
 requires-python = ">=3.10"
 dependencies = [
-    "cartesia-line==0.2.17",
+    "cartesia-line==0.2.18",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cartesia-line"
-version = "0.2.17"
+version = "0.2.18"
 description = "Cartesia Voice Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Changes

- Bump `cartesia-line` from `0.2.17` to `0.2.18`.
- Update all checked-in example and integration pins.

## Testing

- `uv run python scripts/check_version_bump.py --comparison-ref origin/main`

This release publishes the direct SIP URI transfer support merged in #272.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and dependency pin updates only; no runtime or SDK code changes in this PR.
> 
> **Overview**
> Releases **cartesia-line 0.2.18** by updating the package version in the root `pyproject.toml` and aligning every checked-in example and integration to pin `cartesia-line==0.2.18` (replacing `0.2.17`).
> 
> This is a release bookkeeping change only; it ships the **direct SIP URI transfer** capability already merged elsewhere (e.g. pinned `transfer_call(target_sip_uri=...)`), not new logic in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f14e66fb9945e4d49729544c974d166f6e91c5d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->